### PR TITLE
feat: image optimization pipeline + helpers (#6, #7, #8, #9, #10)

### DIFF
--- a/src/Console/Commands/GenerateWebPCommand.php
+++ b/src/Console/Commands/GenerateWebPCommand.php
@@ -1,0 +1,228 @@
+<?php
+
+/**
+ * `perf:generate-webp` artisan command.
+ *
+ * Batch-converts every supported image under the given path to WebP using
+ * the package's `FormatConverter`. Honors the configured quality, supports
+ * recursive directory traversal, and prints a per-file outcome summary.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Console\Commands;
+
+use ArtisanPackUI\Performance\Services\Image\FormatConverter;
+use FilesystemIterator;
+use Illuminate\Console\Command;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
+use SplFileInfo;
+use Throwable;
+
+/**
+ * Generate WebP derivatives.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+class GenerateWebPCommand extends Command
+{
+	/**
+	 * Source mime types that can be converted to WebP.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array<int, string>
+	 */
+	protected const CONVERTIBLE_EXTENSIONS = [ 'jpg', 'jpeg', 'png', 'gif', 'bmp' ];
+
+	/**
+	 * The console command signature.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	protected $signature = 'perf:generate-webp
+		{path : Path to a file or directory of images}
+		{--quality= : Output quality (0-100), defaults to the configured format quality}
+		{--recursive : Recurse into subdirectories when converting a directory}
+		{--force : Overwrite existing WebP files}';
+
+	/**
+	 * The console command description.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	protected $description = 'Convert images at the given path to WebP using the configured driver.';
+
+	/**
+	 * Executes the command.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param FormatConverter $converter Format converter service.
+	 *
+	 * @return int Exit code (`Command::SUCCESS` or `Command::FAILURE`).
+	 */
+	public function handle( FormatConverter $converter ): int
+	{
+		$path = (string) $this->argument( 'path' );
+
+		if ( ! file_exists( $path ) ) {
+			$this->error( "Path does not exist: {$path}" );
+
+			return self::FAILURE;
+		}
+
+		if ( ! $converter->supports( 'webp' ) ) {
+			$this->error( "Driver '{$converter->driver()}' cannot encode WebP on this system." );
+
+			return self::FAILURE;
+		}
+
+		$quality = $this->resolveQuality();
+		$files   = $this->collectFiles( $path, (bool) $this->option( 'recursive' ) );
+
+		if ( empty( $files ) ) {
+			$this->warn( 'No convertible images found.' );
+
+			return self::SUCCESS;
+		}
+
+		$converted = 0;
+		$skipped   = 0;
+		$failed    = 0;
+
+		foreach ( $files as $file ) {
+			$destination = $this->targetPath( $file );
+
+			if ( file_exists( $destination ) && ! $this->option( 'force' ) ) {
+				$this->line( "skip: {$file}" );
+				$skipped++;
+				continue;
+			}
+
+			try {
+				$converter->toWebp( $file, $quality );
+				$this->line( "ok:   {$file}" );
+				$converted++;
+			} catch ( Throwable $exception ) {
+				$this->error( "fail: {$file} ({$exception->getMessage()})" );
+				$failed++;
+			}
+		}
+
+		$this->info( "Converted {$converted}, skipped {$skipped}, failed {$failed}." );
+
+		return $failed > 0 ? self::FAILURE : self::SUCCESS;
+	}
+
+	/**
+	 * Resolves the quality value from the option or config.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return int Quality clamped between 0 and 100.
+	 */
+	protected function resolveQuality(): int
+	{
+		$quality = $this->option( 'quality' );
+
+		if ( null === $quality || '' === $quality ) {
+			$quality = config(
+				'artisanpack.performance.images.formats.webp.quality',
+				FormatConverter::DEFAULT_WEBP_QUALITY,
+			);
+		}
+
+		return max( 0, min( 100, (int) $quality ) );
+	}
+
+	/**
+	 * Collects convertible image files at the given path.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path      Source path (file or directory).
+	 * @param bool   $recursive Whether to recurse into subdirectories.
+	 *
+	 * @throws RuntimeException When the directory cannot be opened.
+	 *
+	 * @return array<int, string> Absolute paths to convertible image files.
+	 */
+	protected function collectFiles( string $path, bool $recursive ): array
+	{
+		if ( is_file( $path ) ) {
+			return $this->isConvertible( new SplFileInfo( $path ) ) ? [ $path ] : [];
+		}
+
+		$files = [];
+
+		if ( $recursive ) {
+			$iterator = new RecursiveIteratorIterator(
+				new RecursiveDirectoryIterator( $path, FilesystemIterator::SKIP_DOTS ),
+			);
+		} else {
+			$iterator = new FilesystemIterator( $path, FilesystemIterator::SKIP_DOTS );
+		}
+
+		foreach ( $iterator as $file ) {
+			if ( $this->isConvertible( $file ) ) {
+				$files[] = $file->getPathname();
+			}
+		}
+
+		sort( $files );
+
+		return $files;
+	}
+
+	/**
+	 * Reports whether the given file is a convertible image.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param SplFileInfo $file File handle to inspect.
+	 *
+	 * @return bool True when the file is a regular image with a convertible extension.
+	 */
+	protected function isConvertible( SplFileInfo $file ): bool
+	{
+		if ( ! $file->isFile() ) {
+			return false;
+		}
+
+		return in_array( strtolower( $file->getExtension() ), self::CONVERTIBLE_EXTENSIONS, true );
+	}
+
+	/**
+	 * Builds the WebP destination path for the given source file.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute source path.
+	 *
+	 * @return string Absolute WebP destination path.
+	 */
+	protected function targetPath( string $path ): string
+	{
+		$directory = dirname( $path );
+		$basename  = pathinfo( $path, PATHINFO_FILENAME );
+
+		return $directory . DIRECTORY_SEPARATOR . $basename . '.webp';
+	}
+}

--- a/src/PerformanceServiceProvider.php
+++ b/src/PerformanceServiceProvider.php
@@ -20,6 +20,9 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Performance;
 
+use ArtisanPackUI\Performance\Console\Commands\GenerateWebPCommand;
+use ArtisanPackUI\Performance\Services\Image\FormatConverter;
+use ArtisanPackUI\Performance\Services\ImageService;
 use ArtisanPackUI\Performance\Services\PerformanceService;
 use Illuminate\Support\ServiceProvider;
 
@@ -51,8 +54,16 @@ class PerformanceServiceProvider extends ServiceProvider
 			'artisanpack-performance-temp',
 		);
 
+		$this->app->singleton( FormatConverter::class, function ( $app ) {
+			return new FormatConverter();
+		} );
+
+		$this->app->singleton( ImageService::class, function ( $app ) {
+			return new ImageService( $app->make( FormatConverter::class ) );
+		} );
+
 		$this->app->singleton( 'performance', function ( $app ) {
-			return new PerformanceService();
+			return new PerformanceService( $app->make( ImageService::class ) );
 		} );
 
 		$this->app->singleton( PerformanceService::class, function ( $app ) {
@@ -72,7 +83,24 @@ class PerformanceServiceProvider extends ServiceProvider
 		$this->mergeConfiguration();
 		$this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
 		$this->registerEventListeners();
+		$this->registerCommands();
 		$this->publishConfiguration();
+	}
+
+	/**
+	 * Registers the package's console commands.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function registerCommands(): void
+	{
+		if ( $this->app->runningInConsole() ) {
+			$this->commands( [
+				GenerateWebPCommand::class,
+			] );
+		}
 	}
 
 	/**

--- a/src/Services/Image/FormatConverter.php
+++ b/src/Services/Image/FormatConverter.php
@@ -1,0 +1,368 @@
+<?php
+
+/**
+ * Image format converter.
+ *
+ * Converts source images (JPEG, PNG, GIF, BMP) to modern delivery formats
+ * (WebP, AVIF) using the GD or Imagick extension. Transparency is preserved
+ * for PNG sources, conversion errors are surfaced as `RuntimeException`s,
+ * and unsupported format/driver combinations are reported via `supports()`
+ * so callers can fall back rather than fail.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Services\Image;
+
+use GdImage;
+use Imagick;
+use ImagickException;
+use RuntimeException;
+
+/**
+ * Format converter class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+class FormatConverter
+{
+	/**
+	 * Default quality for WebP output.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var int
+	 */
+	public const DEFAULT_WEBP_QUALITY = 80;
+
+	/**
+	 * Default quality for AVIF output.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var int
+	 */
+	public const DEFAULT_AVIF_QUALITY = 70;
+
+	/**
+	 * Supported target formats.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array<int, string>
+	 */
+	public const SUPPORTED_FORMATS = [ 'webp', 'avif' ];
+
+	/**
+	 * Drivers this converter knows how to dispatch to.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array<int, string>
+	 */
+	public const SUPPORTED_DRIVERS = [ 'gd', 'imagick' ];
+
+	/**
+	 * Active image driver (`gd` or `imagick`).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	protected string $driver;
+
+	/**
+	 * Creates a new converter.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string|null $driver Optional driver override; defaults to the
+	 *                            `artisanpack.performance.images.driver` config value.
+	 */
+	public function __construct( ?string $driver = null )
+	{
+		$this->driver = $driver ?? (string) config( 'artisanpack.performance.images.driver', 'gd' );
+	}
+
+	/**
+	 * Converts a source image to WebP.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path    Absolute path to the source image.
+	 * @param int    $quality Output quality (0-100).
+	 *
+	 * @throws RuntimeException When the source is unreadable or the driver cannot encode WebP.
+	 *
+	 * @return string Absolute path to the generated WebP file.
+	 */
+	public function toWebp( string $path, int $quality = self::DEFAULT_WEBP_QUALITY ): string
+	{
+		return $this->convert( $path, 'webp', $quality );
+	}
+
+	/**
+	 * Converts a source image to AVIF.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path    Absolute path to the source image.
+	 * @param int    $quality Output quality (0-100).
+	 *
+	 * @throws RuntimeException When the source is unreadable or the driver cannot encode AVIF.
+	 *
+	 * @return string Absolute path to the generated AVIF file.
+	 */
+	public function toAvif( string $path, int $quality = self::DEFAULT_AVIF_QUALITY ): string
+	{
+		return $this->convert( $path, 'avif', $quality );
+	}
+
+	/**
+	 * Converts a source image to the given target format.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path    Absolute path to the source image.
+	 * @param string $format  Target format (`webp` or `avif`).
+	 * @param int    $quality Output quality (0-100).
+	 *
+	 * @throws RuntimeException When the source is unreadable, the format is unsupported, or encoding fails.
+	 *
+	 * @return string Absolute path to the generated file.
+	 */
+	public function convert( string $path, string $format, int $quality ): string
+	{
+		$format = strtolower( $format );
+
+		if ( ! in_array( $format, self::SUPPORTED_FORMATS, true ) ) {
+			throw new RuntimeException( "Unsupported target format: {$format}" );
+		}
+
+		if ( ! is_file( $path ) || ! is_readable( $path ) ) {
+			throw new RuntimeException( "Source image is not readable: {$path}" );
+		}
+
+		if ( ! $this->supports( $format ) ) {
+			throw new RuntimeException( "Driver '{$this->driver}' cannot encode {$format} on this system" );
+		}
+
+		$quality     = max( 0, min( 100, $quality ) );
+		$destination = $this->targetPath( $path, $format );
+
+		if ( 'imagick' === $this->driver ) {
+			$this->convertWithImagick( $path, $destination, $format, $quality );
+		} else {
+			$this->convertWithGd( $path, $destination, $format, $quality );
+		}
+
+		return $destination;
+	}
+
+	/**
+	 * Reports whether the active driver can encode the given format.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $format Target format (`webp` or `avif`).
+	 *
+	 * @return bool True when the driver can encode the requested format.
+	 */
+	public function supports( string $format ): bool
+	{
+		$format = strtolower( $format );
+
+		if ( ! in_array( $format, self::SUPPORTED_FORMATS, true ) ) {
+			return false;
+		}
+
+		if ( ! in_array( $this->driver, self::SUPPORTED_DRIVERS, true ) ) {
+			return false;
+		}
+
+		if ( 'imagick' === $this->driver ) {
+			if ( ! class_exists( Imagick::class ) ) {
+				return false;
+			}
+
+			$formats = ( new Imagick() )->queryFormats( strtoupper( $format ) );
+
+			return ! empty( $formats );
+		}
+
+		if ( 'webp' === $format ) {
+			return function_exists( 'imagewebp' );
+		}
+
+		return function_exists( 'imageavif' );
+	}
+
+	/**
+	 * Returns the active driver name.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string The driver name (`gd` or `imagick`).
+	 */
+	public function driver(): string
+	{
+		return $this->driver;
+	}
+
+	/**
+	 * Encodes the source image with Imagick.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path        Absolute path to the source image.
+	 * @param string $destination Absolute path to write the converted file.
+	 * @param string $format      Target format (`webp` or `avif`).
+	 * @param int    $quality     Output quality (0-100).
+	 *
+	 * @throws RuntimeException When Imagick fails to encode the image.
+	 *
+	 * @return void
+	 */
+	protected function convertWithImagick( string $path, string $destination, string $format, int $quality ): void
+	{
+		try {
+			$image = new Imagick( $path );
+			$image->setImageFormat( $format );
+			$image->setImageCompressionQuality( $quality );
+
+			if ( $this->hasAlphaChannel( $path ) ) {
+				$image->setImageAlphaChannel( Imagick::ALPHACHANNEL_ACTIVATE );
+			}
+
+			$image->writeImage( $destination );
+			$image->clear();
+		} catch ( ImagickException $exception ) {
+			throw new RuntimeException(
+				"Imagick failed to convert {$path} to {$format}: " . $exception->getMessage(),
+				0,
+				$exception,
+			);
+		}
+	}
+
+	/**
+	 * Encodes the source image with GD.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path        Absolute path to the source image.
+	 * @param string $destination Absolute path to write the converted file.
+	 * @param string $format      Target format (`webp` or `avif`).
+	 * @param int    $quality     Output quality (0-100).
+	 *
+	 * @throws RuntimeException When GD cannot read or encode the image.
+	 *
+	 * @return void
+	 */
+	protected function convertWithGd( string $path, string $destination, string $format, int $quality ): void
+	{
+		$image = $this->createGdImage( $path );
+
+		if ( $this->hasAlphaChannel( $path ) ) {
+			imagepalettetotruecolor( $image );
+			imagealphablending( $image, false );
+			imagesavealpha( $image, true );
+		}
+
+		$result = 'webp' === $format
+			? imagewebp( $image, $destination, $quality )
+			: imageavif( $image, $destination, $quality );
+
+		imagedestroy( $image );
+
+		if ( false === $result ) {
+			throw new RuntimeException( "GD failed to encode {$format} for {$path}" );
+		}
+	}
+
+	/**
+	 * Creates a GD resource from the source image.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute path to the source image.
+	 *
+	 * @throws RuntimeException When the mime type cannot be detected or is unsupported.
+	 *
+	 * @return GdImage
+	 */
+	protected function createGdImage( string $path ): GdImage
+	{
+		$info = getimagesize( $path );
+
+		if ( false === $info ) {
+			throw new RuntimeException( "Unable to read image metadata: {$path}" );
+		}
+
+		$image = match ( $info[2] ) {
+			IMAGETYPE_JPEG => imagecreatefromjpeg( $path ),
+			IMAGETYPE_PNG  => imagecreatefrompng( $path ),
+			IMAGETYPE_GIF  => imagecreatefromgif( $path ),
+			IMAGETYPE_BMP  => imagecreatefrombmp( $path ),
+			IMAGETYPE_WEBP => imagecreatefromwebp( $path ),
+			default        => false,
+		};
+
+		if ( false === $image ) {
+			throw new RuntimeException( "Unsupported image type for GD: {$path}" );
+		}
+
+		return $image;
+	}
+
+	/**
+	 * Determines whether the source image carries an alpha channel.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute path to the source image.
+	 *
+	 * @return bool True when the source mime type supports transparency.
+	 */
+	protected function hasAlphaChannel( string $path ): bool
+	{
+		$info = getimagesize( $path );
+
+		if ( false === $info ) {
+			return false;
+		}
+
+		return in_array( $info[2], [ IMAGETYPE_PNG, IMAGETYPE_GIF, IMAGETYPE_WEBP ], true );
+	}
+
+	/**
+	 * Builds the destination path for the converted file.
+	 *
+	 * The converted file is stored alongside the original with the new
+	 * extension swapped in.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path   Absolute path to the source image.
+	 * @param string $format Target format (`webp` or `avif`).
+	 *
+	 * @return string Absolute path for the converted file.
+	 */
+	protected function targetPath( string $path, string $format ): string
+	{
+		$directory = dirname( $path );
+		$basename  = pathinfo( $path, PATHINFO_FILENAME );
+
+		return $directory . DIRECTORY_SEPARATOR . $basename . '.' . $format;
+	}
+}

--- a/src/Services/Image/FormatConverter.php
+++ b/src/Services/Image/FormatConverter.php
@@ -73,25 +73,30 @@ class FormatConverter
 	public const SUPPORTED_DRIVERS = [ 'gd', 'imagick' ];
 
 	/**
-	 * Active image driver (`gd` or `imagick`).
+	 * Optional driver override pinned at construction time.
+	 *
+	 * Null means "always read from config", which is the production path.
+	 * Tests can pin a specific driver via the constructor without touching
+	 * config state.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @var string
+	 * @var string|null
 	 */
-	protected string $driver;
+	protected ?string $driverOverride;
 
 	/**
 	 * Creates a new converter.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string|null $driver Optional driver override; defaults to the
-	 *                            `artisanpack.performance.images.driver` config value.
+	 * @param string|null $driver Optional driver override; when null the driver
+	 *                            is read from `artisanpack.performance.images.driver`
+	 *                            on every call so runtime config changes take effect.
 	 */
 	public function __construct( ?string $driver = null )
 	{
-		$this->driver = $driver ?? (string) config( 'artisanpack.performance.images.driver', 'gd' );
+		$this->driverOverride = $driver;
 	}
 
 	/**
@@ -144,6 +149,7 @@ class FormatConverter
 	public function convert( string $path, string $format, int $quality ): string
 	{
 		$format = strtolower( $format );
+		$driver = $this->driver();
 
 		if ( ! in_array( $format, self::SUPPORTED_FORMATS, true ) ) {
 			throw new RuntimeException( "Unsupported target format: {$format}" );
@@ -154,13 +160,13 @@ class FormatConverter
 		}
 
 		if ( ! $this->supports( $format ) ) {
-			throw new RuntimeException( "Driver '{$this->driver}' cannot encode {$format} on this system" );
+			throw new RuntimeException( "Driver '{$driver}' cannot encode {$format} on this system" );
 		}
 
 		$quality     = max( 0, min( 100, $quality ) );
 		$destination = $this->targetPath( $path, $format );
 
-		if ( 'imagick' === $this->driver ) {
+		if ( $this->usesImagick() ) {
 			$this->convertWithImagick( $path, $destination, $format, $quality );
 		} else {
 			$this->convertWithGd( $path, $destination, $format, $quality );
@@ -181,21 +187,26 @@ class FormatConverter
 	public function supports( string $format ): bool
 	{
 		$format = strtolower( $format );
+		$driver = $this->driver();
 
 		if ( ! in_array( $format, self::SUPPORTED_FORMATS, true ) ) {
 			return false;
 		}
 
-		if ( ! in_array( $this->driver, self::SUPPORTED_DRIVERS, true ) ) {
+		if ( ! in_array( $driver, self::SUPPORTED_DRIVERS, true ) ) {
 			return false;
 		}
 
-		if ( 'imagick' === $this->driver ) {
+		if ( 'imagick' === $driver ) {
 			if ( ! class_exists( Imagick::class ) ) {
 				return false;
 			}
 
-			$formats = ( new Imagick() )->queryFormats( strtoupper( $format ) );
+			try {
+				$formats = ( new Imagick() )->queryFormats( strtoupper( $format ) );
+			} catch ( ImagickException ) {
+				return false;
+			}
 
 			return ! empty( $formats );
 		}
@@ -210,13 +221,33 @@ class FormatConverter
 	/**
 	 * Returns the active driver name.
 	 *
+	 * Reads the override pinned at construction time, falling back to the
+	 * `artisanpack.performance.images.driver` config value so runtime swaps
+	 * take effect on every call.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @return string The driver name (`gd` or `imagick`).
 	 */
 	public function driver(): string
 	{
-		return $this->driver;
+		return $this->driverOverride ?? (string) config( 'artisanpack.performance.images.driver', 'gd' );
+	}
+
+	/**
+	 * Reports whether the active driver should route through Imagick.
+	 *
+	 * Single source of truth for the GD-vs-Imagick decision used across
+	 * `ImageService` and `FormatConverter` so unknown drivers can't silently
+	 * fall through to GD.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool True when the active driver is Imagick and the extension is loaded.
+	 */
+	public function usesImagick(): bool
+	{
+		return 'imagick' === $this->driver() && class_exists( Imagick::class );
 	}
 
 	/**
@@ -235,6 +266,8 @@ class FormatConverter
 	 */
 	protected function convertWithImagick( string $path, string $destination, string $format, int $quality ): void
 	{
+		$image = null;
+
 		try {
 			$image = new Imagick( $path );
 			$image->setImageFormat( $format );
@@ -245,13 +278,14 @@ class FormatConverter
 			}
 
 			$image->writeImage( $destination );
-			$image->clear();
 		} catch ( ImagickException $exception ) {
 			throw new RuntimeException(
 				"Imagick failed to convert {$path} to {$format}: " . $exception->getMessage(),
 				0,
 				$exception,
 			);
+		} finally {
+			$image?->clear();
 		}
 	}
 

--- a/src/Services/ImageService.php
+++ b/src/Services/ImageService.php
@@ -1,0 +1,638 @@
+<?php
+
+/**
+ * Image service.
+ *
+ * Central service for the package's image optimization features. Coordinates
+ * format conversion (WebP/AVIF), resizing, srcset generation, dominant color
+ * extraction, and placeholder generation. Heavy lifting is delegated to
+ * `FormatConverter` and the active driver (GD or Imagick).
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Services;
+
+use ArtisanPackUI\Performance\Events\ImageOptimized;
+use ArtisanPackUI\Performance\Services\Image\FormatConverter;
+use GdImage;
+use Imagick;
+use ImagickException;
+use RuntimeException;
+
+/**
+ * Image service class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+class ImageService
+{
+	/**
+	 * Format converter.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var FormatConverter
+	 */
+	protected FormatConverter $converter;
+
+	/**
+	 * Creates a new image service.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param FormatConverter|null $converter Optional converter override; defaults to a converter using the configured driver.
+	 */
+	public function __construct( ?FormatConverter $converter = null )
+	{
+		$this->converter = $converter ?? new FormatConverter();
+	}
+
+	/**
+	 * Runs the optimization pipeline for the given image.
+	 *
+	 * Generates the requested format derivatives at each requested width and
+	 * returns a structured payload describing every file produced. Fires the
+	 * `ImageOptimized` event once the pipeline completes.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string               $path    Absolute path to the source image.
+	 * @param array<string, mixed> $options Optional overrides:
+	 *                                      - `sizes`   array<int> Widths to generate (defaults to config).
+	 *                                      - `formats` array<string> Formats to generate (defaults to enabled formats).
+	 *                                      - `quality` int Quality applied to every format.
+	 *
+	 * @throws RuntimeException When the source image cannot be read.
+	 *
+	 * @return array<string, mixed> Optimization payload:
+	 *                              - `source`     string Path to the source image.
+	 *                              - `sizes`      array<int> Widths that were generated.
+	 *                              - `formats`    array<string> Formats that were generated.
+	 *                              - `variants`   array<int, array{path: string, format: string, width: int}>
+	 */
+	public function optimize( string $path, array $options = [] ): array
+	{
+		if ( ! is_file( $path ) || ! is_readable( $path ) ) {
+			throw new RuntimeException( "Source image is not readable: {$path}" );
+		}
+
+		$dimensions = getimagesize( $path );
+
+		if ( false === $dimensions ) {
+			throw new RuntimeException( "Unable to read image metadata: {$path}" );
+		}
+
+		$sourceWidth = (int) $dimensions[0];
+		$sizes       = $this->clampSizes( $this->resolveSizes( $options ), $sourceWidth );
+		$formats     = $this->resolveFormats( $options );
+		$variants    = [];
+
+		foreach ( $sizes as $width ) {
+			$resized = $this->resize( $path, $width );
+
+			foreach ( $formats as $format ) {
+				if ( ! $this->supportsFormat( $format ) ) {
+					continue;
+				}
+
+				$quality = $this->resolveQuality( $format, $options );
+				$variant = $this->converter->convert( $resized, $format, $quality );
+
+				$variants[] = [
+					'path'   => $variant,
+					'format' => $format,
+					'width'  => $width,
+				];
+			}
+
+			if ( $resized !== $path ) {
+				@unlink( $resized );
+			}
+		}
+
+		ImageOptimized::dispatch( $path, $formats, $sizes );
+
+		return [
+			'source'   => $path,
+			'sizes'    => $sizes,
+			'formats'  => $formats,
+			'variants' => $variants,
+		];
+	}
+
+	/**
+	 * Converts the source image to the requested format.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path    Absolute path to the source image.
+	 * @param string $format  Target format (`webp` or `avif`).
+	 * @param int    $quality Output quality (0-100).
+	 *
+	 * @return string Absolute path to the generated file.
+	 */
+	public function convertFormat( string $path, string $format, int $quality ): string
+	{
+		return $this->converter->convert( $path, $format, $quality );
+	}
+
+	/**
+	 * Resizes the source image to the requested dimensions.
+	 *
+	 * When `$height` is null the height is computed to preserve the source
+	 * aspect ratio. When the source is smaller than the target width the
+	 * original path is returned unchanged.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string   $path   Absolute path to the source image.
+	 * @param int      $width  Target width in pixels.
+	 * @param int|null $height Optional target height; computed when null.
+	 *
+	 * @throws RuntimeException When the source image cannot be read.
+	 *
+	 * @return string Absolute path to the resized image (or original when no resize was needed).
+	 */
+	public function resize( string $path, int $width, ?int $height = null ): string
+	{
+		$dimensions = getimagesize( $path );
+
+		if ( false === $dimensions ) {
+			throw new RuntimeException( "Unable to read image metadata: {$path}" );
+		}
+
+		[ $sourceWidth, $sourceHeight ] = $dimensions;
+
+		if ( $sourceWidth <= $width ) {
+			return $path;
+		}
+
+		$targetHeight = $height ?? (int) round( ( $width / $sourceWidth ) * $sourceHeight );
+		$destination  = $this->resizedPath( $path, $width );
+
+		if ( 'imagick' === $this->converter->driver() && class_exists( Imagick::class ) ) {
+			$this->resizeWithImagick( $path, $destination, $width, $targetHeight );
+
+			return $destination;
+		}
+
+		$this->resizeWithGd( $path, $destination, $sourceWidth, $sourceHeight, $width, $targetHeight );
+
+		return $destination;
+	}
+
+	/**
+	 * Generates a responsive `srcset` value for the given widths.
+	 *
+	 * Each width is generated as a separate file and returned as `path Wn`
+	 * entries joined with commas, matching the standard HTML srcset syntax.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string         $path  Absolute path to the source image.
+	 * @param array<int,int> $sizes Widths to generate.
+	 *
+	 * @return string The srcset attribute value.
+	 */
+	public function generateSrcset( string $path, array $sizes ): string
+	{
+		$entries = [];
+
+		foreach ( $sizes as $width ) {
+			$resized   = $this->resize( $path, $width );
+			$entries[] = $resized . ' ' . $width . 'w';
+		}
+
+		return implode( ', ', $entries );
+	}
+
+	/**
+	 * Extracts the dominant color from the source image.
+	 *
+	 * Samples the image at low resolution and averages the channels to
+	 * produce a 7-character hex string suitable for use as an LQIP background.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute path to the source image.
+	 *
+	 * @throws RuntimeException When the image cannot be opened.
+	 *
+	 * @return string Hex color string in the form `#rrggbb`.
+	 */
+	public function extractDominantColor( string $path ): string
+	{
+		if ( ! is_file( $path ) || ! is_readable( $path ) ) {
+			throw new RuntimeException( "Source image is not readable: {$path}" );
+		}
+
+		if ( 'imagick' === $this->converter->driver() && class_exists( Imagick::class ) ) {
+			return $this->dominantColorWithImagick( $path );
+		}
+
+		return $this->dominantColorWithGd( $path );
+	}
+
+	/**
+	 * Generates a placeholder representation of the image.
+	 *
+	 * Supported types:
+	 *  - `dominant_color`: returns the dominant color hex string.
+	 *  - `blur`: returns a tiny base64-encoded blurred preview suitable for
+	 *            inline `src` attributes (LQIP).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute path to the source image.
+	 * @param string $type Placeholder type (`dominant_color` or `blur`).
+	 *
+	 * @throws RuntimeException When the placeholder type is unknown.
+	 *
+	 * @return string Hex color string or base64 data URI depending on type.
+	 */
+	public function generatePlaceholder( string $path, string $type = 'dominant_color' ): string
+	{
+		return match ( $type ) {
+			'dominant_color' => $this->extractDominantColor( $path ),
+			'blur'           => $this->generateBlurPlaceholder( $path ),
+			default          => throw new RuntimeException( "Unknown placeholder type: {$type}" ),
+		};
+	}
+
+	/**
+	 * Reports whether the active driver can encode the given format.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $format Target format (`webp` or `avif`).
+	 *
+	 * @return bool True when the format is supported.
+	 */
+	public function supportsFormat( string $format ): bool
+	{
+		return $this->converter->supports( $format );
+	}
+
+	/**
+	 * Returns the underlying format converter.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return FormatConverter
+	 */
+	public function converter(): FormatConverter
+	{
+		return $this->converter;
+	}
+
+	/**
+	 * Resolves the widths to generate from options/config.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<string, mixed> $options Caller-provided options.
+	 *
+	 * @return array<int, int> Widths sorted ascending and deduplicated.
+	 */
+	protected function resolveSizes( array $options ): array
+	{
+		$sizes = $options['sizes'] ?? config( 'artisanpack.performance.images.sizes', [] );
+		$sizes = array_values( array_unique( array_map( 'intval', (array) $sizes ) ) );
+		sort( $sizes );
+
+		return $sizes;
+	}
+
+	/**
+	 * Clamps requested widths to the source width and dedupes.
+	 *
+	 * Prevents upscaling and ensures each width produces a distinct variant
+	 * file (widths greater than the source would otherwise all collide on
+	 * the same FormatConverter destination).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<int, int> $sizes       Widths requested by the caller.
+	 * @param int             $sourceWidth Source image width in pixels.
+	 *
+	 * @return array<int, int> Effective widths to generate, sorted ascending.
+	 */
+	protected function clampSizes( array $sizes, int $sourceWidth ): array
+	{
+		$clamped = array_values( array_unique( array_map(
+			static fn ( int $width ): int => min( $width, $sourceWidth ),
+			$sizes,
+		) ) );
+
+		sort( $clamped );
+
+		return $clamped;
+	}
+
+	/**
+	 * Resolves the formats to generate from options/config.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<string, mixed> $options Caller-provided options.
+	 *
+	 * @return array<int, string> Format keys in the order they should be generated.
+	 */
+	protected function resolveFormats( array $options ): array
+	{
+		if ( isset( $options['formats'] ) ) {
+			return array_values( array_map( 'strtolower', (array) $options['formats'] ) );
+		}
+
+		$configured = (array) config( 'artisanpack.performance.images.formats', [] );
+		$enabled    = [];
+
+		foreach ( $configured as $format => $settings ) {
+			if ( ! empty( $settings['enabled'] ) ) {
+				$enabled[] = (string) $format;
+			}
+		}
+
+		return $enabled;
+	}
+
+	/**
+	 * Resolves the quality for the given format from options/config.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string               $format  Target format.
+	 * @param array<string, mixed> $options Caller-provided options.
+	 *
+	 * @return int Quality clamped between 0 and 100.
+	 */
+	protected function resolveQuality( string $format, array $options ): int
+	{
+		if ( isset( $options['quality'] ) ) {
+			return max( 0, min( 100, (int) $options['quality'] ) );
+		}
+
+		$default = 'webp' === $format
+			? FormatConverter::DEFAULT_WEBP_QUALITY
+			: FormatConverter::DEFAULT_AVIF_QUALITY;
+
+		$configured = config( "artisanpack.performance.images.formats.{$format}.quality", $default );
+
+		return max( 0, min( 100, (int) $configured ) );
+	}
+
+	/**
+	 * Builds the destination path for a resized image.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path  Absolute path to the source image.
+	 * @param int    $width Target width.
+	 *
+	 * @return string Absolute path for the resized derivative.
+	 */
+	protected function resizedPath( string $path, int $width ): string
+	{
+		$directory = dirname( $path );
+		$basename  = pathinfo( $path, PATHINFO_FILENAME );
+		$extension = pathinfo( $path, PATHINFO_EXTENSION );
+
+		return $directory . DIRECTORY_SEPARATOR . $basename . '-' . $width . 'w.' . $extension;
+	}
+
+	/**
+	 * Resizes the source image using Imagick.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path        Absolute path to the source image.
+	 * @param string $destination Absolute path to write the resized image.
+	 * @param int    $width       Target width.
+	 * @param int    $height      Target height.
+	 *
+	 * @throws RuntimeException When Imagick fails to resize the image.
+	 *
+	 * @return void
+	 */
+	protected function resizeWithImagick( string $path, string $destination, int $width, int $height ): void
+	{
+		try {
+			$image = new Imagick( $path );
+			$image->resizeImage( $width, $height, Imagick::FILTER_LANCZOS, 1 );
+			$image->writeImage( $destination );
+			$image->clear();
+		} catch ( ImagickException $exception ) {
+			throw new RuntimeException(
+				"Imagick failed to resize {$path}: " . $exception->getMessage(),
+				0,
+				$exception,
+			);
+		}
+	}
+
+	/**
+	 * Resizes the source image using GD.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path         Absolute path to the source image.
+	 * @param string $destination  Absolute path to write the resized image.
+	 * @param int    $sourceWidth  Source image width.
+	 * @param int    $sourceHeight Source image height.
+	 * @param int    $width        Target width.
+	 * @param int    $height       Target height.
+	 *
+	 * @throws RuntimeException When GD cannot encode the resized image.
+	 *
+	 * @return void
+	 */
+	protected function resizeWithGd(
+		string $path,
+		string $destination,
+		int $sourceWidth,
+		int $sourceHeight,
+		int $width,
+		int $height,
+	): void {
+		$source = $this->createGdImage( $path );
+		$target = imagecreatetruecolor( $width, $height );
+
+		imagealphablending( $target, false );
+		imagesavealpha( $target, true );
+		$transparent = imagecolorallocatealpha( $target, 0, 0, 0, 127 );
+		imagefilledrectangle( $target, 0, 0, $width, $height, $transparent );
+
+		imagecopyresampled( $target, $source, 0, 0, 0, 0, $width, $height, $sourceWidth, $sourceHeight );
+
+		$result = $this->writeGdImage( $target, $destination, $path );
+
+		imagedestroy( $source );
+		imagedestroy( $target );
+
+		if ( false === $result ) {
+			throw new RuntimeException( "GD failed to write resized image: {$destination}" );
+		}
+	}
+
+	/**
+	 * Writes a GD image to disk using the encoder matching the destination extension.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param GdImage $image       GD image resource.
+	 * @param string  $destination Absolute destination path.
+	 * @param string  $sourcePath  Source path (used to pick the encoder when the destination has no extension).
+	 *
+	 * @return bool True on success, false on failure.
+	 */
+	protected function writeGdImage( GdImage $image, string $destination, string $sourcePath ): bool
+	{
+		$extension = strtolower( pathinfo( $destination, PATHINFO_EXTENSION ) );
+
+		if ( '' === $extension ) {
+			$extension = strtolower( pathinfo( $sourcePath, PATHINFO_EXTENSION ) );
+		}
+
+		return match ( $extension ) {
+			'jpg', 'jpeg' => imagejpeg( $image, $destination, 90 ),
+			'png'         => imagepng( $image, $destination ),
+			'gif'         => imagegif( $image, $destination ),
+			'webp'        => imagewebp( $image, $destination, 80 ),
+			default       => imagepng( $image, $destination ),
+		};
+	}
+
+	/**
+	 * Extracts the dominant color using Imagick.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute path to the source image.
+	 *
+	 * @throws RuntimeException When Imagick fails to read the image.
+	 *
+	 * @return string Hex color string `#rrggbb`.
+	 */
+	protected function dominantColorWithImagick( string $path ): string
+	{
+		try {
+			$image = new Imagick( $path );
+			$image->resizeImage( 1, 1, Imagick::FILTER_LANCZOS, 1 );
+			$pixel = $image->getImagePixelColor( 0, 0 )->getColor();
+			$image->clear();
+		} catch ( ImagickException $exception ) {
+			throw new RuntimeException(
+				"Imagick failed to sample {$path}: " . $exception->getMessage(),
+				0,
+				$exception,
+			);
+		}
+
+		return sprintf( '#%02x%02x%02x', $pixel['r'], $pixel['g'], $pixel['b'] );
+	}
+
+	/**
+	 * Extracts the dominant color using GD.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute path to the source image.
+	 *
+	 * @return string Hex color string `#rrggbb`.
+	 */
+	protected function dominantColorWithGd( string $path ): string
+	{
+		$source = $this->createGdImage( $path );
+		$thumb  = imagecreatetruecolor( 1, 1 );
+
+		imagecopyresampled( $thumb, $source, 0, 0, 0, 0, 1, 1, imagesx( $source ), imagesy( $source ) );
+		$rgb = imagecolorat( $thumb, 0, 0 );
+
+		imagedestroy( $source );
+		imagedestroy( $thumb );
+
+		$r = ( $rgb >> 16 ) & 0xFF;
+		$g = ( $rgb >> 8 ) & 0xFF;
+		$b = $rgb & 0xFF;
+
+		return sprintf( '#%02x%02x%02x', $r, $g, $b );
+	}
+
+	/**
+	 * Generates a small base64-encoded blurred placeholder (LQIP).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute path to the source image.
+	 *
+	 * @throws RuntimeException When the placeholder cannot be generated.
+	 *
+	 * @return string Data URI of the placeholder.
+	 */
+	protected function generateBlurPlaceholder( string $path ): string
+	{
+		if ( ! is_file( $path ) || ! is_readable( $path ) ) {
+			throw new RuntimeException( "Source image is not readable: {$path}" );
+		}
+
+		$source = $this->createGdImage( $path );
+		$thumb  = imagecreatetruecolor( 16, 16 );
+
+		imagecopyresampled( $thumb, $source, 0, 0, 0, 0, 16, 16, imagesx( $source ), imagesy( $source ) );
+
+		ob_start();
+		imagejpeg( $thumb, null, 30 );
+		$bytes = (string) ob_get_clean();
+
+		imagedestroy( $source );
+		imagedestroy( $thumb );
+
+		return 'data:image/jpeg;base64,' . base64_encode( $bytes );
+	}
+
+	/**
+	 * Creates a GD resource from the source image.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute path to the source image.
+	 *
+	 * @throws RuntimeException When the source mime type cannot be decoded by GD.
+	 *
+	 * @return GdImage
+	 */
+	protected function createGdImage( string $path ): GdImage
+	{
+		$info = getimagesize( $path );
+
+		if ( false === $info ) {
+			throw new RuntimeException( "Unable to read image metadata: {$path}" );
+		}
+
+		$image = match ( $info[2] ) {
+			IMAGETYPE_JPEG => imagecreatefromjpeg( $path ),
+			IMAGETYPE_PNG  => imagecreatefrompng( $path ),
+			IMAGETYPE_GIF  => imagecreatefromgif( $path ),
+			IMAGETYPE_BMP  => imagecreatefrombmp( $path ),
+			IMAGETYPE_WEBP => imagecreatefromwebp( $path ),
+			default        => false,
+		};
+
+		if ( false === $image ) {
+			throw new RuntimeException( "Unsupported image type for GD: {$path}" );
+		}
+
+		return $image;
+	}
+}

--- a/src/Services/ImageService.php
+++ b/src/Services/ImageService.php
@@ -121,12 +121,19 @@ class ImageService
 			}
 		}
 
-		ImageOptimized::dispatch( $path, $formats, $sizes );
+		$producedFormats = array_values( array_unique( array_map(
+			static fn ( array $variant ): string => $variant['format'],
+			$variants,
+		) ) );
+
+		if ( ! empty( $variants ) ) {
+			ImageOptimized::dispatch( $path, $producedFormats, $sizes );
+		}
 
 		return [
 			'source'   => $path,
 			'sizes'    => $sizes,
-			'formats'  => $formats,
+			'formats'  => $producedFormats,
 			'variants' => $variants,
 		];
 	}
@@ -174,14 +181,17 @@ class ImageService
 
 		[ $sourceWidth, $sourceHeight ] = $dimensions;
 
-		if ( $sourceWidth <= $width ) {
+		// Skip only when the caller asked for the aspect-preserving default AND
+		// the source is already small enough — never short-circuit when an
+		// explicit height was supplied or we'd silently return wrong dimensions.
+		if ( null === $height && $sourceWidth <= $width ) {
 			return $path;
 		}
 
 		$targetHeight = $height ?? (int) round( ( $width / $sourceWidth ) * $sourceHeight );
 		$destination  = $this->resizedPath( $path, $width );
 
-		if ( 'imagick' === $this->converter->driver() && class_exists( Imagick::class ) ) {
+		if ( $this->converter->usesImagick() ) {
 			$this->resizeWithImagick( $path, $destination, $width, $targetHeight );
 
 			return $destination;
@@ -237,7 +247,7 @@ class ImageService
 			throw new RuntimeException( "Source image is not readable: {$path}" );
 		}
 
-		if ( 'imagick' === $this->converter->driver() && class_exists( Imagick::class ) ) {
+		if ( $this->converter->usesImagick() ) {
 			return $this->dominantColorWithImagick( $path );
 		}
 
@@ -427,17 +437,20 @@ class ImageService
 	 */
 	protected function resizeWithImagick( string $path, string $destination, int $width, int $height ): void
 	{
+		$image = null;
+
 		try {
 			$image = new Imagick( $path );
 			$image->resizeImage( $width, $height, Imagick::FILTER_LANCZOS, 1 );
 			$image->writeImage( $destination );
-			$image->clear();
 		} catch ( ImagickException $exception ) {
 			throw new RuntimeException(
 				"Imagick failed to resize {$path}: " . $exception->getMessage(),
 				0,
 				$exception,
 			);
+		} finally {
+			$image?->clear();
 		}
 	}
 
@@ -526,17 +539,20 @@ class ImageService
 	 */
 	protected function dominantColorWithImagick( string $path ): string
 	{
+		$image = null;
+
 		try {
 			$image = new Imagick( $path );
 			$image->resizeImage( 1, 1, Imagick::FILTER_LANCZOS, 1 );
 			$pixel = $image->getImagePixelColor( 0, 0 )->getColor();
-			$image->clear();
 		} catch ( ImagickException $exception ) {
 			throw new RuntimeException(
 				"Imagick failed to sample {$path}: " . $exception->getMessage(),
 				0,
 				$exception,
 			);
+		} finally {
+			$image?->clear();
 		}
 
 		return sprintf( '#%02x%02x%02x', $pixel['r'], $pixel['g'], $pixel['b'] );
@@ -592,11 +608,15 @@ class ImageService
 		imagecopyresampled( $thumb, $source, 0, 0, 0, 0, 16, 16, imagesx( $source ), imagesy( $source ) );
 
 		ob_start();
-		imagejpeg( $thumb, null, 30 );
-		$bytes = (string) ob_get_clean();
+		$encoded = imagejpeg( $thumb, null, 30 );
+		$bytes   = ob_get_clean();
 
 		imagedestroy( $source );
 		imagedestroy( $thumb );
+
+		if ( false === $encoded || false === $bytes || '' === $bytes ) {
+			throw new RuntimeException( "GD failed to encode blur placeholder for: {$path}" );
+		}
 
 		return 'data:image/jpeg;base64,' . base64_encode( $bytes );
 	}

--- a/src/Services/PerformanceService.php
+++ b/src/Services/PerformanceService.php
@@ -35,6 +35,42 @@ use Closure;
 class PerformanceService
 {
 	/**
+	 * Image service used for optimization, format conversion, and color extraction.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var ImageService
+	 */
+	protected ImageService $images;
+
+	/**
+	 * Creates a new performance service.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param ImageService|null $images Optional image service override (constructs the default when null).
+	 */
+	public function __construct( ?ImageService $images = null )
+	{
+		$this->images = $images ?? new ImageService();
+	}
+
+	/**
+	 * Returns the underlying image service.
+	 *
+	 * Exposes the image pipeline for callers that need to call methods not
+	 * proxied by the facade (resize, generateSrcset, generatePlaceholder).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return ImageService
+	 */
+	public function images(): ImageService
+	{
+		return $this->images;
+	}
+
+	/**
 	 * Checks whether a Performance feature is enabled.
 	 *
 	 * Reads the `artisanpack.performance.features.<name>` config key. Returns
@@ -55,9 +91,9 @@ class PerformanceService
 	/**
 	 * Optimizes an image at the given path.
 	 *
-	 * Stubbed in Phase 1. The image optimization pipeline is implemented in
-	 * Phase 2 and will return the generated derivatives (paths, sizes,
-	 * formats) keyed by variant.
+	 * Delegates to the underlying `ImageService` which generates the
+	 * configured format derivatives (WebP/AVIF) at every configured width,
+	 * fires the `ImageOptimized` event, and returns the produced variants.
 	 *
 	 * @since 1.0.0
 	 *
@@ -68,7 +104,7 @@ class PerformanceService
 	 */
 	public function optimizeImage( string $path, array $options = [] ): array
 	{
-		return [];
+		return $this->images->optimize( $path, $options );
 	}
 
 	/**
@@ -83,7 +119,7 @@ class PerformanceService
 	 */
 	public function convertToWebP( string $path, int $quality = 80 ): string
 	{
-		return $path;
+		return $this->images->convertFormat( $path, 'webp', $quality );
 	}
 
 	/**
@@ -98,7 +134,36 @@ class PerformanceService
 	 */
 	public function convertToAvif( string $path, int $quality = 70 ): string
 	{
-		return $path;
+		return $this->images->convertFormat( $path, 'avif', $quality );
+	}
+
+	/**
+	 * Extracts the dominant color from the given image.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute path to the source image.
+	 *
+	 * @return string Hex color string `#rrggbb`.
+	 */
+	public function getDominantColor( string $path ): string
+	{
+		return $this->images->extractDominantColor( $path );
+	}
+
+	/**
+	 * Generates a responsive srcset string for the given image.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string         $path  Absolute path to the source image.
+	 * @param array<int,int> $sizes Widths to include in the srcset.
+	 *
+	 * @return string The srcset attribute value.
+	 */
+	public function getResponsiveSrcset( string $path, array $sizes ): string
+	{
+		return $this->images->generateSrcset( $path, $sizes );
 	}
 
 	/**
@@ -141,6 +206,61 @@ class PerformanceService
 	}
 
 	/**
+	 * Remembers a value indefinitely.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string  $key      The cache key.
+	 * @param Closure $callback Callback whose return value is cached.
+	 *
+	 * @return mixed The cached or freshly computed value.
+	 */
+	public function rememberForever( string $key, Closure $callback ): mixed
+	{
+		$store = config( 'artisanpack.performance.fragment_cache.driver' );
+
+		return cache()->store( $store )->rememberForever( "performance:{$key}", $callback );
+	}
+
+	/**
+	 * Invalidates a single namespaced cache key.
+	 *
+	 * Accepts the bare key (e.g. `products`) and applies the package's
+	 * `performance:` prefix internally.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key The cache key to forget.
+	 *
+	 * @return bool True when the key was forgotten.
+	 */
+	public function invalidateCache( string $key ): bool
+	{
+		$store = config( 'artisanpack.performance.fragment_cache.driver' );
+
+		return (bool) cache()->store( $store )->forget( "performance:{$key}" );
+	}
+
+	/**
+	 * Flushes the entire fragment cache store.
+	 *
+	 * Note: this purges the underlying store wholesale, not just the
+	 * `performance:` namespace, because Laravel's cache contract does not
+	 * expose prefix-scoped deletion. Use this on a dedicated store when a
+	 * scoped flush matters.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool True when the store was flushed.
+	 */
+	public function flushCache(): bool
+	{
+		$store = config( 'artisanpack.performance.fragment_cache.driver' );
+
+		return (bool) cache()->store( $store )->flush();
+	}
+
+	/**
 	 * Records a single performance metric sample.
 	 *
 	 * Phase 1 is a no-op; Phase 8 wires this up to the monitoring collector
@@ -157,5 +277,21 @@ class PerformanceService
 	public function recordMetric( string $name, float $value, array $context = [] ): void
 	{
 		// Implemented in Phase 8 (monitoring).
+	}
+
+	/**
+	 * Returns recommended performance actions for the current configuration.
+	 *
+	 * Phase 1 returns an empty list; Phase 8 (monitoring) wires this up to
+	 * the recommendations engine that inspects aggregated metrics, slow
+	 * queries, and feature toggles to surface concrete suggestions.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, array<string, mixed>> List of recommendation payloads.
+	 */
+	public function getRecommendations(): array
+	{
+		return [];
 	}
 }

--- a/src/Services/PerformanceService.php
+++ b/src/Services/PerformanceService.php
@@ -21,6 +21,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\Performance\Services;
 
 use Closure;
+use RuntimeException;
 
 /**
  * Performance service class.
@@ -242,22 +243,38 @@ class PerformanceService
 	}
 
 	/**
-	 * Flushes the entire fragment cache store.
+	 * Flushes the entire fragment cache store wholesale.
 	 *
-	 * Note: this purges the underlying store wholesale, not just the
-	 * `performance:` namespace, because Laravel's cache contract does not
-	 * expose prefix-scoped deletion. Use this on a dedicated store when a
-	 * scoped flush matters.
+	 * Refuses when the fragment-cache driver resolves to the framework's
+	 * default cache store, since Laravel's cache contract exposes only
+	 * store-wide `flush()` (not prefix-scoped deletion) — flushing the
+	 * default store would also wipe sessions, locks, rate-limiter state,
+	 * and unrelated app cache entries. Configure
+	 * `artisanpack.performance.fragment_cache.driver` to a dedicated store
+	 * (a separate redis db, an isolated file disk, etc.) to opt in.
 	 *
 	 * @since 1.0.0
+	 *
+	 * @throws RuntimeException When the fragment store would also wipe the framework default cache.
 	 *
 	 * @return bool True when the store was flushed.
 	 */
 	public function flushCache(): bool
 	{
-		$store = config( 'artisanpack.performance.fragment_cache.driver' );
+		$fragmentStore = config( 'artisanpack.performance.fragment_cache.driver' );
+		$defaultStore  = config( 'cache.default' );
 
-		return (bool) cache()->store( $store )->flush();
+		// A null fragment driver routes through the default store; an explicit
+		// match collapses to the same store. Either way, flushing would nuke
+		// unrelated app cache entries.
+		if ( null === $fragmentStore || $fragmentStore === $defaultStore ) {
+			throw new RuntimeException(
+				'Refusing to flush the framework default cache store. Configure '
+				. 'artisanpack.performance.fragment_cache.driver to a dedicated store first.',
+			);
+		}
+
+		return (bool) cache()->store( $fragmentStore )->flush();
 	}
 
 	/**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -64,7 +64,13 @@ if ( ! function_exists( 'perfOptimizeImage' ) ) {
 
 if ( ! function_exists( 'perfConvertToWebP' ) ) {
 	/**
-	 * Converts the given image to WebP.
+	 * Converts the given image to WebP, falling back to the source path.
+	 *
+	 * Blade-safe wrapper: when the active driver cannot encode WebP on this
+	 * host, returns the original `$path` unchanged instead of throwing so
+	 * templates degrade to the source image rather than 500ing. Callers that
+	 * want explicit error handling should use the Performance facade
+	 * directly.
 	 *
 	 * @since 1.0.0
 	 *
@@ -75,13 +81,22 @@ if ( ! function_exists( 'perfConvertToWebP' ) ) {
 	 */
 	function perfConvertToWebP( string $path, int $quality = 80 ): string
 	{
+		if ( ! performance()->images()->supportsFormat( 'webp' ) ) {
+			return $path;
+		}
+
 		return performance()->convertToWebP( $path, $quality );
 	}
 }
 
 if ( ! function_exists( 'perfConvertToAvif' ) ) {
 	/**
-	 * Converts the given image to AVIF.
+	 * Converts the given image to AVIF, falling back to the source path.
+	 *
+	 * Blade-safe wrapper: when the active driver cannot encode AVIF on this
+	 * host (common — most PHP/GD builds ship without libavif), returns the
+	 * original `$path` unchanged instead of throwing. Callers that want
+	 * explicit error handling should use the Performance facade directly.
 	 *
 	 * @since 1.0.0
 	 *
@@ -92,6 +107,10 @@ if ( ! function_exists( 'perfConvertToAvif' ) ) {
 	 */
 	function perfConvertToAvif( string $path, int $quality = 70 ): string
 	{
+		if ( ! performance()->images()->supportsFormat( 'avif' ) ) {
+			return $path;
+		}
+
 		return performance()->convertToAvif( $path, $quality );
 	}
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -28,3 +28,200 @@ if ( ! function_exists( 'performance' ) ) {
 		return app( 'performance' );
 	}
 }
+
+if ( ! function_exists( 'perfFeatureEnabled' ) ) {
+	/**
+	 * Reports whether a performance feature is enabled.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $feature The feature key (e.g. `image_optimization`).
+	 *
+	 * @return bool
+	 */
+	function perfFeatureEnabled( string $feature ): bool
+	{
+		return performance()->isFeatureEnabled( $feature );
+	}
+}
+
+if ( ! function_exists( 'perfOptimizeImage' ) ) {
+	/**
+	 * Runs the image optimization pipeline for the given path.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string               $path    Absolute path to the source image.
+	 * @param array<string, mixed> $options Optimization overrides forwarded to ImageService.
+	 *
+	 * @return array<string, mixed>
+	 */
+	function perfOptimizeImage( string $path, array $options = [] ): array
+	{
+		return performance()->optimizeImage( $path, $options );
+	}
+}
+
+if ( ! function_exists( 'perfConvertToWebP' ) ) {
+	/**
+	 * Converts the given image to WebP.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path    Absolute path to the source image.
+	 * @param int    $quality Output quality (0-100).
+	 *
+	 * @return string
+	 */
+	function perfConvertToWebP( string $path, int $quality = 80 ): string
+	{
+		return performance()->convertToWebP( $path, $quality );
+	}
+}
+
+if ( ! function_exists( 'perfConvertToAvif' ) ) {
+	/**
+	 * Converts the given image to AVIF.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path    Absolute path to the source image.
+	 * @param int    $quality Output quality (0-100).
+	 *
+	 * @return string
+	 */
+	function perfConvertToAvif( string $path, int $quality = 70 ): string
+	{
+		return performance()->convertToAvif( $path, $quality );
+	}
+}
+
+if ( ! function_exists( 'perfGetDominantColor' ) ) {
+	/**
+	 * Returns the dominant color of the given image as a hex string.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute path to the source image.
+	 *
+	 * @return string
+	 */
+	function perfGetDominantColor( string $path ): string
+	{
+		return performance()->getDominantColor( $path );
+	}
+}
+
+if ( ! function_exists( 'perfGetResponsiveSrcset' ) ) {
+	/**
+	 * Generates a responsive `srcset` value for the given image.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string         $path  Absolute path to the source image.
+	 * @param array<int,int> $sizes Widths to include in the srcset.
+	 *
+	 * @return string
+	 */
+	function perfGetResponsiveSrcset( string $path, array $sizes ): string
+	{
+		return performance()->getResponsiveSrcset( $path, $sizes );
+	}
+}
+
+if ( ! function_exists( 'perfRemember' ) ) {
+	/**
+	 * Remembers a value in the package's namespaced cache for the given TTL.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string  $key      The cache key.
+	 * @param int     $ttl      Time-to-live in seconds.
+	 * @param Closure $callback Callback whose return value is cached.
+	 *
+	 * @return mixed
+	 */
+	function perfRemember( string $key, int $ttl, Closure $callback ): mixed
+	{
+		return performance()->remember( $key, $ttl, $callback );
+	}
+}
+
+if ( ! function_exists( 'perfRememberForever' ) ) {
+	/**
+	 * Remembers a value in the package's namespaced cache indefinitely.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string  $key      The cache key.
+	 * @param Closure $callback Callback whose return value is cached.
+	 *
+	 * @return mixed
+	 */
+	function perfRememberForever( string $key, Closure $callback ): mixed
+	{
+		return performance()->rememberForever( $key, $callback );
+	}
+}
+
+if ( ! function_exists( 'perfInvalidateCache' ) ) {
+	/**
+	 * Invalidates the given namespaced cache key.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key The cache key to forget.
+	 *
+	 * @return bool
+	 */
+	function perfInvalidateCache( string $key ): bool
+	{
+		return performance()->invalidateCache( $key );
+	}
+}
+
+if ( ! function_exists( 'perfFlushCache' ) ) {
+	/**
+	 * Flushes the package's fragment cache store wholesale.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool
+	 */
+	function perfFlushCache(): bool
+	{
+		return performance()->flushCache();
+	}
+}
+
+if ( ! function_exists( 'perfRecordMetric' ) ) {
+	/**
+	 * Records a single performance metric sample.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string               $name    Metric name (e.g. `LCP`).
+	 * @param float                $value   Metric value.
+	 * @param array<string, mixed> $context Optional contextual data.
+	 *
+	 * @return void
+	 */
+	function perfRecordMetric( string $name, float $value, array $context = [] ): void
+	{
+		performance()->recordMetric( $name, $value, $context );
+	}
+}
+
+if ( ! function_exists( 'perfGetRecommendations' ) ) {
+	/**
+	 * Returns recommended performance actions for the current configuration.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	function perfGetRecommendations(): array
+	{
+		return performance()->getRecommendations();
+	}
+}

--- a/tests/Feature/Console/GenerateWebPCommandTest.php
+++ b/tests/Feature/Console/GenerateWebPCommandTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare( strict_types=1 );
+
+beforeEach( function (): void {
+	clearImageFixtures();
+} );
+
+afterEach( function (): void {
+	clearImageFixtures();
+} );
+
+it( 'fails fast when the supplied path does not exist', function (): void {
+	$this->artisan( 'perf:generate-webp', [ 'path' => '/no/such/path' ] )
+		->expectsOutputToContain( 'Path does not exist' )
+		->assertFailed();
+} );
+
+it( 'converts a single image file at the configured quality', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	$source = makeTestImage( 'single.jpg', 100, 100 );
+
+	$this->artisan( 'perf:generate-webp', [ 'path' => $source, '--quality' => 60 ] )
+		->expectsOutputToContain( 'Converted 1' )
+		->assertSuccessful();
+
+	$destination = imageFixturesDir() . DIRECTORY_SEPARATOR . 'single.webp';
+	expect( file_exists( $destination ) )->toBeTrue();
+} );
+
+it( 'converts every image in a directory non-recursively by default', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	makeTestImage( 'a.jpg' );
+	makeTestImage( 'b.png', 80, 80, 'png' );
+
+	// Nested file that should be ignored without --recursive.
+	mkdir( imageFixturesDir() . '/nested', 0777, true );
+	$nested = imageFixturesDir() . '/nested/c.jpg';
+	copy( makeTestImage( 'c.jpg' ), $nested );
+
+	$this->artisan( 'perf:generate-webp', [ 'path' => imageFixturesDir() ] )
+		->expectsOutputToContain( 'Converted 3' )
+		->assertSuccessful();
+
+	expect( file_exists( imageFixturesDir() . '/a.webp' ) )->toBeTrue()
+		->and( file_exists( imageFixturesDir() . '/b.webp' ) )->toBeTrue()
+		->and( file_exists( imageFixturesDir() . '/nested/c.webp' ) )->toBeFalse();
+} );
+
+it( 'recurses into subdirectories when --recursive is set', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	mkdir( imageFixturesDir() . '/deep', 0777, true );
+	$top    = makeTestImage( 'top.jpg' );
+	$nested = imageFixturesDir() . '/deep/nested.jpg';
+	copy( $top, $nested );
+
+	$this->artisan( 'perf:generate-webp', [
+		'path'         => imageFixturesDir(),
+		'--recursive'  => true,
+	] )->assertSuccessful();
+
+	expect( file_exists( imageFixturesDir() . '/deep/nested.webp' ) )->toBeTrue();
+} );
+
+it( 'skips files that already have a WebP sibling unless --force is set', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	$source = makeTestImage( 'existing.jpg' );
+	touch( imageFixturesDir() . '/existing.webp' );
+
+	$this->artisan( 'perf:generate-webp', [ 'path' => $source ] )
+		->expectsOutputToContain( 'skip:' )
+		->assertSuccessful();
+
+	$this->artisan( 'perf:generate-webp', [ 'path' => $source, '--force' => true ] )
+		->expectsOutputToContain( 'Converted 1' )
+		->assertSuccessful();
+} );
+
+it( 'returns success with a warning when no convertible files are found', function (): void {
+	$this->artisan( 'perf:generate-webp', [ 'path' => imageFixturesDir() ] )
+		->expectsOutputToContain( 'No convertible images found' )
+		->assertSuccessful();
+} );

--- a/tests/Feature/HelpersTest.php
+++ b/tests/Feature/HelpersTest.php
@@ -25,6 +25,41 @@ it( 'reports feature flags through perfFeatureEnabled', function (): void {
 		->and( perfFeatureEnabled( 'nonexistent' ) )->toBeFalse();
 } );
 
+it( 'returns the source path from perfConvertToWebP when the active driver cannot encode WebP', function (): void {
+	// Regression: previously threw RuntimeException on encoder-less hosts,
+	// which would 500 any Blade template using {{ perfConvertToWebP($path) }}.
+	$source = makeTestImage( 'helper-webp-fallback.jpg' );
+
+	// Swap in an ImageService whose converter reports no WebP support.
+	$converter = new class( 'gd' ) extends ArtisanPackUI\Performance\Services\Image\FormatConverter {
+		public function supports( string $format ): bool
+		{
+			return false;
+		}
+	};
+
+	app()->instance( ImageService::class, new ImageService( $converter ) );
+	app()->instance( 'performance', new PerformanceService( app( ImageService::class ) ) );
+
+	expect( perfConvertToWebP( $source ) )->toBe( $source );
+} );
+
+it( 'returns the source path from perfConvertToAvif when the active driver cannot encode AVIF', function (): void {
+	$source = makeTestImage( 'helper-avif-fallback.jpg' );
+
+	$converter = new class( 'gd' ) extends ArtisanPackUI\Performance\Services\Image\FormatConverter {
+		public function supports( string $format ): bool
+		{
+			return false;
+		}
+	};
+
+	app()->instance( ImageService::class, new ImageService( $converter ) );
+	app()->instance( 'performance', new PerformanceService( app( ImageService::class ) ) );
+
+	expect( perfConvertToAvif( $source ) )->toBe( $source );
+} );
+
 it( 'delegates image helpers to the PerformanceService', function (): void {
 	if ( ! function_exists( 'imagewebp' ) ) {
 		$this->markTestSkipped( 'GD WebP support is not available' );
@@ -87,15 +122,18 @@ it( 'invalidates the namespaced key via perfInvalidateCache', function (): void 
 		->and( cache()->store( config( 'cache.default' ) )->get( 'performance:helpers:invalidate' ) )->toBeNull();
 } );
 
-it( 'flushes the entire store via perfFlushCache', function (): void {
-	config( [ 'artisanpack.performance.fragment_cache.driver' => config( 'cache.default' ) ] );
+it( 'flushes the entire store via perfFlushCache when a dedicated store is configured', function (): void {
+	config( [
+		'cache.stores.perf_helpers'                       => [ 'driver' => 'array' ],
+		'artisanpack.performance.fragment_cache.driver'   => 'perf_helpers',
+	] );
 
 	perfRemember( 'helpers:flush:a', 60, fn () => 'a' );
 	perfRemember( 'helpers:flush:b', 60, fn () => 'b' );
 
 	expect( perfFlushCache() )->toBeTrue()
-		->and( cache()->store( config( 'cache.default' ) )->get( 'performance:helpers:flush:a' ) )->toBeNull()
-		->and( cache()->store( config( 'cache.default' ) )->get( 'performance:helpers:flush:b' ) )->toBeNull();
+		->and( cache()->store( 'perf_helpers' )->get( 'performance:helpers:flush:a' ) )->toBeNull()
+		->and( cache()->store( 'perf_helpers' )->get( 'performance:helpers:flush:b' ) )->toBeNull();
 } );
 
 it( 'records metrics without throwing via perfRecordMetric', function (): void {

--- a/tests/Feature/HelpersTest.php
+++ b/tests/Feature/HelpersTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Services\ImageService;
+use ArtisanPackUI\Performance\Services\PerformanceService;
+
+beforeEach( function (): void {
+	clearImageFixtures();
+} );
+
+afterEach( function (): void {
+	clearImageFixtures();
+} );
+
+it( 'exposes the performance helper that resolves the service from the container', function (): void {
+	expect( performance() )->toBeInstanceOf( PerformanceService::class )
+		->and( performance() )->toBe( app( 'performance' ) );
+} );
+
+it( 'reports feature flags through perfFeatureEnabled', function (): void {
+	config( [ 'artisanpack.performance.features.image_optimization' => true ] );
+
+	expect( perfFeatureEnabled( 'image_optimization' ) )->toBeTrue()
+		->and( perfFeatureEnabled( 'nonexistent' ) )->toBeFalse();
+} );
+
+it( 'delegates image helpers to the PerformanceService', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	$source = makeTestImage( 'helper.jpg', 80, 80 );
+
+	$webp = perfConvertToWebP( $source, 80 );
+	expect( file_exists( $webp ) )->toBeTrue();
+
+	$color = perfGetDominantColor( $source );
+	expect( $color )->toMatch( '/^#[0-9a-f]{6}$/' );
+
+	$srcset = perfGetResponsiveSrcset( $source, [ 40 ] );
+	expect( $srcset )->toContain( '40w' );
+} );
+
+it( 'runs the optimization pipeline via perfOptimizeImage', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	$source = makeTestImage( 'pipeline-helper.jpg', 300, 150 );
+
+	$result = perfOptimizeImage( $source, [
+		'sizes'   => [ 75 ],
+		'formats' => [ 'webp' ],
+	] );
+
+	expect( $result['variants'] )->toHaveCount( 1 )
+		->and( $result['variants'][0]['format'] )->toBe( 'webp' );
+} );
+
+it( 'stores and retrieves values through perfRemember', function (): void {
+	config( [ 'artisanpack.performance.fragment_cache.driver' => config( 'cache.default' ) ] );
+
+	$first = perfRemember( 'helpers:value', 60, fn () => 'computed' );
+	expect( $first )->toBe( 'computed' );
+
+	$second = perfRemember( 'helpers:value', 60, fn () => 'recomputed' );
+	expect( $second )->toBe( 'computed' );
+} );
+
+it( 'stores values indefinitely through perfRememberForever', function (): void {
+	config( [ 'artisanpack.performance.fragment_cache.driver' => config( 'cache.default' ) ] );
+
+	$first = perfRememberForever( 'helpers:forever', fn () => 'persisted' );
+	expect( $first )->toBe( 'persisted' );
+
+	$second = perfRememberForever( 'helpers:forever', fn () => 'changed' );
+	expect( $second )->toBe( 'persisted' );
+} );
+
+it( 'invalidates the namespaced key via perfInvalidateCache', function (): void {
+	config( [ 'artisanpack.performance.fragment_cache.driver' => config( 'cache.default' ) ] );
+
+	perfRemember( 'helpers:invalidate', 60, fn () => 'cached' );
+
+	expect( perfInvalidateCache( 'helpers:invalidate' ) )->toBeTrue()
+		->and( cache()->store( config( 'cache.default' ) )->get( 'performance:helpers:invalidate' ) )->toBeNull();
+} );
+
+it( 'flushes the entire store via perfFlushCache', function (): void {
+	config( [ 'artisanpack.performance.fragment_cache.driver' => config( 'cache.default' ) ] );
+
+	perfRemember( 'helpers:flush:a', 60, fn () => 'a' );
+	perfRemember( 'helpers:flush:b', 60, fn () => 'b' );
+
+	expect( perfFlushCache() )->toBeTrue()
+		->and( cache()->store( config( 'cache.default' ) )->get( 'performance:helpers:flush:a' ) )->toBeNull()
+		->and( cache()->store( config( 'cache.default' ) )->get( 'performance:helpers:flush:b' ) )->toBeNull();
+} );
+
+it( 'records metrics without throwing via perfRecordMetric', function (): void {
+	perfRecordMetric( 'LCP', 1234.5, [ 'route' => 'home' ] );
+
+	expect( true )->toBeTrue();
+} );
+
+it( 'returns recommendations via perfGetRecommendations', function (): void {
+	expect( perfGetRecommendations() )->toBe( [] );
+} );
+
+it( 'has every documented perf helper available', function (): void {
+	$expected = [
+		'perfFeatureEnabled',
+		'perfOptimizeImage',
+		'perfConvertToWebP',
+		'perfConvertToAvif',
+		'perfGetDominantColor',
+		'perfGetResponsiveSrcset',
+		'perfRemember',
+		'perfRememberForever',
+		'perfInvalidateCache',
+		'perfFlushCache',
+		'perfRecordMetric',
+		'perfGetRecommendations',
+	];
+
+	foreach ( $expected as $function ) {
+		expect( function_exists( $function ) )->toBeTrue( "Expected helper {$function} to exist" );
+	}
+} );
+
+it( 'resolves perfOptimizeImage and the facade to the same ImageService instance', function (): void {
+	// Regression: helpers must route through the container so swapping ImageService
+	// in tests (or in app code) takes effect for all helper calls.
+	expect( performance()->images() )->toBeInstanceOf( ImageService::class )
+		->and( performance()->images() )->toBe( app( ImageService::class ) );
+} );

--- a/tests/Feature/PerformanceServiceTest.php
+++ b/tests/Feature/PerformanceServiceTest.php
@@ -69,15 +69,35 @@ it( 'forgets the namespaced key via invalidateCache', function (): void {
 		->and( cache()->store( config( 'cache.default' ) )->get( 'performance:invalidate-me' ) )->toBeNull();
 } );
 
-it( 'flushes the store via flushCache', function (): void {
-	config( [ 'artisanpack.performance.fragment_cache.driver' => config( 'cache.default' ) ] );
+it( 'flushes the store via flushCache when a dedicated store is configured', function (): void {
+	// Register a dedicated store so the safeguard lets the flush through.
+	config( [
+		'cache.stores.perf_test'                                  => [ 'driver' => 'array' ],
+		'artisanpack.performance.fragment_cache.driver'           => 'perf_test',
+	] );
 
 	$service = app( PerformanceService::class );
 	$service->remember( 'flush:a', 60, fn () => 'a' );
 	$service->remember( 'flush:b', 60, fn () => 'b' );
 
 	expect( $service->flushCache() )->toBeTrue()
-		->and( cache()->store( config( 'cache.default' ) )->get( 'performance:flush:a' ) )->toBeNull();
+		->and( cache()->store( 'perf_test' )->get( 'performance:flush:a' ) )->toBeNull();
+} );
+
+it( 'refuses to flushCache when the fragment driver matches the framework default store', function (): void {
+	// Regression: flush() is store-wide; if the package's fragment store is also
+	// the framework default, flushCache would wipe sessions/locks/app data.
+	config( [ 'artisanpack.performance.fragment_cache.driver' => config( 'cache.default' ) ] );
+
+	expect( fn () => app( PerformanceService::class )->flushCache() )
+		->toThrow( RuntimeException::class, 'Refusing to flush the framework default cache store' );
+} );
+
+it( 'refuses to flushCache when the fragment driver is null', function (): void {
+	config( [ 'artisanpack.performance.fragment_cache.driver' => null ] );
+
+	expect( fn () => app( PerformanceService::class )->flushCache() )
+		->toThrow( RuntimeException::class, 'Refusing to flush the framework default cache store' );
 } );
 
 it( 'delegates image methods to the ImageService', function (): void {

--- a/tests/Feature/PerformanceServiceTest.php
+++ b/tests/Feature/PerformanceServiceTest.php
@@ -2,7 +2,16 @@
 
 declare( strict_types=1 );
 
+use ArtisanPackUI\Performance\Services\ImageService;
 use ArtisanPackUI\Performance\Services\PerformanceService;
+
+beforeEach( function (): void {
+	clearImageFixtures();
+} );
+
+afterEach( function (): void {
+	clearImageFixtures();
+} );
 
 it( 'reports unknown features as disabled', function (): void {
 	expect( app( PerformanceService::class )->isFeatureEnabled( 'missing' ) )->toBeFalse();
@@ -23,6 +32,12 @@ it( 'returns the same instance for the helper, facade root, and container bindin
 		->and( $helper )->toBe( $typed );
 } );
 
+it( 'exposes the bound ImageService via the images() accessor', function (): void {
+	expect( app( PerformanceService::class )->images() )
+		->toBeInstanceOf( ImageService::class )
+		->toBe( app( ImageService::class ) );
+} );
+
 it( 'remembers values via the configured fragment-cache store under the performance namespace', function (): void {
 	// Force the fragment-cache driver to the framework default so the test
 	// stays independent of host config (CACHE_STORE in phpunit.xml).
@@ -34,13 +49,60 @@ it( 'remembers values via the configured fragment-cache store under the performa
 		->and( cache()->store( config( 'cache.default' ) )->get( 'performance:unit-test' ) )->toBe( 'computed' );
 } );
 
-it( 'returns no-op defaults for stubbed image and metric methods', function (): void {
+it( 'remembers values forever via rememberForever', function (): void {
+	config( [ 'artisanpack.performance.fragment_cache.driver' => config( 'cache.default' ) ] );
+
+	$first  = app( PerformanceService::class )->rememberForever( 'forever-key', fn () => 'persisted' );
+	$second = app( PerformanceService::class )->rememberForever( 'forever-key', fn () => 'changed' );
+
+	expect( $first )->toBe( 'persisted' )
+		->and( $second )->toBe( 'persisted' );
+} );
+
+it( 'forgets the namespaced key via invalidateCache', function (): void {
+	config( [ 'artisanpack.performance.fragment_cache.driver' => config( 'cache.default' ) ] );
+
+	$service = app( PerformanceService::class );
+	$service->remember( 'invalidate-me', 60, fn () => 'cached' );
+
+	expect( $service->invalidateCache( 'invalidate-me' ) )->toBeTrue()
+		->and( cache()->store( config( 'cache.default' ) )->get( 'performance:invalidate-me' ) )->toBeNull();
+} );
+
+it( 'flushes the store via flushCache', function (): void {
+	config( [ 'artisanpack.performance.fragment_cache.driver' => config( 'cache.default' ) ] );
+
+	$service = app( PerformanceService::class );
+	$service->remember( 'flush:a', 60, fn () => 'a' );
+	$service->remember( 'flush:b', 60, fn () => 'b' );
+
+	expect( $service->flushCache() )->toBeTrue()
+		->and( cache()->store( config( 'cache.default' ) )->get( 'performance:flush:a' ) )->toBeNull();
+} );
+
+it( 'delegates image methods to the ImageService', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	$source  = makeTestImage( 'delegate.jpg', 200, 100 );
 	$service = app( PerformanceService::class );
 
-	expect( $service->optimizeImage( '/img.jpg' ) )->toBe( [] )
-		->and( $service->convertToWebP( '/img.jpg' ) )->toBe( '/img.jpg' )
-		->and( $service->convertToAvif( '/img.jpg' ) )->toBe( '/img.jpg' )
-		->and( $service->script( '/js/app.js' ) )->toBe( [] );
+	$webp = $service->convertToWebP( $source, 70 );
+	expect( file_exists( $webp ) )->toBeTrue();
+
+	$color = $service->getDominantColor( $source );
+	expect( $color )->toMatch( '/^#[0-9a-f]{6}$/' );
+
+	$srcset = $service->getResponsiveSrcset( $source, [ 100 ] );
+	expect( $srcset )->toContain( '100w' );
+} );
+
+it( 'returns no-op defaults for script and metric and recommendation methods', function (): void {
+	$service = app( PerformanceService::class );
+
+	expect( $service->script( '/js/app.js' ) )->toBe( [] )
+		->and( $service->getRecommendations() )->toBe( [] );
 
 	// recordMetric is a no-op; just assert it returns void without throwing.
 	$service->recordMetric( 'LCP', 1234.5 );

--- a/tests/Feature/ServiceProviderTest.php
+++ b/tests/Feature/ServiceProviderTest.php
@@ -3,6 +3,8 @@
 declare( strict_types=1 );
 
 use ArtisanPackUI\Performance\Facades\Performance;
+use ArtisanPackUI\Performance\Services\Image\FormatConverter;
+use ArtisanPackUI\Performance\Services\ImageService;
 use ArtisanPackUI\Performance\Services\PerformanceService;
 
 it( 'merges package configuration under the artisanpack.performance namespace', function (): void {
@@ -38,6 +40,25 @@ it( 'lets user overrides take precedence over package defaults', function (): vo
 
 it( 'returns false for unknown features rather than throwing', function (): void {
 	expect( Performance::isFeatureEnabled( 'nonexistent_feature' ) )->toBeFalse();
+} );
+
+it( 'binds FormatConverter and ImageService as singletons', function (): void {
+	$converterA = app( FormatConverter::class );
+	$converterB = app( FormatConverter::class );
+	$imageA     = app( ImageService::class );
+	$imageB     = app( ImageService::class );
+
+	expect( $converterA )->toBeInstanceOf( FormatConverter::class )
+		->and( $converterA )->toBe( $converterB )
+		->and( $imageA )->toBeInstanceOf( ImageService::class )
+		->and( $imageA )->toBe( $imageB )
+		->and( $imageA->converter() )->toBe( $converterA );
+} );
+
+it( 'registers the perf:generate-webp console command', function (): void {
+	$registered = array_keys( $this->app['Illuminate\\Contracts\\Console\\Kernel']->all() );
+
+	expect( $registered )->toContain( 'perf:generate-webp' );
 } );
 
 it( 'replaces list-valued config overrides wholesale instead of per-index', function (): void {

--- a/tests/Feature/Services/Image/FormatConverterTest.php
+++ b/tests/Feature/Services/Image/FormatConverterTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Services\Image\FormatConverter;
+
+beforeEach( function (): void {
+	clearImageFixtures();
+} );
+
+afterEach( function (): void {
+	clearImageFixtures();
+} );
+
+it( 'reports supported formats based on the GD driver capabilities', function (): void {
+	$converter = new FormatConverter( 'gd' );
+
+	expect( $converter->supports( 'webp' ) )->toBe( function_exists( 'imagewebp' ) )
+		->and( $converter->supports( 'avif' ) )->toBe( function_exists( 'imageavif' ) )
+		->and( $converter->supports( 'unknown' ) )->toBeFalse();
+} );
+
+it( 'reports supported formats based on the Imagick driver capabilities', function (): void {
+	if ( ! class_exists( Imagick::class ) ) {
+		$this->markTestSkipped( 'Imagick extension is not installed' );
+	}
+
+	$converter = new FormatConverter( 'imagick' );
+	$queryWebp = ( new Imagick() )->queryFormats( 'WEBP' );
+	$queryAvif = ( new Imagick() )->queryFormats( 'AVIF' );
+
+	expect( $converter->supports( 'webp' ) )->toBe( ! empty( $queryWebp ) )
+		->and( $converter->supports( 'avif' ) )->toBe( ! empty( $queryAvif ) );
+} );
+
+it( 'converts a JPEG to WebP using the GD driver', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	$source    = makeTestImage( 'source.jpg', 80, 80, 'jpeg' );
+	$converter = new FormatConverter( 'gd' );
+
+	$destination = $converter->toWebp( $source, 75 );
+
+	expect( $destination )->toEndWith( '.webp' )
+		->and( file_exists( $destination ) )->toBeTrue()
+		->and( getimagesize( $destination )[2] )->toBe( IMAGETYPE_WEBP );
+} );
+
+it( 'converts a PNG to WebP and preserves transparency', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	$source    = makeTestImage( 'transparent.png', 40, 40, 'png' );
+	$converter = new FormatConverter( 'gd' );
+
+	$destination = $converter->toWebp( $source );
+
+	expect( file_exists( $destination ) )->toBeTrue()
+		->and( getimagesize( $destination )[2] )->toBe( IMAGETYPE_WEBP );
+} );
+
+it( 'converts a JPEG to AVIF using Imagick when available', function (): void {
+	if ( ! class_exists( Imagick::class ) ) {
+		$this->markTestSkipped( 'Imagick is not installed' );
+	}
+
+	$converter = new FormatConverter( 'imagick' );
+
+	if ( ! $converter->supports( 'avif' ) ) {
+		$this->markTestSkipped( 'Imagick AVIF support not available' );
+	}
+
+	$source      = makeTestImage( 'avif-source.jpg', 60, 60, 'jpeg' );
+	$destination = $converter->toAvif( $source, 60 );
+
+	expect( $destination )->toEndWith( '.avif' )
+		->and( file_exists( $destination ) )->toBeTrue();
+} );
+
+it( 'throws when the source image cannot be read', function (): void {
+	$converter = new FormatConverter( 'gd' );
+
+	expect( fn () => $converter->toWebp( '/does/not/exist.jpg' ) )
+		->toThrow( RuntimeException::class, 'Source image is not readable' );
+} );
+
+it( 'throws on an unsupported target format', function (): void {
+	$source    = makeTestImage( 'unsupported.jpg' );
+	$converter = new FormatConverter( 'gd' );
+
+	expect( fn () => $converter->convert( $source, 'bmp', 80 ) )
+		->toThrow( RuntimeException::class, 'Unsupported target format' );
+} );
+
+it( 'throws when the active driver cannot encode the requested format', function (): void {
+	// Force a synthetic driver name so supports() returns false for everything.
+	$source    = makeTestImage( 'unencodable.jpg' );
+	$converter = new FormatConverter( 'nonexistent' );
+
+	expect( fn () => $converter->toWebp( $source ) )
+		->toThrow( RuntimeException::class, "Driver 'nonexistent' cannot encode webp" );
+} );
+
+it( 'clamps quality values to the 0-100 range', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	$source    = makeTestImage( 'clamp.jpg' );
+	$converter = new FormatConverter( 'gd' );
+
+	// Should not throw, regardless of out-of-range quality.
+	$destination = $converter->convert( $source, 'webp', 250 );
+
+	expect( file_exists( $destination ) )->toBeTrue();
+
+	$destination = $converter->convert( $source, 'webp', -10 );
+
+	expect( file_exists( $destination ) )->toBeTrue();
+} );
+
+it( 'defaults the driver to the configured value', function (): void {
+	config( [ 'artisanpack.performance.images.driver' => 'imagick' ] );
+
+	$converter = new FormatConverter();
+
+	expect( $converter->driver() )->toBe( 'imagick' );
+} );

--- a/tests/Feature/Services/Image/FormatConverterTest.php
+++ b/tests/Feature/Services/Image/FormatConverterTest.php
@@ -129,3 +129,30 @@ it( 'defaults the driver to the configured value', function (): void {
 
 	expect( $converter->driver() )->toBe( 'imagick' );
 } );
+
+it( 'reads the driver from config on every call so runtime swaps take effect', function (): void {
+	// Regression: previously the driver was captured in the constructor, so a
+	// singleton-bound converter would silently ignore subsequent config swaps.
+	config( [ 'artisanpack.performance.images.driver' => 'gd' ] );
+	$converter = new FormatConverter();
+	expect( $converter->driver() )->toBe( 'gd' );
+
+	config( [ 'artisanpack.performance.images.driver' => 'imagick' ] );
+	expect( $converter->driver() )->toBe( 'imagick' );
+} );
+
+it( 'pins the driver when constructed with an explicit override', function (): void {
+	$converter = new FormatConverter( 'imagick' );
+
+	config( [ 'artisanpack.performance.images.driver' => 'gd' ] );
+
+	expect( $converter->driver() )->toBe( 'imagick' );
+} );
+
+it( 'reports usesImagick only when the driver is imagick and the extension is loaded', function (): void {
+	$gd      = new FormatConverter( 'gd' );
+	$imagick = new FormatConverter( 'imagick' );
+
+	expect( $gd->usesImagick() )->toBeFalse()
+		->and( $imagick->usesImagick() )->toBe( class_exists( Imagick::class ) );
+} );

--- a/tests/Feature/Services/ImageServiceTest.php
+++ b/tests/Feature/Services/ImageServiceTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Events\ImageOptimized;
+use ArtisanPackUI\Performance\Services\Image\FormatConverter;
+use ArtisanPackUI\Performance\Services\ImageService;
+use Illuminate\Support\Facades\Event;
+
+beforeEach( function (): void {
+	clearImageFixtures();
+} );
+
+afterEach( function (): void {
+	clearImageFixtures();
+} );
+
+it( 'optimizes an image by generating every enabled format at every configured width', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	Event::fake();
+
+	config( [
+		'artisanpack.performance.images.driver'  => 'gd',
+		'artisanpack.performance.images.sizes'   => [ 100, 200 ],
+		'artisanpack.performance.images.formats' => [
+			'webp' => [ 'enabled' => true, 'quality' => 70 ],
+			'avif' => [ 'enabled' => false, 'quality' => 60 ],
+		],
+	] );
+
+	$source  = makeTestImage( 'pipeline.jpg', 400, 200, 'jpeg' );
+	$service = new ImageService( new FormatConverter( 'gd' ) );
+
+	$result = $service->optimize( $source );
+
+	expect( $result['source'] )->toBe( $source )
+		->and( $result['sizes'] )->toBe( [ 100, 200 ] )
+		->and( $result['formats'] )->toBe( [ 'webp' ] )
+		->and( $result['variants'] )->toHaveCount( 2 )
+		->and( collect( $result['variants'] )->pluck( 'format' )->all() )->toBe( [ 'webp', 'webp' ] )
+		->and( collect( $result['variants'] )->pluck( 'width' )->all() )->toBe( [ 100, 200 ] );
+
+	foreach ( $result['variants'] as $variant ) {
+		expect( file_exists( $variant['path'] ) )->toBeTrue();
+	}
+
+	Event::assertDispatched( ImageOptimized::class );
+} );
+
+it( 'clamps requested widths to the source width so variants do not collide on the same file', function (): void {
+	// Regression: requesting widths larger than the source would otherwise leave every
+	// oversize width pointing at the same FormatConverter destination (source.webp),
+	// overwriting prior variants.
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	$source  = makeTestImage( 'clamp.jpg', 400, 200, 'jpeg' );
+	$service = new ImageService( new FormatConverter( 'gd' ) );
+
+	$result = $service->optimize( $source, [
+		'sizes'   => [ 200, 800, 1600 ],
+		'formats' => [ 'webp' ],
+	] );
+
+	// Sizes collapse to [200, 400] after clamping to the 400-wide source.
+	expect( $result['sizes'] )->toBe( [ 200, 400 ] )
+		->and( $result['variants'] )->toHaveCount( 2 );
+
+	$paths = collect( $result['variants'] )->pluck( 'path' )->all();
+	expect( count( array_unique( $paths ) ) )->toBe( 2 );
+} );
+
+it( 'skips formats the active driver cannot encode rather than failing the pipeline', function (): void {
+	Event::fake();
+
+	$source = makeTestImage( 'skip.jpg', 200, 200, 'jpeg' );
+
+	$converter = new class( 'gd' ) extends FormatConverter {
+		public function supports( string $format ): bool
+		{
+			return false;
+		}
+	};
+
+	$service = new ImageService( $converter );
+
+	$result = $service->optimize( $source, [
+		'sizes'   => [ 100 ],
+		'formats' => [ 'avif' ],
+	] );
+
+	expect( $result['variants'] )->toBe( [] );
+	Event::assertDispatched( ImageOptimized::class );
+} );
+
+it( 'converts a single image to the requested format', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	$source  = makeTestImage( 'convert.jpg' );
+	$service = new ImageService( new FormatConverter( 'gd' ) );
+
+	$converted = $service->convertFormat( $source, 'webp', 80 );
+
+	expect( file_exists( $converted ) )->toBeTrue()
+		->and( $converted )->toEndWith( '.webp' );
+} );
+
+it( 'returns the source path when the resize target is wider than the original', function (): void {
+	$source  = makeTestImage( 'small.jpg', 100, 50 );
+	$service = new ImageService( new FormatConverter( 'gd' ) );
+
+	expect( $service->resize( $source, 500 ) )->toBe( $source );
+} );
+
+it( 'resizes an image to the given width and preserves the aspect ratio', function (): void {
+	$source  = makeTestImage( 'wide.jpg', 400, 200 );
+	$service = new ImageService( new FormatConverter( 'gd' ) );
+
+	$resized = $service->resize( $source, 100 );
+
+	expect( $resized )->not->toBe( $source )
+		->and( file_exists( $resized ) )->toBeTrue();
+
+	[ $width, $height ] = getimagesize( $resized );
+
+	expect( $width )->toBe( 100 )
+		->and( $height )->toBe( 50 );
+} );
+
+it( 'generates a srcset string with widths in ascending order', function (): void {
+	$source  = makeTestImage( 'srcset.jpg', 800, 400 );
+	$service = new ImageService( new FormatConverter( 'gd' ) );
+
+	$srcset = $service->generateSrcset( $source, [ 200, 400 ] );
+
+	expect( $srcset )->toContain( '200w' )
+		->and( $srcset )->toContain( '400w' )
+		->and( substr_count( $srcset, ',' ) )->toBe( 1 );
+} );
+
+it( 'extracts the dominant color as a 7-character hex string', function (): void {
+	$source  = makeTestImage( 'color.jpg', 40, 40, 'jpeg', [ 200, 50, 100 ] );
+	$service = new ImageService( new FormatConverter( 'gd' ) );
+
+	$color = $service->extractDominantColor( $source );
+
+	expect( $color )->toMatch( '/^#[0-9a-f]{6}$/' );
+} );
+
+it( 'generates dominant color and blur placeholders', function (): void {
+	$source  = makeTestImage( 'placeholder.jpg', 80, 60 );
+	$service = new ImageService( new FormatConverter( 'gd' ) );
+
+	expect( $service->generatePlaceholder( $source, 'dominant_color' ) )->toMatch( '/^#[0-9a-f]{6}$/' )
+		->and( $service->generatePlaceholder( $source, 'blur' ) )->toStartWith( 'data:image/jpeg;base64,' );
+} );
+
+it( 'throws for unknown placeholder types', function (): void {
+	$source  = makeTestImage( 'unknown-placeholder.jpg' );
+	$service = new ImageService( new FormatConverter( 'gd' ) );
+
+	expect( fn () => $service->generatePlaceholder( $source, 'mystery' ) )
+		->toThrow( RuntimeException::class, 'Unknown placeholder type' );
+} );
+
+it( 'throws when optimizing a missing source image', function (): void {
+	$service = new ImageService( new FormatConverter( 'gd' ) );
+
+	expect( fn () => $service->optimize( '/no/such/file.jpg' ) )
+		->toThrow( RuntimeException::class, 'Source image is not readable' );
+} );
+
+it( 'delegates supportsFormat to the underlying converter', function (): void {
+	$service = new ImageService( new FormatConverter( 'gd' ) );
+
+	expect( $service->supportsFormat( 'webp' ) )->toBe( function_exists( 'imagewebp' ) )
+		->and( $service->supportsFormat( 'avif' ) )->toBe( function_exists( 'imageavif' ) );
+} );

--- a/tests/Feature/Services/ImageServiceTest.php
+++ b/tests/Feature/Services/ImageServiceTest.php
@@ -93,8 +93,43 @@ it( 'skips formats the active driver cannot encode rather than failing the pipel
 		'formats' => [ 'avif' ],
 	] );
 
-	expect( $result['variants'] )->toBe( [] );
-	Event::assertDispatched( ImageOptimized::class );
+	// Pipeline tolerates the unsupported driver and returns an empty result.
+	expect( $result['variants'] )->toBe( [] )
+		->and( $result['formats'] )->toBe( [] );
+
+	// Regression: no event dispatch when nothing was produced, so listeners
+	// don't enqueue downstream work for files that don't exist.
+	Event::assertNotDispatched( ImageOptimized::class );
+} );
+
+it( 'dispatches ImageOptimized with the formats actually produced, not requested', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	Event::fake();
+
+	$source = makeTestImage( 'produced.jpg', 200, 200, 'jpeg' );
+
+	// Converter that supports WebP but pretends AVIF is unsupported.
+	$converter = new class( 'gd' ) extends FormatConverter {
+		public function supports( string $format ): bool
+		{
+			return 'webp' === strtolower( $format );
+		}
+	};
+
+	$service = new ImageService( $converter );
+
+	$service->optimize( $source, [
+		'sizes'   => [ 100 ],
+		'formats' => [ 'avif', 'webp' ],
+	] );
+
+	Event::assertDispatched( ImageOptimized::class, function ( ImageOptimized $event ): bool {
+		// Regression: previously dispatched the REQUESTED formats; now only the produced ones.
+		return [ 'webp' ] === $event->formats;
+	} );
 } );
 
 it( 'converts a single image to the requested format', function (): void {
@@ -111,11 +146,28 @@ it( 'converts a single image to the requested format', function (): void {
 		->and( $converted )->toEndWith( '.webp' );
 } );
 
-it( 'returns the source path when the resize target is wider than the original', function (): void {
+it( 'returns the source path when the resize target is wider than the original and height is null', function (): void {
 	$source  = makeTestImage( 'small.jpg', 100, 50 );
 	$service = new ImageService( new FormatConverter( 'gd' ) );
 
 	expect( $service->resize( $source, 500 ) )->toBe( $source );
+} );
+
+it( 'honors an explicit height even when the source is smaller than the target width', function (): void {
+	// Regression: resize() used to short-circuit on `sourceWidth <= width`
+	// and silently ignore an explicit $height, returning wrong dimensions.
+	$source  = makeTestImage( 'short.jpg', 200, 100 );
+	$service = new ImageService( new FormatConverter( 'gd' ) );
+
+	$resized = $service->resize( $source, 800, 50 );
+
+	expect( $resized )->not->toBe( $source )
+		->and( file_exists( $resized ) )->toBeTrue();
+
+	[ $width, $height ] = getimagesize( $resized );
+
+	expect( $width )->toBe( 800 )
+		->and( $height )->toBe( 50 );
 } );
 
 it( 'resizes an image to the given width and preserves the aspect ratio', function (): void {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -12,8 +12,7 @@
 */
 
 pest()->extend( Tests\TestCase::class )
- // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
-    ->in( 'Feature' );
+	->in( 'Feature' );
 
 /*
 |--------------------------------------------------------------------------
@@ -27,7 +26,7 @@ pest()->extend( Tests\TestCase::class )
 */
 
 expect()->extend( 'toBeOne', function () {
-    return $this->toBe( 1 );
+	return $this->toBe( 1 );
 } );
 
 /*
@@ -35,13 +34,82 @@ expect()->extend( 'toBeOne', function () {
 | Functions
 |--------------------------------------------------------------------------
 |
-| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
-| project that you don't want to repeat in every file. Here you can also expose helpers as
-| global functions to help you to reduce the number of lines of code in your test files.
+| Image fixture helpers. Tests that need real image bytes (format conversion,
+| dominant color, resize) call these instead of committing binary fixtures.
+| `imageFixturesDir()` returns a per-test directory that is wiped in
+| `beforeEach`/`afterEach` hooks defined by the consuming test files.
 |
 */
 
-function something(): void
+function imageFixturesDir(): string
 {
-    // ..
+	$dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'artisanpack-perf-fixtures';
+
+	if ( ! is_dir( $dir ) ) {
+		mkdir( $dir, 0777, true );
+	}
+
+	return $dir;
+}
+
+function makeTestImage(
+	string $filename,
+	int $width = 200,
+	int $height = 120,
+	string $format = 'jpeg',
+	array $rgb = [ 220, 30, 60 ],
+): string {
+	$path  = imageFixturesDir() . DIRECTORY_SEPARATOR . $filename;
+	$image = imagecreatetruecolor( $width, $height );
+
+	$color = imagecolorallocate( $image, $rgb[0], $rgb[1], $rgb[2] );
+	imagefilledrectangle( $image, 0, 0, $width, $height, $color );
+
+	switch ( strtolower( $format ) ) {
+		case 'png':
+			imagepng( $image, $path );
+			break;
+		case 'gif':
+			imagegif( $image, $path );
+			break;
+		case 'jpeg':
+		case 'jpg':
+		default:
+			imagejpeg( $image, $path, 90 );
+			break;
+	}
+
+	imagedestroy( $image );
+
+	return $path;
+}
+
+function clearImageFixtures(): void
+{
+	$dir = imageFixturesDir();
+
+	if ( ! is_dir( $dir ) ) {
+		return;
+	}
+
+	foreach ( scandir( $dir ) as $entry ) {
+		if ( '.' === $entry || '..' === $entry ) {
+			continue;
+		}
+
+		$path = $dir . DIRECTORY_SEPARATOR . $entry;
+
+		if ( is_dir( $path ) ) {
+			foreach ( scandir( $path ) as $nested ) {
+				if ( '.' === $nested || '..' === $nested ) {
+					continue;
+				}
+				@unlink( $path . DIRECTORY_SEPARATOR . $nested );
+			}
+			@rmdir( $path );
+			continue;
+		}
+
+		@unlink( $path );
+	}
 }


### PR DESCRIPTION
<!--- Bundles five related Phase 1/2 issues that share the same image-service core --->

## Description

Bundles five related Phase 1/2 issues that all hang off a shared `ImageService` core. Per direction from the request, these were combined into a single PR rather than split — they're small, mutually dependent, and easier to review together than as five sequential PRs against each other.

**Closes:** #6, #7, #8, #9, #10

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issues:**
- #6 — Create global helper functions
- #7 — Create core unit tests
- #8 — Implement ImageService
- #9 — Implement WebP format conversion
- #10 — Implement AVIF format conversion

## Motivation and Context

Phase 1 left `PerformanceService::optimizeImage()`/`convertToWebP()`/`convertToAvif()` as stubs. Phase 2 needs a real image pipeline before any later phase (lazy-loading components, monitoring listeners, media-library integration) can be built. The five issues all touch the same surface (`ImageService` + helpers + tests + the `perf:generate-webp` command) so they were grouped to avoid five rebase rounds.

## Changes Made

- **#8 `ImageService`** — `optimize`, `convertFormat`, `resize`, `generateSrcset`, `extractDominantColor`, `generatePlaceholder`, `supportsFormat`. Clamps requested widths to the source so oversized variants don't collide on the same destination, and cleans up resize intermediates.
- **#9 `FormatConverter` (WebP)** — GD + Imagick driver paths, transparency-aware for PNG/GIF sources, runtime `supports()` check, quality clamped to 0-100.
- **#10 `FormatConverter` (AVIF)** — Imagick path via `setImageFormat('avif')`, GD path via `imageavif()` when PHP 8.1+/libavif is present, graceful skip via `supports()` when neither is available.
- **#9 `perf:generate-webp`** artisan command with `--quality`, `--recursive`, `--force`; non-recursive default; skip-when-exists unless forced.
- **#6 `perf*` helpers** — `perfOptimizeImage`, `perfConvertToWebP`, `perfConvertToAvif`, `perfGetDominantColor`, `perfGetResponsiveSrcset`, `perfRemember`, `perfRememberForever`, `perfInvalidateCache`, `perfFlushCache`, `perfRecordMetric`, `perfGetRecommendations`, `perfFeatureEnabled`. The format-conversion helpers are Blade-safe — they fall back to the source path on hosts without the encoder so templates degrade gracefully.
- **#7 unit tests** — coverage for `ImageService`, `FormatConverter` (incl. Imagick paths), `GenerateWebPCommand`, helpers, and service-provider bindings, plus runtime image fixture helpers in `tests/Pest.php` so no binary fixtures ship in the repo.
- `PerformanceService` now delegates image methods to `ImageService` and gains `rememberForever`, `invalidateCache`, `flushCache`, `getRecommendations`, `getDominantColor`, `getResponsiveSrcset`, and an `images()` accessor.
- `PerformanceServiceProvider` binds `FormatConverter` and `ImageService` as singletons and registers `perf:generate-webp` when running in console.

### Pre-PR review fixes

A multi-agent code review on the diff surfaced 9 confirmed correctness issues, all addressed in the second commit on this branch:

1. **Blade-safe helpers** — `perfConvertToWebP/perfConvertToAvif` gate on `supportsFormat()` and return the source path on encoder-less hosts (prevents 500s on every Blade template using them).
2. **`resize()` honors explicit `\$height`** — previously short-circuited on `sourceWidth <= width` and silently returned wrong dimensions.
3. **`generateBlurPlaceholder()` checks encoder result** — no more silent corrupt `data:image/jpeg;base64,` URIs.
4. **`flushCache()` refuses the default store** — wholesale flush would otherwise wipe sessions, locks, rate-limiter, app cache.
5. **`ImageOptimized` event correctness** — dispatched only when variants were produced, with actually-produced formats (not requested).
6. **`supports()` Imagick try/catch** — misconfigured ImageMagick installs no longer escape out of the gate.
7. **`try/finally` on three Imagick paths** — `clear()` runs on throw, preventing C-side wand leaks.
8. **Lazy driver read** — `FormatConverter` re-reads `images.driver` from config on every call instead of capturing at construction.
9. **No silent GD fallthrough** — `usesImagick()` centralizes the driver decision; unknown drivers no longer route through GD by accident.

Three lower-severity findings were deferred to follow-up issues: `FormatConverter::targetPath()` collisions for direct-API callers, `collectFiles()` memory for very large media trees, and exception-message i18n (sibling packages enforce inconsistently).

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS Darwin 25.5.0 (M-series, aarch64)
- PHP Version: 8.4.22
- GD: WebP yes, AVIF no (typical install)
- Imagick: WebP yes, AVIF yes (ImageMagick 7.1.2-25)
- Project Version: ArtisanPack UI Performance 1.0.0 (release/1.0)

**Tests Performed:**
1. `composer test` — 77 Pest tests, 178 assertions, 100% passing
2. `composer lint` — pint + phpcs clean (23 PHP files)
3. Manual: `php artisan perf:generate-webp` on a directory of 14MB Canon JPEGs with `--quality`, `--recursive`, `--force` — produced expected WebP variants, skip semantics correct, recursion correct
4. Manual: `php artisan tinker` driving every `perf*` helper end-to-end on a real photo (`perfFeatureEnabled`, `perfGetDominantColor`, `perfConvertToWebP`, `perfGetResponsiveSrcset`, `perfOptimizeImage`, `perfRemember*`, `perfInvalidateCache`, `perfGetRecommendations`)
5. Verified `perf:generate-webp` shows up in the dev app's `php artisan list`

## Accessibility Tests Run

N/A — backend-only changes (no UI/keyboard/screen-reader surface).

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `tests/Feature/Services/ImageServiceTest.php` — pipeline, resize (incl. explicit-height regression), srcset, dominant color, placeholder, format support, clamp-size collision regression, event-dispatch contract
- `tests/Feature/Services/Image/FormatConverterTest.php` — GD + Imagick WebP/AVIF conversion, transparency, error handling, quality clamp, driver allowlist, lazy driver read, `usesImagick()`
- `tests/Feature/Console/GenerateWebPCommandTest.php` — single file, directory, recursive, force, skip, empty directory
- `tests/Feature/HelpersTest.php` — every helper exercised end-to-end, Blade-safe fallback regression, cache helpers, `flushCache` dedicated-store path
- `tests/Feature/PerformanceServiceTest.php` extended for cache helpers, delegation, `flushCache` safety refusal
- `tests/Feature/ServiceProviderTest.php` extended for `FormatConverter`/`ImageService` singleton bindings and `perf:generate-webp` registration

## Documentation

- [x] Inline code documentation added

Every new class and public method has full PHPDoc per `.ai/package-blueprint`. No README/wiki changes — this PR is scaffolding for Phase 2 features that will be documented when their UI components land.

## Screenshots

N/A.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests (77/77)
- [x] Code has been linted (pint + phpcs)
- [x] Accessibility tests completed (N/A — backend)
- [x] Code follows project style guide (tabs, WordPress-style spacing, Yoda)
- [x] Self-review completed (multi-agent code review pass + 9 fixes applied)
- [x] Comments added for complex code (e.g. `clampSizes` workaround rationale, `flushCache` safeguard reason)
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to batch convert images to WebP from a file or folder, with support for recursive scanning, quality control, and overwrite options.
  * Introduced image optimization features for resizing, format conversion, responsive `srcset` output, dominant color extraction, and placeholder generation.
  * Added helper functions for image operations, caching, and feature checks.

* **Bug Fixes**
  * Improved format conversion support detection, with safe fallbacks when WebP/AVIF encoding isn’t available.
  * Added clearer handling for missing files, unsupported formats, and failed conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->