### PR TITLE
feat: image components + queue jobs (#11, #12, #13, #14, #15)

### DIFF
--- a/config/performance.php
+++ b/config/performance.php
@@ -78,8 +78,14 @@ return [
 			'auto_detect_lcp' => true,
 		],
 		'dominant_color' => [
-			'enabled'   => true,
-			'algorithm' => 'average',
+			'enabled'     => true,
+			'algorithm'   => 'average',
+			'cache_store' => null,
+			'cache_ttl'   => 0,
+		],
+		'jobs' => [
+			'tries'   => 3,
+			'backoff' => 30,
 		],
 	],
 

--- a/resources/views/components/lazy-image.blade.php
+++ b/resources/views/components/lazy-image.blade.php
@@ -1,0 +1,35 @@
+{{--
+    Lazy image component template.
+
+    Renders an `<img>` element with native `loading="lazy"` and optional
+    placeholders. Skeleton placeholders wrap the image in a div the
+    application can style via the `.perf-skeleton` class.
+--}}
+@php
+	$imgClass = trim( 'perf-lazy-image' . ( null !== $class ? ' ' . $class : '' ) );
+	$imgAttrs = $attributes->except( [ 'class' ] )->merge( [ 'class' => $imgClass ] );
+@endphp
+
+@if ( $shouldUseSkeleton() )
+	<div class="perf-skeleton" @if ( null !== $width && null !== $height ) style="aspect-ratio: {{ $width }} / {{ $height }};" @endif>
+@endif
+
+<img
+	src="{{ $initialSrc() }}"
+	@if ( $shouldUseBlurPlaceholder() ) data-src="{{ $src }}" @endif
+	alt="{{ $alt }}"
+	loading="{{ $loadingAttribute }}"
+	decoding="async"
+	@if ( null !== $width ) width="{{ $width }}" @endif
+	@if ( null !== $height ) height="{{ $height }}" @endif
+	@if ( null !== $srcset ) srcset="{{ $srcset }}" @endif
+	@if ( null !== $sizes ) sizes="{{ $sizes }}" @endif
+	@if ( $shouldEmitFetchpriority() ) fetchpriority="{{ $fetchpriority }}" @endif
+	@if ( null !== $threshold ) data-threshold="{{ $threshold }}" @endif
+	@if ( '' !== $placeholderStyle ) style="{{ $placeholderStyle }}" @endif
+	{{ $imgAttrs }}
+/>
+
+@if ( $shouldUseSkeleton() )
+	</div>
+@endif

--- a/resources/views/components/responsive-image.blade.php
+++ b/resources/views/components/responsive-image.blade.php
@@ -1,0 +1,43 @@
+{{--
+    Responsive image component template.
+
+    Emits a `<picture>` element with AVIF and WebP sources when supported and
+    falls back to the original-format `<img>`. Forwards lazy-loading,
+    fetchpriority, and placeholder behavior to the lazy image component so all
+    image attributes live in one place.
+--}}
+@php
+	$pictureClass = trim( 'perf-responsive-image' . ( null !== $class ? ' ' . $class : '' ) );
+@endphp
+
+<picture class="{{ $pictureClass }}" {{ $attributes->except( [ 'class' ] ) }}>
+	@if ( '' !== $avifSrcset )
+		<source
+			type="image/avif"
+			srcset="{{ $avifSrcset }}"
+			@if ( null !== $sizesAttr ) sizes="{{ $sizesAttr }}" @endif
+		/>
+	@endif
+
+	@if ( '' !== $webpSrcset )
+		<source
+			type="image/webp"
+			srcset="{{ $webpSrcset }}"
+			@if ( null !== $sizesAttr ) sizes="{{ $sizesAttr }}" @endif
+		/>
+	@endif
+
+	<x-perf-lazy-image
+		:src="$fallbackSrc"
+		:alt="$alt"
+		:width="$width"
+		:height="$height"
+		:lazy="$lazy"
+		:placeholder="$placeholder"
+		:dominant-color="$dominantColor"
+		:fetchpriority="$fetchpriority"
+		:sizes="$sizesAttr"
+		:srcset="'' !== $fallbackSrcset ? $fallbackSrcset : null"
+		:class="$imgClass"
+	/>
+</picture>

--- a/src/Images/DominantColorExtractor.php
+++ b/src/Images/DominantColorExtractor.php
@@ -1,0 +1,651 @@
+<?php
+
+/**
+ * Dominant color extractor.
+ *
+ * Samples a source image and returns its dominant color as a 7-character hex
+ * string suitable for use as an LQIP background. Two algorithms are supported:
+ *  - `average`: downsamples the image to a single pixel and averages RGB.
+ *    Fast and good enough for blurred placeholders.
+ *  - `quantize`: bins pixels into a coarse RGB lattice and returns the
+ *    centroid of the most populated bin. Slower but produces a color that
+ *    matches the visually dominant region.
+ *
+ * Transparent pixels are skipped so colors derived from PNG/GIF/WebP sources
+ * reflect the visible content rather than the transparent fill.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Images;
+
+use GdImage;
+use Illuminate\Contracts\Cache\Repository;
+use Imagick;
+use ImagickException;
+use ImagickPixel;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Dominant color extractor class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+class DominantColorExtractor
+{
+	/**
+	 * Supported algorithm keys.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array<int, string>
+	 */
+	public const ALGORITHMS = [ 'average', 'quantize' ];
+
+	/**
+	 * Default algorithm when neither the caller nor config selects one.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public const DEFAULT_ALGORITHM = 'average';
+
+	/**
+	 * Alpha threshold above which a GD pixel is considered transparent.
+	 *
+	 * GD alpha values run from 0 (opaque) to 127 (fully transparent). The
+	 * midpoint conservatively treats nearly-transparent pixels as background
+	 * fill so the extracted color reflects visible content.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var int
+	 */
+	protected const GD_ALPHA_TRANSPARENT_THRESHOLD = 64;
+
+	/**
+	 * Number of bins per RGB axis used by the quantize algorithm.
+	 *
+	 * 8 bins → 8^3 = 512 buckets, fine enough to surface meaningful colors
+	 * while keeping the bin map small.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var int
+	 */
+	protected const QUANTIZE_BINS_PER_AXIS = 8;
+
+	/**
+	 * Maximum width/height the quantize sampler downscales to.
+	 *
+	 * Sampling at full resolution is wasteful — a 100x100 thumbnail captures
+	 * the dominant region without the per-pixel iteration cost.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var int
+	 */
+	protected const QUANTIZE_SAMPLE_SIZE = 100;
+
+	/**
+	 * Optional cache override pinned at construction time.
+	 *
+	 * Null means "read from config on every call" which is the production path.
+	 * Tests can pin a specific cache store (e.g. an array store) without
+	 * touching global config.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var Repository|null
+	 */
+	protected ?Repository $cache;
+
+	/**
+	 * Optional algorithm override pinned at construction time.
+	 *
+	 * Null means "read from config on every call". Tests and callers that want
+	 * to force an algorithm without flipping config use this constructor seam.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string|null
+	 */
+	protected ?string $algorithmOverride;
+
+	/**
+	 * Creates a new extractor.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string|null     $algorithm Optional algorithm override (`average` or `quantize`).
+	 * @param Repository|null $cache     Optional cache repository override.
+	 */
+	public function __construct( ?string $algorithm = null, ?Repository $cache = null )
+	{
+		$this->algorithmOverride = $algorithm;
+		$this->cache             = $cache;
+	}
+
+	/**
+	 * Extracts the dominant color from the given image.
+	 *
+	 * Caches the result keyed by file path, modification time, and algorithm
+	 * so repeated calls do not re-decode the image. Pass `$useCache = false`
+	 * to bypass the cache (useful in tests).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string      $path      Absolute path to the source image.
+	 * @param string|null $algorithm Optional algorithm override for this call.
+	 * @param bool        $useCache  Whether to read from / write to the cache.
+	 *
+	 * @throws RuntimeException When the source image is unreadable or the algorithm is unknown.
+	 *
+	 * @return string Hex color string in the form `#rrggbb`.
+	 */
+	public function extract( string $path, ?string $algorithm = null, bool $useCache = true ): string
+	{
+		if ( ! is_file( $path ) || ! is_readable( $path ) ) {
+			throw new RuntimeException( "Source image is not readable: {$path}" );
+		}
+
+		$algorithm = $this->resolveAlgorithm( $algorithm );
+
+		if ( ! in_array( $algorithm, self::ALGORITHMS, true ) ) {
+			throw new RuntimeException( "Unknown dominant color algorithm: {$algorithm}" );
+		}
+
+		if ( ! $useCache ) {
+			return $this->compute( $path, $algorithm );
+		}
+
+		$cache = $this->cacheStore();
+
+		if ( null === $cache ) {
+			return $this->compute( $path, $algorithm );
+		}
+
+		$key = $this->cacheKey( $path, $algorithm );
+		$ttl = (int) config( 'artisanpack.performance.images.dominant_color.cache_ttl', 0 );
+
+		if ( $ttl > 0 ) {
+			return (string) $cache->remember( $key, $ttl, fn (): string => $this->compute( $path, $algorithm ) );
+		}
+
+		return (string) $cache->rememberForever( $key, fn (): string => $this->compute( $path, $algorithm ) );
+	}
+
+	/**
+	 * Returns the configured/overridden algorithm name.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function algorithm(): string
+	{
+		return $this->resolveAlgorithm( null );
+	}
+
+	/**
+	 * Computes the dominant color without touching the cache.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path      Absolute path to the source image.
+	 * @param string $algorithm Resolved algorithm name.
+	 *
+	 * @return string Hex color string `#rrggbb`.
+	 */
+	protected function compute( string $path, string $algorithm ): string
+	{
+		return match ( $algorithm ) {
+			'quantize' => $this->quantize( $path ),
+			default    => $this->average( $path ),
+		};
+	}
+
+	/**
+	 * Resolves the algorithm precedence: per-call → override → config → default.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string|null $perCall The per-call algorithm override.
+	 *
+	 * @return string Normalized algorithm name.
+	 */
+	protected function resolveAlgorithm( ?string $perCall ): string
+	{
+		$algorithm = $perCall
+			?? $this->algorithmOverride
+			?? config( 'artisanpack.performance.images.dominant_color.algorithm', self::DEFAULT_ALGORITHM );
+
+		return strtolower( (string) $algorithm );
+	}
+
+	/**
+	 * Returns the cache repository the extractor should use.
+	 *
+	 * Resolves the constructor override first, then falls back to the store
+	 * named by `artisanpack.performance.images.dominant_color.cache_store`.
+	 * Returns null when caching cannot be wired up so callers fall back to a
+	 * direct compute.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return Repository|null
+	 */
+	protected function cacheStore(): ?Repository
+	{
+		if ( null !== $this->cache ) {
+			return $this->cache;
+		}
+
+		if ( ! function_exists( 'cache' ) ) {
+			return null;
+		}
+
+		$store = config( 'artisanpack.performance.images.dominant_color.cache_store' );
+
+		try {
+			return cache()->store( $store );
+		} catch ( Throwable ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Builds the cache key for the given source/algorithm pair.
+	 *
+	 * Includes the file modification time so the cache invalidates when the
+	 * source is replaced without changing its path.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path      Absolute path to the source image.
+	 * @param string $algorithm Algorithm name.
+	 *
+	 * @return string Namespaced cache key.
+	 */
+	protected function cacheKey( string $path, string $algorithm ): string
+	{
+		$mtime = @filemtime( $path );
+
+		return sprintf(
+			'performance:dominant_color:%s:%s:%d',
+			$algorithm,
+			md5( $path ),
+			false === $mtime ? 0 : $mtime,
+		);
+	}
+
+	/**
+	 * Computes the average-color algorithm.
+	 *
+	 * Uses Imagick when the driver supports it; otherwise falls back to GD.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute path to the source image.
+	 *
+	 * @return string Hex color string `#rrggbb`.
+	 */
+	protected function average( string $path ): string
+	{
+		if ( $this->usesImagick() ) {
+			return $this->averageWithImagick( $path );
+		}
+
+		return $this->averageWithGd( $path );
+	}
+
+	/**
+	 * Computes the quantize algorithm.
+	 *
+	 * Buckets sampled pixels into an RGB lattice and returns the centroid of
+	 * the most populated bucket as a hex string.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute path to the source image.
+	 *
+	 * @return string Hex color string `#rrggbb`.
+	 */
+	protected function quantize( string $path ): string
+	{
+		if ( $this->usesImagick() ) {
+			return $this->quantizeWithImagick( $path );
+		}
+
+		return $this->quantizeWithGd( $path );
+	}
+
+	/**
+	 * Averages the source image using Imagick.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute path to the source image.
+	 *
+	 * @throws RuntimeException When Imagick fails to read the image.
+	 *
+	 * @return string Hex color string `#rrggbb`.
+	 */
+	protected function averageWithImagick( string $path ): string
+	{
+		$image = null;
+
+		try {
+			$image = new Imagick( $path );
+
+			if ( $image->getImageAlphaChannel() ) {
+				$image->setImageBackgroundColor( new ImagickPixel( 'white' ) );
+				$image = $image->mergeImageLayers( Imagick::LAYERMETHOD_FLATTEN );
+			}
+
+			$image->resizeImage( 1, 1, Imagick::FILTER_LANCZOS, 1 );
+			$pixel = $image->getImagePixelColor( 0, 0 )->getColor();
+		} catch ( ImagickException $exception ) {
+			throw new RuntimeException(
+				"Imagick failed to sample {$path}: " . $exception->getMessage(),
+				0,
+				$exception,
+			);
+		} finally {
+			$image?->clear();
+		}
+
+		return $this->toHex( (int) $pixel['r'], (int) $pixel['g'], (int) $pixel['b'] );
+	}
+
+	/**
+	 * Averages the source image using GD.
+	 *
+	 * Walks a small grid of samples and averages opaque pixels only so the
+	 * computed color reflects visible content.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute path to the source image.
+	 *
+	 * @return string Hex color string `#rrggbb`.
+	 */
+	protected function averageWithGd( string $path ): string
+	{
+		$source = $this->createGdImage( $path );
+		$width  = imagesx( $source );
+		$height = imagesy( $source );
+
+		$totalR  = 0;
+		$totalG  = 0;
+		$totalB  = 0;
+		$samples = 0;
+
+		$stepX = max( 1, (int) floor( $width / self::QUANTIZE_SAMPLE_SIZE ) );
+		$stepY = max( 1, (int) floor( $height / self::QUANTIZE_SAMPLE_SIZE ) );
+
+		for ( $y = 0; $y < $height; $y += $stepY ) {
+			for ( $x = 0; $x < $width; $x += $stepX ) {
+				$rgba = imagecolorat( $source, $x, $y );
+
+				if ( ( ( $rgba >> 24 ) & 0x7F ) >= self::GD_ALPHA_TRANSPARENT_THRESHOLD ) {
+					continue;
+				}
+
+				$totalR += ( $rgba >> 16 ) & 0xFF;
+				$totalG += ( $rgba >> 8 ) & 0xFF;
+				$totalB += $rgba & 0xFF;
+				$samples++;
+			}
+		}
+
+		imagedestroy( $source );
+
+		if ( 0 === $samples ) {
+			return '#ffffff';
+		}
+
+		return $this->toHex(
+			(int) round( $totalR / $samples ),
+			(int) round( $totalG / $samples ),
+			(int) round( $totalB / $samples ),
+		);
+	}
+
+	/**
+	 * Computes the quantize algorithm using Imagick.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute path to the source image.
+	 *
+	 * @throws RuntimeException When Imagick fails to read the image.
+	 *
+	 * @return string Hex color string `#rrggbb`.
+	 */
+	protected function quantizeWithImagick( string $path ): string
+	{
+		$image = null;
+
+		try {
+			$image = new Imagick( $path );
+
+			if ( $image->getImageAlphaChannel() ) {
+				$image->setImageBackgroundColor( new ImagickPixel( 'white' ) );
+				$image = $image->mergeImageLayers( Imagick::LAYERMETHOD_FLATTEN );
+			}
+
+			$image->resizeImage( self::QUANTIZE_SAMPLE_SIZE, self::QUANTIZE_SAMPLE_SIZE, Imagick::FILTER_LANCZOS, 1 );
+
+			$width  = $image->getImageWidth();
+			$height = $image->getImageHeight();
+			$bins   = [];
+
+			for ( $y = 0; $y < $height; $y++ ) {
+				for ( $x = 0; $x < $width; $x++ ) {
+					$color = $image->getImagePixelColor( $x, $y )->getColor();
+					$this->binPixel( $bins, (int) $color['r'], (int) $color['g'], (int) $color['b'] );
+				}
+			}
+		} catch ( ImagickException $exception ) {
+			throw new RuntimeException(
+				"Imagick failed to sample {$path}: " . $exception->getMessage(),
+				0,
+				$exception,
+			);
+		} finally {
+			$image?->clear();
+		}
+
+		return $this->dominantBinHex( $bins );
+	}
+
+	/**
+	 * Computes the quantize algorithm using GD.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute path to the source image.
+	 *
+	 * @return string Hex color string `#rrggbb`.
+	 */
+	protected function quantizeWithGd( string $path ): string
+	{
+		$source = $this->createGdImage( $path );
+		$width  = imagesx( $source );
+		$height = imagesy( $source );
+
+		$stepX = max( 1, (int) floor( $width / self::QUANTIZE_SAMPLE_SIZE ) );
+		$stepY = max( 1, (int) floor( $height / self::QUANTIZE_SAMPLE_SIZE ) );
+
+		$bins = [];
+
+		for ( $y = 0; $y < $height; $y += $stepY ) {
+			for ( $x = 0; $x < $width; $x += $stepX ) {
+				$rgba = imagecolorat( $source, $x, $y );
+
+				if ( ( ( $rgba >> 24 ) & 0x7F ) >= self::GD_ALPHA_TRANSPARENT_THRESHOLD ) {
+					continue;
+				}
+
+				$this->binPixel(
+					$bins,
+					( $rgba >> 16 ) & 0xFF,
+					( $rgba >> 8 ) & 0xFF,
+					$rgba & 0xFF,
+				);
+			}
+		}
+
+		imagedestroy( $source );
+
+		return $this->dominantBinHex( $bins );
+	}
+
+	/**
+	 * Accumulates a pixel into the quantize bin map.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<string, array{count: int, r: int, g: int, b: int}> $bins Reference to the bin accumulator.
+	 * @param int                                                      $r    Red channel (0-255).
+	 * @param int                                                      $g    Green channel (0-255).
+	 * @param int                                                      $b    Blue channel (0-255).
+	 *
+	 * @return void
+	 */
+	protected function binPixel( array &$bins, int $r, int $g, int $b ): void
+	{
+		$binSize = (int) ceil( 256 / self::QUANTIZE_BINS_PER_AXIS );
+		$rBin    = (int) floor( $r / $binSize );
+		$gBin    = (int) floor( $g / $binSize );
+		$bBin    = (int) floor( $b / $binSize );
+		$key     = "{$rBin}-{$gBin}-{$bBin}";
+
+		if ( ! isset( $bins[ $key ] ) ) {
+			$bins[ $key ] = [ 'count' => 0, 'r' => 0, 'g' => 0, 'b' => 0 ];
+		}
+
+		$bins[ $key ]['count']++;
+		$bins[ $key ]['r'] += $r;
+		$bins[ $key ]['g'] += $g;
+		$bins[ $key ]['b'] += $b;
+	}
+
+	/**
+	 * Returns the centroid of the most populated quantize bin as a hex string.
+	 *
+	 * Returns white when no opaque pixels were sampled (e.g. fully transparent
+	 * source) so callers always get a sensible placeholder.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<string, array{count: int, r: int, g: int, b: int}> $bins Accumulated bins.
+	 *
+	 * @return string Hex color string `#rrggbb`.
+	 */
+	protected function dominantBinHex( array $bins ): string
+	{
+		if ( empty( $bins ) ) {
+			return '#ffffff';
+		}
+
+		$winner = null;
+
+		foreach ( $bins as $bin ) {
+			if ( null === $winner || $bin['count'] > $winner['count'] ) {
+				$winner = $bin;
+			}
+		}
+
+		$count = $winner['count'];
+
+		return $this->toHex(
+			(int) round( $winner['r'] / $count ),
+			(int) round( $winner['g'] / $count ),
+			(int) round( $winner['b'] / $count ),
+		);
+	}
+
+	/**
+	 * Reports whether the configured driver should use Imagick.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool
+	 */
+	protected function usesImagick(): bool
+	{
+		$driver = (string) config( 'artisanpack.performance.images.driver', 'gd' );
+
+		return 'imagick' === $driver && class_exists( Imagick::class );
+	}
+
+	/**
+	 * Formats an RGB triple as a 7-character lowercase hex string.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $r Red channel (0-255).
+	 * @param int $g Green channel (0-255).
+	 * @param int $b Blue channel (0-255).
+	 *
+	 * @return string Hex color string `#rrggbb`.
+	 */
+	protected function toHex( int $r, int $g, int $b ): string
+	{
+		return sprintf(
+			'#%02x%02x%02x',
+			max( 0, min( 255, $r ) ),
+			max( 0, min( 255, $g ) ),
+			max( 0, min( 255, $b ) ),
+		);
+	}
+
+	/**
+	 * Creates a GD resource from the source image.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute path to the source image.
+	 *
+	 * @throws RuntimeException When the mime type cannot be decoded by GD.
+	 *
+	 * @return GdImage
+	 */
+	protected function createGdImage( string $path ): GdImage
+	{
+		$info = getimagesize( $path );
+
+		if ( false === $info ) {
+			throw new RuntimeException( "Unable to read image metadata: {$path}" );
+		}
+
+		$image = match ( $info[2] ) {
+			IMAGETYPE_JPEG => imagecreatefromjpeg( $path ),
+			IMAGETYPE_PNG  => imagecreatefrompng( $path ),
+			IMAGETYPE_GIF  => imagecreatefromgif( $path ),
+			IMAGETYPE_BMP  => imagecreatefrombmp( $path ),
+			IMAGETYPE_WEBP => imagecreatefromwebp( $path ),
+			default        => false,
+		};
+
+		if ( false === $image ) {
+			throw new RuntimeException( "Unsupported image type for GD: {$path}" );
+		}
+
+		return $image;
+	}
+}

--- a/src/Images/ResponsiveImageGenerator.php
+++ b/src/Images/ResponsiveImageGenerator.php
@@ -1,0 +1,310 @@
+<?php
+
+/**
+ * Responsive image generator.
+ *
+ * Generates the multiple width variants and modern-format derivatives that
+ * power responsive `<picture>` markup. Heavy lifting (resize + format
+ * conversion) is delegated to `ImageService` so this class stays focused on
+ * deciding which sizes/formats to produce and shaping the result for the
+ * Blade components and queued jobs that consume it.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Images;
+
+use ArtisanPackUI\Performance\Services\ImageService;
+use RuntimeException;
+
+/**
+ * Responsive image generator class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+class ResponsiveImageGenerator
+{
+	/**
+	 * Image service used for resize/convert primitives.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var ImageService
+	 */
+	protected ImageService $images;
+
+	/**
+	 * Creates a new generator.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param ImageService|null $images Optional image service override.
+	 */
+	public function __construct( ?ImageService $images = null )
+	{
+		$this->images = $images ?? new ImageService();
+	}
+
+	/**
+	 * Generates resized variants of the source at every requested width.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string                $path  Absolute path to the source image.
+	 * @param array<int, int>|null  $sizes Widths to generate (defaults to config/DEFAULT_SIZES).
+	 *
+	 * @throws RuntimeException When the source is unreadable.
+	 *
+	 * @return array<int, string> Map of `width => generated path`, sorted ascending.
+	 */
+	public function generateSizes( string $path, ?array $sizes = null ): array
+	{
+		$this->guardReadable( $path );
+
+		$resolved = $this->resolveSizes( $sizes, $path );
+		$result   = [];
+
+		foreach ( $resolved as $width ) {
+			$result[ $width ] = $this->images->resize( $path, $width );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Generates resized variants at every requested width and every enabled format.
+	 *
+	 * Each width is resized once and then converted to each format the active
+	 * driver supports. Unsupported formats are skipped without failing so the
+	 * caller still gets the original-format derivatives.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string                  $path    Absolute path to the source image.
+	 * @param array<int, int>|null    $sizes   Widths to generate.
+	 * @param array<int, string>|null $formats Format keys to convert to (e.g. `['webp', 'avif']`).
+	 *                                         Pass `[]` to skip format conversion. Defaults to enabled formats.
+	 *
+	 * @throws RuntimeException When the source is unreadable.
+	 *
+	 * @return array<int, array{width: int, format: string, path: string}>
+	 */
+	public function generate( string $path, ?array $sizes = null, ?array $formats = null ): array
+	{
+		$this->guardReadable( $path );
+
+		$resolvedSizes   = $this->resolveSizes( $sizes, $path );
+		$resolvedFormats = $this->resolveFormats( $formats );
+		$variants        = [];
+
+		foreach ( $resolvedSizes as $width ) {
+			$resized    = $this->images->resize( $path, $width );
+			$originalEx = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
+
+			$variants[] = [
+				'width'  => $width,
+				'format' => $originalEx,
+				'path'   => $resized,
+			];
+
+			foreach ( $resolvedFormats as $format ) {
+				if ( ! $this->images->supportsFormat( $format ) ) {
+					continue;
+				}
+
+				$variants[] = [
+					'width'  => $width,
+					'format' => $format,
+					'path'   => $this->images->convertFormat( $resized, $format, $this->qualityFor( $format ) ),
+				];
+			}
+		}
+
+		return $variants;
+	}
+
+	/**
+	 * Builds a `srcset` value for the given widths, optionally for a specific format.
+	 *
+	 * When `$format` is null the source-format derivatives are used; otherwise
+	 * each width is converted to the requested format first. Returns an empty
+	 * string when no variants could be generated (e.g. unsupported format).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string               $path   Absolute path to the source image.
+	 * @param array<int, int>|null $sizes  Widths to include.
+	 * @param string|null          $format Optional format to convert variants to before composing the srcset.
+	 *
+	 * @return string Srcset attribute value, or empty string when nothing was produced.
+	 */
+	public function generateSrcset( string $path, ?array $sizes = null, ?string $format = null ): string
+	{
+		$this->guardReadable( $path );
+
+		$resolvedSizes = $this->resolveSizes( $sizes, $path );
+		$entries       = [];
+
+		foreach ( $resolvedSizes as $width ) {
+			$variant = $this->images->resize( $path, $width );
+
+			if ( null !== $format ) {
+				$format = strtolower( $format );
+
+				if ( ! $this->images->supportsFormat( $format ) ) {
+					continue;
+				}
+
+				$variant = $this->images->convertFormat( $variant, $format, $this->qualityFor( $format ) );
+			}
+
+			$entries[] = $variant . ' ' . $width . 'w';
+		}
+
+		return implode( ', ', $entries );
+	}
+
+	/**
+	 * Returns the widths the generator will use for the given source.
+	 *
+	 * Exposed so components and jobs can introspect the effective sizes
+	 * without triggering a generation pass.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string               $path  Absolute path to the source image.
+	 * @param array<int, int>|null $sizes Caller-supplied widths.
+	 *
+	 * @return array<int, int>
+	 */
+	public function effectiveSizes( string $path, ?array $sizes = null ): array
+	{
+		$this->guardReadable( $path );
+
+		return $this->resolveSizes( $sizes, $path );
+	}
+
+	/**
+	 * Returns the underlying image service.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return ImageService
+	 */
+	public function images(): ImageService
+	{
+		return $this->images;
+	}
+
+	/**
+	 * Resolves the widths to generate, dedupes them, and clamps to the source width.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<int, int>|null $sizes Caller-supplied widths.
+	 * @param string               $path  Absolute path to the source image.
+	 *
+	 * @throws RuntimeException When the source dimensions cannot be read.
+	 *
+	 * @return array<int, int> Effective widths sorted ascending.
+	 */
+	protected function resolveSizes( ?array $sizes, string $path ): array
+	{
+		// Fall back to the package config (which is itself defaulted in
+		// config/performance.php → images.sizes). Keeping that file as the
+		// single source of truth — duplicating the literal here would let
+		// the two drift apart on future tweaks.
+		$candidates = $sizes ?? config( 'artisanpack.performance.images.sizes', [] );
+
+		$normalized = array_values( array_unique( array_map( 'intval', (array) $candidates ) ) );
+		sort( $normalized );
+
+		$dimensions = getimagesize( $path );
+
+		if ( false === $dimensions ) {
+			throw new RuntimeException( "Unable to read image metadata: {$path}" );
+		}
+
+		$sourceWidth = (int) $dimensions[0];
+		$clamped     = array_values( array_unique( array_map(
+			static fn ( int $width ): int => max( 1, min( $width, $sourceWidth ) ),
+			$normalized,
+		) ) );
+
+		sort( $clamped );
+
+		return $clamped;
+	}
+
+	/**
+	 * Resolves the formats to convert to from the caller or config.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<int, string>|null $formats Caller-supplied formats.
+	 *
+	 * @return array<int, string> Lowercased format keys.
+	 */
+	protected function resolveFormats( ?array $formats ): array
+	{
+		if ( null !== $formats ) {
+			return array_values( array_map( 'strtolower', $formats ) );
+		}
+
+		$configured = (array) config( 'artisanpack.performance.images.formats', [] );
+		$enabled    = [];
+
+		foreach ( $configured as $format => $settings ) {
+			if ( ! empty( $settings['enabled'] ) ) {
+				$enabled[] = strtolower( (string) $format );
+			}
+		}
+
+		return $enabled;
+	}
+
+	/**
+	 * Resolves the configured quality for the given format.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $format Format key.
+	 *
+	 * @return int Quality 0-100.
+	 */
+	protected function qualityFor( string $format ): int
+	{
+		$default = 'webp' === $format ? 80 : 70;
+		$value   = (int) config( "artisanpack.performance.images.formats.{$format}.quality", $default );
+
+		return max( 0, min( 100, $value ) );
+	}
+
+	/**
+	 * Guards that the source path is readable.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $path Absolute path to the source image.
+	 *
+	 * @throws RuntimeException When the source path is unreadable.
+	 *
+	 * @return void
+	 */
+	protected function guardReadable( string $path ): void
+	{
+		if ( ! is_file( $path ) || ! is_readable( $path ) ) {
+			throw new RuntimeException( "Source image is not readable: {$path}" );
+		}
+	}
+}

--- a/src/Jobs/ConvertImageFormatJob.php
+++ b/src/Jobs/ConvertImageFormatJob.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Convert image format queued job.
+ *
+ * Converts a single source image to one target format (WebP or AVIF) via
+ * `ImageService::convertFormat`. Designed to be chained with other jobs in
+ * the package's optimization pipeline.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Jobs;
+
+use ArtisanPackUI\Performance\Services\ImageService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Convert image format job class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+class ConvertImageFormatJob implements ShouldQueue
+{
+	use Dispatchable;
+	use InteractsWithQueue;
+	use Queueable;
+	use SerializesModels;
+
+	/**
+	 * Number of times the job may be attempted.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var int
+	 */
+	public int $tries;
+
+	/**
+	 * Seconds between retry attempts.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var int
+	 */
+	public int $backoff;
+
+	/**
+	 * Creates a new job instance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string   $path    Absolute path to the source image.
+	 * @param string   $format  Target format (`webp` or `avif`).
+	 * @param int|null $quality Output quality (0-100). Defaults to the configured format quality.
+	 */
+	public function __construct(
+		public string $path,
+		public string $format,
+		public ?int $quality = null,
+	) {
+		$this->onQueue( (string) config( 'artisanpack.performance.images.queue', 'default' ) );
+		$this->tries   = (int) config( 'artisanpack.performance.images.jobs.tries', 3 );
+		$this->backoff = (int) config( 'artisanpack.performance.images.jobs.backoff', 30 );
+	}
+
+	/**
+	 * Executes the job.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param ImageService $images Image service resolved from the container.
+	 *
+	 * @return void
+	 */
+	public function handle( ImageService $images ): void
+	{
+		$format = strtolower( $this->format );
+
+		if ( ! $images->supportsFormat( $format ) ) {
+			// Driver can't encode this format on this host — skip rather than
+			// fail so the rest of the chain still runs. Emit an info log so
+			// operators see the skip rather than a silent no-op (otherwise
+			// the chain looks like it ran successfully).
+			Log::info( 'ConvertImageFormatJob skipped: driver cannot encode format', [
+				'path'   => $this->path,
+				'format' => $format,
+			] );
+
+			return;
+		}
+
+		$quality = $this->quality
+			?? (int) config( "artisanpack.performance.images.formats.{$format}.quality", 80 );
+
+		$images->convertFormat( $this->path, $format, $quality );
+	}
+}

--- a/src/Jobs/GenerateResponsiveSizesJob.php
+++ b/src/Jobs/GenerateResponsiveSizesJob.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Generate responsive sizes queued job.
+ *
+ * Generates resized variants of a source image via the
+ * `ResponsiveImageGenerator`. Use to backfill responsive variants for an
+ * existing image or as a chained step in the optimization pipeline.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Jobs;
+
+use ArtisanPackUI\Performance\Images\ResponsiveImageGenerator;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Generate responsive sizes job class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+class GenerateResponsiveSizesJob implements ShouldQueue
+{
+	use Dispatchable;
+	use InteractsWithQueue;
+	use Queueable;
+	use SerializesModels;
+
+	/**
+	 * Number of times the job may be attempted.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var int
+	 */
+	public int $tries;
+
+	/**
+	 * Seconds between retry attempts.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var int
+	 */
+	public int $backoff;
+
+	/**
+	 * Creates a new job instance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string                  $path    Absolute path to the source image.
+	 * @param array<int, int>|null    $sizes   Widths to generate (defaults to configured sizes).
+	 * @param array<int, string>|null $formats Formats to convert variants to.
+	 */
+	public function __construct(
+		public string $path,
+		public ?array $sizes = null,
+		public ?array $formats = null,
+	) {
+		$this->onQueue( (string) config( 'artisanpack.performance.images.queue', 'default' ) );
+		$this->tries   = (int) config( 'artisanpack.performance.images.jobs.tries', 3 );
+		$this->backoff = (int) config( 'artisanpack.performance.images.jobs.backoff', 30 );
+	}
+
+	/**
+	 * Executes the job.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param ResponsiveImageGenerator $generator Responsive image generator resolved from the container.
+	 *
+	 * @return void
+	 */
+	public function handle( ResponsiveImageGenerator $generator ): void
+	{
+		$generator->generate( $this->path, $this->sizes, $this->formats );
+	}
+}

--- a/src/Jobs/OptimizeImageJob.php
+++ b/src/Jobs/OptimizeImageJob.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Optimize image queued job.
+ *
+ * Runs the full image optimization pipeline (resize + format conversion)
+ * against a single source image. Designed to be dispatched after upload so
+ * the request thread doesn't block on encoding. The pipeline dispatches
+ * `ImageOptimized` when it produces at least one variant.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Jobs;
+
+use ArtisanPackUI\Performance\Services\ImageService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Optimize image job class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+class OptimizeImageJob implements ShouldQueue
+{
+	use Dispatchable;
+	use InteractsWithQueue;
+	use Queueable;
+	use SerializesModels;
+
+	/**
+	 * Number of times the job may be attempted.
+	 *
+	 * Resolved from `artisanpack.performance.images.jobs.tries` so applications
+	 * can tune retry counts without subclassing.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var int
+	 */
+	public int $tries;
+
+	/**
+	 * Seconds between retry attempts.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var int
+	 */
+	public int $backoff;
+
+	/**
+	 * Creates a new job instance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string               $path    Absolute path to the source image.
+	 * @param array<string, mixed> $options Optimization overrides forwarded to `ImageService::optimize()`.
+	 */
+	public function __construct(
+		public string $path,
+		public array $options = [],
+	) {
+		$this->onQueue( (string) config( 'artisanpack.performance.images.queue', 'default' ) );
+		$this->tries   = (int) config( 'artisanpack.performance.images.jobs.tries', 3 );
+		$this->backoff = (int) config( 'artisanpack.performance.images.jobs.backoff', 30 );
+	}
+
+	/**
+	 * Executes the job.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param ImageService $images Image service resolved from the container.
+	 *
+	 * @return void
+	 */
+	public function handle( ImageService $images ): void
+	{
+		$images->optimize( $this->path, $this->options );
+	}
+}

--- a/src/PerformanceServiceProvider.php
+++ b/src/PerformanceServiceProvider.php
@@ -21,9 +21,13 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\Performance;
 
 use ArtisanPackUI\Performance\Console\Commands\GenerateWebPCommand;
+use ArtisanPackUI\Performance\Images\DominantColorExtractor;
+use ArtisanPackUI\Performance\Images\ResponsiveImageGenerator;
 use ArtisanPackUI\Performance\Services\Image\FormatConverter;
 use ArtisanPackUI\Performance\Services\ImageService;
 use ArtisanPackUI\Performance\Services\PerformanceService;
+use ArtisanPackUI\Performance\View\Components\LazyImage;
+use ArtisanPackUI\Performance\View\Components\ResponsiveImage;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -58,8 +62,19 @@ class PerformanceServiceProvider extends ServiceProvider
 			return new FormatConverter();
 		} );
 
+		$this->app->singleton( DominantColorExtractor::class, function ( $app ) {
+			return new DominantColorExtractor();
+		} );
+
 		$this->app->singleton( ImageService::class, function ( $app ) {
-			return new ImageService( $app->make( FormatConverter::class ) );
+			return new ImageService(
+				$app->make( FormatConverter::class ),
+				$app->make( DominantColorExtractor::class ),
+			);
+		} );
+
+		$this->app->singleton( ResponsiveImageGenerator::class, function ( $app ) {
+			return new ResponsiveImageGenerator( $app->make( ImageService::class ) );
 		} );
 
 		$this->app->singleton( 'performance', function ( $app ) {
@@ -82,9 +97,30 @@ class PerformanceServiceProvider extends ServiceProvider
 	{
 		$this->mergeConfiguration();
 		$this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
+		$this->loadViewsFrom( __DIR__ . '/../resources/views', 'performance' );
+		$this->loadBladeComponents();
 		$this->registerEventListeners();
 		$this->registerCommands();
 		$this->publishConfiguration();
+	}
+
+	/**
+	 * Registers the package's Blade components under the `perf` prefix.
+	 *
+	 * The components are also published under `resources/views/components`
+	 * so applications can override the templates without forking the
+	 * component classes.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function loadBladeComponents(): void
+	{
+		$this->loadViewComponentsAs( 'perf', [
+			LazyImage::class,
+			ResponsiveImage::class,
+		] );
 	}
 
 	/**

--- a/src/Services/ImageService.php
+++ b/src/Services/ImageService.php
@@ -21,6 +21,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\Performance\Services;
 
 use ArtisanPackUI\Performance\Events\ImageOptimized;
+use ArtisanPackUI\Performance\Images\DominantColorExtractor;
 use ArtisanPackUI\Performance\Services\Image\FormatConverter;
 use GdImage;
 use Imagick;
@@ -47,15 +48,28 @@ class ImageService
 	protected FormatConverter $converter;
 
 	/**
+	 * Dominant color extractor.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var DominantColorExtractor
+	 */
+	protected DominantColorExtractor $dominantColor;
+
+	/**
 	 * Creates a new image service.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param FormatConverter|null $converter Optional converter override; defaults to a converter using the configured driver.
+	 * @param FormatConverter|null        $converter     Optional converter override; defaults to a converter using the configured driver.
+	 * @param DominantColorExtractor|null $dominantColor Optional dominant color extractor override.
 	 */
-	public function __construct( ?FormatConverter $converter = null )
-	{
-		$this->converter = $converter ?? new FormatConverter();
+	public function __construct(
+		?FormatConverter $converter = null,
+		?DominantColorExtractor $dominantColor = null,
+	) {
+		$this->converter     = $converter ?? new FormatConverter();
+		$this->dominantColor = $dominantColor ?? new DominantColorExtractor();
 	}
 
 	/**
@@ -243,15 +257,19 @@ class ImageService
 	 */
 	public function extractDominantColor( string $path ): string
 	{
-		if ( ! is_file( $path ) || ! is_readable( $path ) ) {
-			throw new RuntimeException( "Source image is not readable: {$path}" );
-		}
+		return $this->dominantColor->extract( $path );
+	}
 
-		if ( $this->converter->usesImagick() ) {
-			return $this->dominantColorWithImagick( $path );
-		}
-
-		return $this->dominantColorWithGd( $path );
+	/**
+	 * Returns the dominant color extractor used by the service.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return DominantColorExtractor
+	 */
+	public function dominantColorExtractor(): DominantColorExtractor
+	{
+		return $this->dominantColor;
 	}
 
 	/**
@@ -524,65 +542,6 @@ class ImageService
 			'webp'        => imagewebp( $image, $destination, 80 ),
 			default       => imagepng( $image, $destination ),
 		};
-	}
-
-	/**
-	 * Extracts the dominant color using Imagick.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $path Absolute path to the source image.
-	 *
-	 * @throws RuntimeException When Imagick fails to read the image.
-	 *
-	 * @return string Hex color string `#rrggbb`.
-	 */
-	protected function dominantColorWithImagick( string $path ): string
-	{
-		$image = null;
-
-		try {
-			$image = new Imagick( $path );
-			$image->resizeImage( 1, 1, Imagick::FILTER_LANCZOS, 1 );
-			$pixel = $image->getImagePixelColor( 0, 0 )->getColor();
-		} catch ( ImagickException $exception ) {
-			throw new RuntimeException(
-				"Imagick failed to sample {$path}: " . $exception->getMessage(),
-				0,
-				$exception,
-			);
-		} finally {
-			$image?->clear();
-		}
-
-		return sprintf( '#%02x%02x%02x', $pixel['r'], $pixel['g'], $pixel['b'] );
-	}
-
-	/**
-	 * Extracts the dominant color using GD.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $path Absolute path to the source image.
-	 *
-	 * @return string Hex color string `#rrggbb`.
-	 */
-	protected function dominantColorWithGd( string $path ): string
-	{
-		$source = $this->createGdImage( $path );
-		$thumb  = imagecreatetruecolor( 1, 1 );
-
-		imagecopyresampled( $thumb, $source, 0, 0, 0, 0, 1, 1, imagesx( $source ), imagesy( $source ) );
-		$rgb = imagecolorat( $thumb, 0, 0 );
-
-		imagedestroy( $source );
-		imagedestroy( $thumb );
-
-		$r = ( $rgb >> 16 ) & 0xFF;
-		$g = ( $rgb >> 8 ) & 0xFF;
-		$b = $rgb & 0xFF;
-
-		return sprintf( '#%02x%02x%02x', $r, $g, $b );
 	}
 
 	/**

--- a/src/Services/PerformanceService.php
+++ b/src/Services/PerformanceService.php
@@ -20,6 +20,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Performance\Services;
 
+use ArtisanPackUI\Performance\Images\ResponsiveImageGenerator;
 use Closure;
 use RuntimeException;
 
@@ -45,15 +46,28 @@ class PerformanceService
 	protected ImageService $images;
 
 	/**
+	 * Responsive image generator (lazily resolved against `$images`).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var ResponsiveImageGenerator|null
+	 */
+	protected ?ResponsiveImageGenerator $responsiveImages = null;
+
+	/**
 	 * Creates a new performance service.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param ImageService|null $images Optional image service override (constructs the default when null).
+	 * @param ImageService|null             $images           Optional image service override.
+	 * @param ResponsiveImageGenerator|null $responsiveImages Optional responsive generator override.
 	 */
-	public function __construct( ?ImageService $images = null )
-	{
-		$this->images = $images ?? new ImageService();
+	public function __construct(
+		?ImageService $images = null,
+		?ResponsiveImageGenerator $responsiveImages = null,
+	) {
+		$this->images           = $images ?? new ImageService();
+		$this->responsiveImages = $responsiveImages;
 	}
 
 	/**
@@ -69,6 +83,18 @@ class PerformanceService
 	public function images(): ImageService
 	{
 		return $this->images;
+	}
+
+	/**
+	 * Returns the responsive image generator.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return ResponsiveImageGenerator
+	 */
+	public function responsiveImages(): ResponsiveImageGenerator
+	{
+		return $this->responsiveImages ??= new ResponsiveImageGenerator( $this->images );
 	}
 
 	/**
@@ -164,7 +190,23 @@ class PerformanceService
 	 */
 	public function getResponsiveSrcset( string $path, array $sizes ): string
 	{
-		return $this->images->generateSrcset( $path, $sizes );
+		return $this->responsiveImages()->generateSrcset( $path, $sizes );
+	}
+
+	/**
+	 * Generates every responsive variant (sizes × formats) for the given image.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string                  $path    Absolute path to the source image.
+	 * @param array<int, int>|null    $sizes   Widths to generate.
+	 * @param array<int, string>|null $formats Formats to convert to.
+	 *
+	 * @return array<int, array{width: int, format: string, path: string}>
+	 */
+	public function generateResponsiveVariants( string $path, ?array $sizes = null, ?array $formats = null ): array
+	{
+		return $this->responsiveImages()->generate( $path, $sizes, $formats );
 	}
 
 	/**

--- a/src/View/Components/LazyImage.php
+++ b/src/View/Components/LazyImage.php
@@ -1,0 +1,296 @@
+<?php
+
+/**
+ * Lazy image Blade component.
+ *
+ * Renders an `<img>` element with native `loading="lazy"` and `decoding="async"`,
+ * a configurable placeholder (dominant color, blur LQIP, skeleton, none), and
+ * `fetchpriority` support for above-the-fold images. Width/height attributes
+ * are required for CLS prevention; callers that supply only `src` will receive
+ * a component without dimensions.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\View\Components;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+/**
+ * Lazy image component class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+final class LazyImage extends Component
+{
+	/**
+	 * Supported placeholder strategies.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array<int, string>
+	 */
+	public const PLACEHOLDERS = [ 'dominant_color', 'blur', 'skeleton', 'none' ];
+
+	/**
+	 * Resolved placeholder strategy for the component.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public string $resolvedPlaceholder;
+
+	/**
+	 * Resolved `loading` attribute value (`lazy` or `eager`).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public string $loadingAttribute;
+
+	/**
+	 * Resolved background style applied for the dominant-color placeholder.
+	 *
+	 * Empty string when no background is applied.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public string $placeholderStyle;
+
+	/**
+	 * Creates a new lazy image component instance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string      $src           Image source URL.
+	 * @param string      $alt           Alt text for accessibility.
+	 * @param int|null    $width         Width in pixels (recommended to prevent CLS).
+	 * @param int|null    $height        Height in pixels (recommended to prevent CLS).
+	 * @param bool        $lazy          Whether to render `loading="lazy"`. Pass false for LCP images.
+	 * @param string|null $placeholder   Placeholder strategy: `dominant_color`, `blur`, `skeleton`, or `none`.
+	 * @param string|null $dominantColor Hex color used when `placeholder=dominant_color`.
+	 * @param string|null $blurSrc       Data URI of the blurred LQIP when `placeholder=blur`.
+	 * @param string|null $fetchpriority Fetchpriority hint: `high`, `low`, or `auto`.
+	 * @param string|null $threshold     Optional viewport threshold (CSS root margin) emitted as a `data-threshold` attribute.
+	 * @param string|null $sizes         Optional `sizes` attribute.
+	 * @param string|null $srcset        Optional `srcset` attribute.
+	 * @param string|null $class         Additional CSS classes to append to the `<img>` element.
+	 */
+	public function __construct(
+		public string $src,
+		public string $alt = '',
+		public ?int $width = null,
+		public ?int $height = null,
+		public bool $lazy = true,
+		public ?string $placeholder = null,
+		public ?string $dominantColor = null,
+		public ?string $blurSrc = null,
+		public ?string $fetchpriority = null,
+		public ?string $threshold = null,
+		public ?string $sizes = null,
+		public ?string $srcset = null,
+		public ?string $class = null,
+	) {
+		$this->resolvedPlaceholder = $this->resolvePlaceholder( $placeholder );
+		$this->loadingAttribute    = $lazy ? 'lazy' : 'eager';
+		$this->placeholderStyle    = $this->resolvePlaceholderStyle();
+	}
+
+	/**
+	 * Returns the view to render.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return View
+	 */
+	public function render(): View
+	{
+		return view( 'performance::components.lazy-image' );
+	}
+
+	/**
+	 * Reports whether the configured fetchpriority value is supported by browsers.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool
+	 */
+	public function shouldEmitFetchpriority(): bool
+	{
+		return null !== $this->fetchpriority
+			&& in_array( strtolower( $this->fetchpriority ), [ 'high', 'low', 'auto' ], true );
+	}
+
+	/**
+	 * Reports whether a skeleton placeholder should wrap the image.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool
+	 */
+	public function shouldUseSkeleton(): bool
+	{
+		return 'skeleton' === $this->resolvedPlaceholder;
+	}
+
+	/**
+	 * Reports whether the component should emit a blur LQIP src attribute.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool
+	 */
+	public function shouldUseBlurPlaceholder(): bool
+	{
+		return 'blur' === $this->resolvedPlaceholder
+			&& ! empty( $this->blurSrc )
+			&& $this->isSafeBlurDataUri( $this->blurSrc );
+	}
+
+	/**
+	 * Returns the source the browser should render first.
+	 *
+	 * Blur placeholders display the LQIP data URI until the lazy load swaps in
+	 * the high-resolution source; every other strategy uses the original
+	 * source directly.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function initialSrc(): string
+	{
+		return $this->shouldUseBlurPlaceholder() ? (string) $this->blurSrc : $this->src;
+	}
+
+	/**
+	 * Reports whether the given data URI is a safe raster blur placeholder.
+	 *
+	 * Whitelists `image/jpeg`, `image/png`, `image/webp`, `image/avif`, and
+	 * `image/gif` mime types. Rejects everything else — most importantly
+	 * `image/svg+xml`, which is loadable from `<img src>` but can fire
+	 * outbound requests via `<image href="https://attacker/leak">` or
+	 * `<use href="...">` references (an exfiltration/fingerprinting channel
+	 * through a placeholder attribute, even though the SVG can't execute
+	 * scripts in the `<img src>` context).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $uri Caller-supplied data URI.
+	 *
+	 * @return bool
+	 */
+	protected function isSafeBlurDataUri( string $uri ): bool
+	{
+		// Match the mime type followed by either `;` (further params, incl.
+		// `;base64,`) or `,` (raw data immediately). Anything else — including
+		// `image/svg+xml`, `text/html`, an unknown mime, or trailing garbage —
+		// fails to match.
+		return 1 === preg_match(
+			'#^data:image/(?:jpeg|png|webp|avif|gif)[;,]#i',
+			$uri,
+		);
+	}
+
+	/**
+	 * Resolves the placeholder strategy with fall-back precedence.
+	 *
+	 * Per-call → config → `none`. Unknown strategies degrade to `none` so
+	 * typos don't surface bad markup.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string|null $placeholder Caller-supplied placeholder strategy.
+	 *
+	 * @return string
+	 */
+	protected function resolvePlaceholder( ?string $placeholder ): string
+	{
+		$value = $placeholder
+			?? config( 'artisanpack.performance.images.lazy_loading.placeholder', 'none' );
+
+		$value = strtolower( (string) $value );
+
+		return in_array( $value, self::PLACEHOLDERS, true ) ? $value : 'none';
+	}
+
+	/**
+	 * Resolves the inline style for the dominant-color placeholder.
+	 *
+	 * Returns an empty string when no background should be applied so the
+	 * component template can conditionally skip the `style` attribute. The
+	 * color value is validated against the `#rrggbb`/`#rgb`/`#rrggbbaa` hex
+	 * pattern before composition so a hostile or accidentally-malformed
+	 * value can't smuggle additional CSS declarations through the
+	 * `style="..."` attribute (Blade attribute escaping does not strip CSS
+	 * tokens — it just escapes quotes/HTML).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	protected function resolvePlaceholderStyle(): string
+	{
+		if ( 'dominant_color' !== $this->resolvedPlaceholder ) {
+			return '';
+		}
+
+		$color = $this->dominantColor;
+
+		if ( empty( $color ) || ! $this->isValidHexColor( $color ) ) {
+			return '';
+		}
+
+		return 'background-color: ' . $color . ';';
+	}
+
+	/**
+	 * Reports whether the given string is a syntactically valid hex color.
+	 *
+	 * Accepts the four CSS Color Module 4 hex shorthands — `#rgb`, `#rgba`,
+	 * `#rrggbb`, `#rrggbbaa` — and rejects every other input so the value
+	 * is safe to interpolate into a CSS `style` attribute. Fully transparent
+	 * alpha values (`#rrggbb00`, `#rgb0`) are also rejected: a transparent
+	 * placeholder is invisible and defeats the entire point of the
+	 * `dominant_color` strategy.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $color Caller-supplied color value.
+	 *
+	 * @return bool
+	 */
+	protected function isValidHexColor( string $color ): bool
+	{
+		if ( 1 !== preg_match( '/^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/', $color ) ) {
+			return false;
+		}
+
+		// 9-character form is `#rrggbbaa`; alpha = `00` is fully transparent.
+		if ( 9 === strlen( $color ) && '00' === strtolower( substr( $color, -2 ) ) ) {
+			return false;
+		}
+
+		// 5-character form is `#rgba`; alpha = `0` is fully transparent.
+		if ( 5 === strlen( $color ) && '0' === substr( $color, -1 ) ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/src/View/Components/ResponsiveImage.php
+++ b/src/View/Components/ResponsiveImage.php
@@ -1,0 +1,423 @@
+<?php
+
+/**
+ * Responsive image Blade component.
+ *
+ * Renders a `<picture>` element with AVIF and WebP `<source>` entries (when
+ * the active driver supports them) and an `<img>` fallback. Variants are
+ * resolved against the `ResponsiveImageGenerator` so callers only supply the
+ * source path and optional sizes — the component computes srcsets and the
+ * effective widths.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\View\Components;
+
+use ArtisanPackUI\Performance\Images\ResponsiveImageGenerator;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+use Throwable;
+
+/**
+ * Responsive image component class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+final class ResponsiveImage extends Component
+{
+	/**
+	 * Resolved srcset value for the AVIF `<source>` element.
+	 *
+	 * Empty string when AVIF cannot be produced.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public string $avifSrcset = '';
+
+	/**
+	 * Resolved srcset value for the WebP `<source>` element.
+	 *
+	 * Empty string when WebP cannot be produced.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public string $webpSrcset = '';
+
+	/**
+	 * Resolved srcset value for the original-format `<img>` fallback.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public string $fallbackSrcset = '';
+
+	/**
+	 * Resolved fallback `<img>` src.
+	 *
+	 * Defaults to the original source when generation produces no widths.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public string $fallbackSrc;
+
+	/**
+	 * Absolute filesystem path used for variant generation.
+	 *
+	 * Null when the source is a remote URL or cannot be mapped to a file.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string|null
+	 */
+	protected ?string $sourceFile = null;
+
+	/**
+	 * Public URL prefix applied to generated variant filenames.
+	 *
+	 * Generation produces filesystem paths; the component swaps the file
+	 * directory for this URL prefix so the srcset entries are loadable by
+	 * the browser. Null when the component cannot derive a safe URL prefix
+	 * (e.g. caller passed an absolute filesystem path outside `public_path()`)
+	 * — the component degrades to a bare `<img>` in that case.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string|null
+	 */
+	protected ?string $srcsetBaseUrl = null;
+
+	/**
+	 * Creates a new responsive image component instance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string                  $src             Absolute path or URL to the source image.
+	 * @param string                  $alt             Alt text for accessibility.
+	 * @param array<int, int>|null    $sizes           Widths to generate (defaults to package config).
+	 * @param string|null             $sizesAttr       Value for the `sizes` attribute (e.g. `(max-width: 640px) 100vw, 50vw`).
+	 * @param int|null                $width           Width in pixels (recommended for CLS).
+	 * @param int|null                $height          Height in pixels (recommended for CLS).
+	 * @param bool                    $lazy            Whether to render `loading="lazy"`.
+	 * @param string|null             $placeholder     Placeholder strategy forwarded to the underlying `<img>`.
+	 * @param string|null             $dominantColor   Hex color used when `placeholder=dominant_color`.
+	 * @param string|null             $fetchpriority   Fetchpriority hint forwarded to the underlying `<img>`.
+	 * @param array<int, string>|null $formats         Formats to emit (defaults to enabled formats).
+	 * @param string|null             $class           CSS classes added to the `<picture>` element.
+	 * @param string|null             $imgClass        CSS classes added to the `<img>` element.
+	 */
+	public function __construct(
+		public string $src,
+		public string $alt = '',
+		public ?array $sizes = null,
+		public ?string $sizesAttr = null,
+		public ?int $width = null,
+		public ?int $height = null,
+		public bool $lazy = true,
+		public ?string $placeholder = null,
+		public ?string $dominantColor = null,
+		public ?string $fetchpriority = null,
+		public ?array $formats = null,
+		public ?string $class = null,
+		public ?string $imgClass = null,
+	) {
+		$this->fallbackSrc = $src;
+		$this->resolveSources();
+	}
+
+	/**
+	 * Returns the view to render.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return View
+	 */
+	public function render(): View
+	{
+		return view( 'performance::components.responsive-image' );
+	}
+
+	/**
+	 * Resolves srcset values for AVIF, WebP, and fallback variants.
+	 *
+	 * Generation runs against the filesystem path resolved from `src`. The
+	 * resulting variant filenames are mapped back to web-loadable URLs by
+	 * replacing the file directory with the URL directory of `src`. When the
+	 * source can't be mapped to a local file (remote URL, unresolved relative
+	 * path) the component falls back to a bare `<img>` so callers still get a
+	 * usable element.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function resolveSources(): void
+	{
+		$this->sourceFile = $this->resolveSourceFile();
+
+		if ( null === $this->sourceFile ) {
+			return;
+		}
+
+		$this->srcsetBaseUrl = $this->resolveSrcsetBaseUrl();
+
+		// No URL prefix means the variants can't be expressed as web URLs —
+		// emit a bare <img> rather than leaking filesystem paths into srcset.
+		if ( null === $this->srcsetBaseUrl ) {
+			return;
+		}
+
+		$generator = $this->resolveGenerator();
+		$formats   = $this->resolveFormats();
+
+		try {
+			$this->fallbackSrcset = $this->rewriteSrcset(
+				$generator->generateSrcset( $this->sourceFile, $this->sizes ),
+			);
+
+			if ( in_array( 'avif', $formats, true ) && $generator->images()->supportsFormat( 'avif' ) ) {
+				$this->avifSrcset = $this->rewriteSrcset(
+					$generator->generateSrcset( $this->sourceFile, $this->sizes, 'avif' ),
+				);
+			}
+
+			if ( in_array( 'webp', $formats, true ) && $generator->images()->supportsFormat( 'webp' ) ) {
+				$this->webpSrcset = $this->rewriteSrcset(
+					$generator->generateSrcset( $this->sourceFile, $this->sizes, 'webp' ),
+				);
+			}
+		} catch ( Throwable ) {
+			// Generation failed (unreadable file, unsupported driver) — fall
+			// back to the bare `<img src>` so the component never 500s.
+			$this->avifSrcset     = '';
+			$this->webpSrcset     = '';
+			$this->fallbackSrcset = '';
+		}
+	}
+
+	/**
+	 * Resolves `$this->src` to an absolute filesystem path.
+	 *
+	 * Accepts absolute paths verbatim and maps web-relative paths through
+	 * `public_path()` so callers can pass `/storage/foo.jpg` and have the
+	 * component resolve to the real file behind the public symlink.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string|null Absolute path to the file, or null when it cannot be located.
+	 */
+	protected function resolveSourceFile(): ?string
+	{
+		if ( str_contains( $this->src, '://' ) ) {
+			return null;
+		}
+
+		if ( is_file( $this->src ) ) {
+			return $this->src;
+		}
+
+		if ( ! function_exists( 'public_path' ) ) {
+			return null;
+		}
+
+		$candidate = public_path( ltrim( $this->src, '/' ) );
+
+		return is_file( $candidate ) ? $candidate : null;
+	}
+
+	/**
+	 * Resolves the URL directory the srcset entries should be prefixed with.
+	 *
+	 * Web URLs use the directory of `$this->src` verbatim. Web-relative paths
+	 * (those starting with `/`) only qualify when the resolved filesystem
+	 * path also lives under `public_path()` — otherwise the path is a
+	 * filesystem path (e.g. `/tmp/foo.jpg`) and using its directory as a URL
+	 * prefix would leak filesystem paths into the rendered srcset. The
+	 * web-root case (`dirname('/foo.jpg') === '/'`) is preserved as `/` so
+	 * srcset entries become `/foo-320w.jpg` rather than the empty string.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string|null URL prefix (no trailing slash, `/` for web-root), or null when none can be derived.
+	 */
+	protected function resolveSrcsetBaseUrl(): ?string
+	{
+		if ( null === $this->sourceFile ) {
+			return null;
+		}
+
+		$isUrl           = str_contains( $this->src, '://' );
+		$startsWithSlash = str_starts_with( $this->src, '/' );
+
+		if ( $isUrl || ( $startsWithSlash && $this->sourceFileIsUnderPublicPath() ) ) {
+			$dir = dirname( $this->src );
+
+			// dirname('/foo.jpg') === '/' — preserve the root slash so
+			// rewriteSrcset emits `/foo-320w.jpg` and not `foo-320w.jpg`.
+			if ( '/' === $dir ) {
+				return '/';
+			}
+
+			return rtrim( $dir, '/' );
+		}
+
+		// Web-relative-looking `src` that doesn't actually live under
+		// public_path → refuse to emit srcsets, since we'd leak a filesystem
+		// path. The caller still gets a bare <img src="$src"> via $fallbackSrc.
+		if ( $startsWithSlash ) {
+			return null;
+		}
+
+		// Otherwise derive a URL from the file path by stripping public_path.
+		if ( ! function_exists( 'public_path' ) ) {
+			return null;
+		}
+
+		$publicRoot = rtrim( public_path(), DIRECTORY_SEPARATOR );
+
+		if ( str_starts_with( $this->sourceFile, $publicRoot . DIRECTORY_SEPARATOR ) ) {
+			$relative = substr( $this->sourceFile, strlen( $publicRoot ) );
+			$dir      = str_replace( DIRECTORY_SEPARATOR, '/', dirname( $relative ) );
+
+			return '/' === $dir ? '/' : '/' . trim( $dir, '/' );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Reports whether the resolved source file lives under `public_path()`.
+	 *
+	 * Used to decide whether a `/`-prefixed `src` should be treated as a web
+	 * path (safe to use its directory as a srcset URL prefix) or as a raw
+	 * filesystem path (must not be exposed to the browser).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool
+	 */
+	protected function sourceFileIsUnderPublicPath(): bool
+	{
+		if ( null === $this->sourceFile || ! function_exists( 'public_path' ) ) {
+			return false;
+		}
+
+		$publicRoot = rtrim( public_path(), DIRECTORY_SEPARATOR );
+
+		return str_starts_with( $this->sourceFile, $publicRoot . DIRECTORY_SEPARATOR );
+	}
+
+	/**
+	 * Rewrites a srcset string so each path entry is prefixed with the URL base.
+	 *
+	 * The generator emits `<filesystem-path> <width>w` tuples; the component
+	 * swaps the filesystem directory for `$srcsetBaseUrl` so the browser can
+	 * actually fetch the variants.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $srcset Raw srcset string from the generator.
+	 *
+	 * @return string Srcset string with web-loadable URLs.
+	 */
+	protected function rewriteSrcset( string $srcset ): string
+	{
+		if ( '' === $srcset || null === $this->srcsetBaseUrl ) {
+			return $srcset;
+		}
+
+		// Strip any trailing slash so the join never produces `//`. For the
+		// web-root case (`srcsetBaseUrl === '/'`) this collapses to '' and
+		// the join produces `/filename` — exactly what we want.
+		$prefix  = rtrim( $this->srcsetBaseUrl, '/' );
+		$entries = array_map( 'trim', explode( ',', $srcset ) );
+		$mapped  = [];
+
+		foreach ( $entries as $entry ) {
+			if ( '' === $entry ) {
+				continue;
+			}
+
+			// Split on the LAST space — the descriptor (`<n>w` / `<n>x`) is
+			// always the trailing token, and filesystem paths may legitimately
+			// contain spaces (a real concern: paths like
+			// `/Users/.../ArtisanPack UI Packages/.../foo.jpg`). Splitting on
+			// the first space would slice the path in half.
+			$lastSpace = strrpos( $entry, ' ' );
+
+			if ( false === $lastSpace ) {
+				$path       = $entry;
+				$descriptor = '';
+			} else {
+				$path       = substr( $entry, 0, $lastSpace );
+				$descriptor = substr( $entry, $lastSpace + 1 );
+			}
+
+			$mapped[] = $prefix . '/' . basename( $path ) . ( '' !== $descriptor ? ' ' . $descriptor : '' );
+		}
+
+		return implode( ', ', $mapped );
+	}
+
+	/**
+	 * Resolves the formats to emit from the caller or config.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	protected function resolveFormats(): array
+	{
+		if ( null !== $this->formats ) {
+			return array_values( array_map( 'strtolower', $this->formats ) );
+		}
+
+		$configured = (array) config( 'artisanpack.performance.images.formats', [] );
+		$enabled    = [];
+
+		foreach ( $configured as $format => $settings ) {
+			if ( ! empty( $settings['enabled'] ) ) {
+				$enabled[] = strtolower( (string) $format );
+			}
+		}
+
+		return $enabled;
+	}
+
+	/**
+	 * Resolves the responsive generator from the container with a sensible fallback.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return ResponsiveImageGenerator
+	 */
+	protected function resolveGenerator(): ResponsiveImageGenerator
+	{
+		if ( function_exists( 'app' ) ) {
+			try {
+				return app( ResponsiveImageGenerator::class );
+			} catch ( Throwable ) {
+				// Container missing the binding (test edge cases) — fall through.
+			}
+		}
+
+		return new ResponsiveImageGenerator();
+	}
+}

--- a/tests/Feature/Images/DominantColorExtractorTest.php
+++ b/tests/Feature/Images/DominantColorExtractorTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Images\DominantColorExtractor;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
+
+beforeEach( function (): void {
+	clearImageFixtures();
+} );
+
+afterEach( function (): void {
+	clearImageFixtures();
+} );
+
+it( 'extracts a dominant color as a 7-character lowercase hex string', function (): void {
+	$source    = makeTestImage( 'avg.jpg', 60, 60, 'jpeg', [ 200, 50, 100 ] );
+	$extractor = new DominantColorExtractor( 'average', new Repository( new ArrayStore() ) );
+
+	$color = $extractor->extract( $source );
+
+	expect( $color )->toMatch( '/^#[0-9a-f]{6}$/' );
+} );
+
+it( 'falls back to the configured algorithm when the caller passes null', function (): void {
+	config( [ 'artisanpack.performance.images.dominant_color.algorithm' => 'quantize' ] );
+
+	$source    = makeTestImage( 'config-algo.jpg', 60, 60, 'jpeg', [ 30, 220, 60 ] );
+	$extractor = new DominantColorExtractor( null, new Repository( new ArrayStore() ) );
+
+	expect( $extractor->algorithm() )->toBe( 'quantize' );
+	expect( $extractor->extract( $source ) )->toMatch( '/^#[0-9a-f]{6}$/' );
+} );
+
+it( 'supports both average and quantize algorithms', function ( string $algorithm ): void {
+	$source    = makeTestImage( "alg-{$algorithm}.jpg", 80, 80, 'jpeg', [ 100, 150, 200 ] );
+	$extractor = new DominantColorExtractor( $algorithm, new Repository( new ArrayStore() ) );
+
+	expect( $extractor->extract( $source ) )->toMatch( '/^#[0-9a-f]{6}$/' );
+} )->with( [ 'average', 'quantize' ] );
+
+it( 'caches the extracted color between calls so the image is sampled once', function (): void {
+	$source    = makeTestImage( 'cached.jpg', 40, 40, 'jpeg', [ 90, 90, 90 ] );
+	$cache     = new Repository( new ArrayStore() );
+	$extractor = new DominantColorExtractor( 'average', $cache );
+
+	$first = $extractor->extract( $source );
+
+	// Locate the cached key by file fingerprint and overwrite with a sentinel.
+	// The next extract() call must read the sentinel rather than re-sample.
+	$expectedKey = sprintf(
+		'performance:dominant_color:average:%s:%d',
+		md5( $source ),
+		filemtime( $source ),
+	);
+
+	expect( $cache->get( $expectedKey ) )->toBe( $first );
+
+	$cache->forever( $expectedKey, '#abcdef' );
+
+	expect( $extractor->extract( $source ) )->toBe( '#abcdef' );
+} );
+
+it( 'skips the cache when `$useCache` is false', function (): void {
+	$source    = makeTestImage( 'no-cache.jpg', 40, 40, 'jpeg', [ 10, 20, 30 ] );
+	$cache     = new Repository( new ArrayStore() );
+	$extractor = new DominantColorExtractor( 'average', $cache );
+
+	$extractor->extract( $source, null, false );
+
+	$expectedKey = sprintf(
+		'performance:dominant_color:average:%s:%d',
+		md5( $source ),
+		filemtime( $source ),
+	);
+
+	expect( $cache->get( $expectedKey ) )->toBeNull();
+} );
+
+it( 'throws when the source image is missing', function (): void {
+	$extractor = new DominantColorExtractor( 'average', new Repository( new ArrayStore() ) );
+
+	expect( fn () => $extractor->extract( '/no/such/file.jpg' ) )
+		->toThrow( RuntimeException::class, 'Source image is not readable' );
+} );
+
+it( 'throws for unknown algorithms', function (): void {
+	$source    = makeTestImage( 'bad-algo.jpg' );
+	$extractor = new DominantColorExtractor( 'bogus', new Repository( new ArrayStore() ) );
+
+	expect( fn () => $extractor->extract( $source ) )
+		->toThrow( RuntimeException::class, 'Unknown dominant color algorithm' );
+} );
+
+it( 'returns a white fallback when every sample is transparent', function (): void {
+	// Pin the GD driver — Imagick's mergeImageLayers flatten and GD's
+	// "skip alpha then default to white" both happen to return `#ffffff`,
+	// so without pinning a driver the test would assert a coincidence
+	// rather than the documented GD branch behavior.
+	config( [ 'artisanpack.performance.images.driver' => 'gd' ] );
+
+	$source = imageFixturesDir() . DIRECTORY_SEPARATOR . 'transparent.png';
+
+	$image       = imagecreatetruecolor( 20, 20 );
+	$transparent = imagecolorallocatealpha( $image, 0, 0, 0, 127 );
+	imagealphablending( $image, false );
+	imagesavealpha( $image, true );
+	imagefilledrectangle( $image, 0, 0, 20, 20, $transparent );
+	imagepng( $image, $source );
+	imagedestroy( $image );
+
+	$extractor = new DominantColorExtractor( 'average', new Repository( new ArrayStore() ) );
+
+	expect( $extractor->extract( $source ) )->toBe( '#ffffff' );
+} );

--- a/tests/Feature/Images/ResponsiveImageGeneratorTest.php
+++ b/tests/Feature/Images/ResponsiveImageGeneratorTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Images\ResponsiveImageGenerator;
+use ArtisanPackUI\Performance\Services\Image\FormatConverter;
+use ArtisanPackUI\Performance\Services\ImageService;
+
+beforeEach( function (): void {
+	clearImageFixtures();
+} );
+
+afterEach( function (): void {
+	clearImageFixtures();
+} );
+
+it( 'generates resized variants for every requested width', function (): void {
+	$source    = makeTestImage( 'sizes.jpg', 800, 400 );
+	$generator = new ResponsiveImageGenerator( new ImageService( new FormatConverter( 'gd' ) ) );
+
+	$variants = $generator->generateSizes( $source, [ 200, 400 ] );
+
+	expect( $variants )->toHaveCount( 2 )
+		->and( $variants )->toHaveKey( 200 )
+		->and( $variants )->toHaveKey( 400 );
+
+	foreach ( $variants as $path ) {
+		expect( file_exists( $path ) )->toBeTrue();
+	}
+} );
+
+it( 'clamps requested widths to the source width to avoid upscaling', function (): void {
+	$source    = makeTestImage( 'clamp.jpg', 400, 200 );
+	$generator = new ResponsiveImageGenerator( new ImageService( new FormatConverter( 'gd' ) ) );
+
+	$effective = $generator->effectiveSizes( $source, [ 200, 800, 1600 ] );
+
+	expect( $effective )->toBe( [ 200, 400 ] );
+} );
+
+it( 'builds a srcset with widths in ascending order', function (): void {
+	$source    = makeTestImage( 'srcset.jpg', 800, 400 );
+	$generator = new ResponsiveImageGenerator( new ImageService( new FormatConverter( 'gd' ) ) );
+
+	$srcset = $generator->generateSrcset( $source, [ 200, 400 ] );
+
+	expect( $srcset )->toContain( '200w' )
+		->and( $srcset )->toContain( '400w' )
+		->and( substr_count( $srcset, ',' ) )->toBe( 1 );
+} );
+
+it( 'generates variants in every enabled format alongside the original', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	config( [
+		'artisanpack.performance.images.formats' => [
+			'webp' => [ 'enabled' => true, 'quality' => 70 ],
+			'avif' => [ 'enabled' => false, 'quality' => 60 ],
+		],
+	] );
+
+	$source    = makeTestImage( 'multi.jpg', 600, 300 );
+	$generator = new ResponsiveImageGenerator( new ImageService( new FormatConverter( 'gd' ) ) );
+
+	$variants = $generator->generate( $source, [ 150, 300 ] );
+
+	$formats = array_unique( array_column( $variants, 'format' ) );
+	sort( $formats );
+
+	expect( $formats )->toBe( [ 'jpg', 'webp' ] );
+
+	foreach ( $variants as $variant ) {
+		expect( file_exists( $variant['path'] ) )->toBeTrue();
+	}
+} );
+
+it( 'skips unsupported formats rather than failing the generation pass', function (): void {
+	$source = makeTestImage( 'skip.jpg', 200, 200 );
+
+	$converter = new class( 'gd' ) extends FormatConverter {
+		public function supports( string $format ): bool
+		{
+			return false;
+		}
+	};
+
+	$generator = new ResponsiveImageGenerator( new ImageService( $converter ) );
+
+	$variants = $generator->generate( $source, [ 100 ], [ 'webp' ] );
+
+	$formats = array_unique( array_column( $variants, 'format' ) );
+
+	expect( $formats )->toBe( [ 'jpg' ] );
+} );
+
+it( 'returns an empty srcset for an unsupported requested format', function (): void {
+	$source = makeTestImage( 'unsupported.jpg', 200, 200 );
+
+	$converter = new class( 'gd' ) extends FormatConverter {
+		public function supports( string $format ): bool
+		{
+			return false;
+		}
+	};
+
+	$generator = new ResponsiveImageGenerator( new ImageService( $converter ) );
+
+	expect( $generator->generateSrcset( $source, [ 100 ], 'webp' ) )->toBe( '' );
+} );
+
+it( 'throws when the source image is unreadable', function (): void {
+	$generator = new ResponsiveImageGenerator( new ImageService( new FormatConverter( 'gd' ) ) );
+
+	expect( fn () => $generator->generate( '/no/such/file.jpg' ) )
+		->toThrow( RuntimeException::class, 'Source image is not readable' );
+} );

--- a/tests/Feature/Jobs/ImageJobsTest.php
+++ b/tests/Feature/Jobs/ImageJobsTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Events\ImageOptimized;
+use ArtisanPackUI\Performance\Jobs\ConvertImageFormatJob;
+use ArtisanPackUI\Performance\Jobs\GenerateResponsiveSizesJob;
+use ArtisanPackUI\Performance\Jobs\OptimizeImageJob;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+
+beforeEach( function (): void {
+	clearImageFixtures();
+} );
+
+afterEach( function (): void {
+	clearImageFixtures();
+} );
+
+it( 'dispatches OptimizeImageJob onto the configured queue', function (): void {
+	Queue::fake();
+
+	config( [
+		'artisanpack.performance.images.queue'         => 'media',
+		'artisanpack.performance.images.jobs.tries'    => 5,
+		'artisanpack.performance.images.jobs.backoff'  => 60,
+	] );
+
+	OptimizeImageJob::dispatch( '/tmp/some.jpg', [ 'sizes' => [ 200 ] ] );
+
+	Queue::assertPushed( OptimizeImageJob::class, function ( OptimizeImageJob $job ): bool {
+		return 'media' === $job->queue
+			&& 5 === $job->tries
+			&& 60 === $job->backoff
+			&& '/tmp/some.jpg' === $job->path
+			&& [ 'sizes' => [ 200 ] ] === $job->options;
+	} );
+} );
+
+it( 'runs the optimization pipeline when OptimizeImageJob is handled synchronously', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	Event::fake();
+
+	$source = makeTestImage( 'opt-job.jpg', 400, 200 );
+
+	OptimizeImageJob::dispatchSync( $source, [
+		'sizes'   => [ 100 ],
+		'formats' => [ 'webp' ],
+	] );
+
+	Event::assertDispatched( ImageOptimized::class );
+} );
+
+it( 'dispatches ConvertImageFormatJob onto the configured queue', function (): void {
+	Queue::fake();
+
+	config( [ 'artisanpack.performance.images.queue' => 'images' ] );
+
+	ConvertImageFormatJob::dispatch( '/tmp/h.jpg', 'webp', 80 );
+
+	Queue::assertPushed( ConvertImageFormatJob::class, function ( ConvertImageFormatJob $job ): bool {
+		return 'images' === $job->queue
+			&& '/tmp/h.jpg' === $job->path
+			&& 'webp' === $job->format
+			&& 80 === $job->quality;
+	} );
+} );
+
+it( 'converts a real source when ConvertImageFormatJob is handled synchronously', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	$source = makeTestImage( 'convert-job.jpg', 100, 100 );
+
+	ConvertImageFormatJob::dispatchSync( $source, 'webp', 80 );
+
+	$expected = dirname( $source ) . DIRECTORY_SEPARATOR . pathinfo( $source, PATHINFO_FILENAME ) . '.webp';
+
+	expect( file_exists( $expected ) )->toBeTrue();
+} );
+
+it( 'silently skips ConvertImageFormatJob when the driver cannot encode the requested format', function (): void {
+	$source = makeTestImage( 'convert-skip.jpg', 100, 100 );
+
+	app()->bind( ArtisanPackUI\Performance\Services\ImageService::class, function () {
+		return new class extends ArtisanPackUI\Performance\Services\ImageService {
+			public function __construct()
+			{
+			}
+
+			public function supportsFormat( string $format ): bool
+			{
+				return false;
+			}
+
+			public function convertFormat( string $path, string $format, int $quality ): string
+			{
+				throw new RuntimeException( 'Should not be called when format is unsupported' );
+			}
+		};
+	} );
+
+	// Asserts the job returns cleanly rather than throwing.
+	ConvertImageFormatJob::dispatchSync( $source, 'avif', 70 );
+
+	expect( true )->toBeTrue();
+} );
+
+it( 'dispatches GenerateResponsiveSizesJob with retry configuration', function (): void {
+	Queue::fake();
+
+	config( [
+		'artisanpack.performance.images.jobs.tries'   => 4,
+		'artisanpack.performance.images.jobs.backoff' => 45,
+	] );
+
+	GenerateResponsiveSizesJob::dispatch( '/tmp/h.jpg', [ 320, 640 ], [ 'webp' ] );
+
+	Queue::assertPushed( GenerateResponsiveSizesJob::class, function ( GenerateResponsiveSizesJob $job ): bool {
+		return [ 320, 640 ] === $job->sizes
+			&& [ 'webp' ] === $job->formats
+			&& 4 === $job->tries
+			&& 45 === $job->backoff;
+	} );
+} );
+
+it( 'chains the optimization jobs into a single queued pipeline', function (): void {
+	Bus::fake();
+
+	Bus::chain( [
+		new ConvertImageFormatJob( '/tmp/h.jpg', 'webp', 80 ),
+		new ConvertImageFormatJob( '/tmp/h.jpg', 'avif', 70 ),
+		new GenerateResponsiveSizesJob( '/tmp/h.jpg', [ 320, 640 ] ),
+	] )->dispatch();
+
+	Bus::assertChained( [
+		ConvertImageFormatJob::class,
+		ConvertImageFormatJob::class,
+		GenerateResponsiveSizesJob::class,
+	] );
+} );

--- a/tests/Feature/View/Components/LazyImageTest.php
+++ b/tests/Feature/View/Components/LazyImageTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\View\Components\LazyImage;
+use Illuminate\Support\Facades\Blade;
+
+beforeEach( function (): void {
+	clearImageFixtures();
+} );
+
+afterEach( function (): void {
+	clearImageFixtures();
+} );
+
+it( 'renders an img element with native lazy loading and async decoding by default', function (): void {
+	$html = Blade::render( '<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" />' );
+
+	expect( $html )->toContain( '<img' )
+		->and( $html )->toContain( 'src="/img/hero.jpg"' )
+		->and( $html )->toContain( 'loading="lazy"' )
+		->and( $html )->toContain( 'decoding="async"' )
+		->and( $html )->toContain( 'alt="Hero"' );
+} );
+
+it( 'switches to eager loading when lazy is false', function (): void {
+	$html = Blade::render( '<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" :lazy="false" />' );
+
+	expect( $html )->toContain( 'loading="eager"' )
+		->and( $html )->not->toContain( 'loading="lazy"' );
+} );
+
+it( 'emits width and height attributes for CLS prevention', function (): void {
+	$html = Blade::render( '<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" :width="800" :height="400" />' );
+
+	expect( $html )->toContain( 'width="800"' )
+		->and( $html )->toContain( 'height="400"' );
+} );
+
+it( 'applies a dominant color background when placeholder=dominant_color', function (): void {
+	$html = Blade::render(
+		'<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" placeholder="dominant_color" dominant-color="#3b82f6" />',
+	);
+
+	expect( $html )->toContain( 'background-color: #3b82f6;' );
+} );
+
+it( 'rejects non-hex dominant-color values rather than smuggling CSS through the style attribute', function (): void {
+	// Regression: the style attribute composed raw concatenation of $dominantColor,
+	// so a hostile value could close out the declaration and inject additional
+	// CSS (e.g. `background-image: url(//attacker.test/leak)`). Component must
+	// validate the value against the hex pattern and drop it on mismatch.
+	$payload = 'red; background-image: url(//attacker.test/leak)';
+
+	$html = Blade::render(
+		'<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" placeholder="dominant_color" :dominant-color="$c" />',
+		[ 'c' => $payload ],
+	);
+
+	expect( $html )->not->toContain( 'background-image' )
+		->and( $html )->not->toContain( 'attacker.test' );
+} );
+
+it( 'accepts three-, four-, six-, and eight-digit hex shorthand colors', function (): void {
+	$threeDigit = Blade::render(
+		'<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" placeholder="dominant_color" dominant-color="#f3a" />',
+	);
+
+	$fourDigit = Blade::render(
+		'<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" placeholder="dominant_color" dominant-color="#f3a8" />',
+	);
+
+	$withAlpha = Blade::render(
+		'<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" placeholder="dominant_color" dominant-color="#3b82f680" />',
+	);
+
+	expect( $threeDigit )->toContain( 'background-color: #f3a;' )
+		->and( $fourDigit )->toContain( 'background-color: #f3a8;' )
+		->and( $withAlpha )->toContain( 'background-color: #3b82f680;' );
+} );
+
+it( 'rejects fully transparent hex colors that would render an invisible placeholder', function (): void {
+	// Regression: `#rrggbb00` and `#rgb0` are syntactically valid hex but
+	// resolve to alpha=0 — the placeholder would be invisible and defeat
+	// the purpose of the dominant_color strategy. The component must drop
+	// them rather than emit a useless background-color declaration.
+	$eightDigitTransparent = Blade::render(
+		'<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" placeholder="dominant_color" dominant-color="#3b82f600" />',
+	);
+
+	$fourDigitTransparent = Blade::render(
+		'<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" placeholder="dominant_color" dominant-color="#3b80" />',
+	);
+
+	expect( $eightDigitTransparent )->not->toContain( 'background-color:' )
+		->and( $fourDigitTransparent )->not->toContain( 'background-color:' );
+} );
+
+it( 'rejects an SVG blur data URI rather than emitting an exfiltration vector', function (): void {
+	// Regression: `data:image/svg+xml` is loadable from <img src> but SVG
+	// can fire outbound requests via <image href> / <use href> references —
+	// a fingerprinting/exfil channel through what was supposed to be a
+	// passive placeholder attribute. Whitelist raster types only.
+	$html = Blade::render(
+		'<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" placeholder="blur" :blur-src="$b" />',
+		[ 'b' => 'data:image/svg+xml;base64,PHN2Zy8+' ],
+	);
+
+	expect( $html )->toContain( 'src="/img/hero.jpg"' )
+		->and( $html )->not->toContain( 'data:image/svg+xml' )
+		->and( $html )->not->toContain( 'data-src=' );
+} );
+
+it( 'accepts a raster blur data URI as the initial src', function (): void {
+	// Sanity check on the whitelist — raster mime types must round-trip,
+	// otherwise the regex tightening would break the happy path.
+	$png  = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVQI12NgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC';
+	$html = Blade::render(
+		'<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" placeholder="blur" :blur-src="$b" />',
+		[ 'b' => $png ],
+	);
+
+	expect( $html )->toContain( 'src="' . $png . '"' )
+		->and( $html )->toContain( 'data-src="/img/hero.jpg"' );
+} );
+
+it( 'ignores a non-image blurSrc data URI rather than rendering it as the initial src', function (): void {
+	// Browsers won't render data:text/html via <img>, but the contract says
+	// blurSrc must be an image data URI; reject everything else.
+	$html = Blade::render(
+		'<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" placeholder="blur" :blur-src="$b" />',
+		[ 'b' => 'data:text/html,<script>alert(1)</script>' ],
+	);
+
+	expect( $html )->toContain( 'src="/img/hero.jpg"' )
+		->and( $html )->not->toContain( 'data:text/html' )
+		->and( $html )->not->toContain( 'data-src=' );
+} );
+
+it( 'emits the blur data URI as the initial src when placeholder=blur', function (): void {
+	$blur = 'data:image/jpeg;base64,/9j/abc==';
+	$html = Blade::render(
+		'<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" placeholder="blur" :blur-src="$b" />',
+		[ 'b' => $blur ],
+	);
+
+	expect( $html )->toContain( 'src="' . $blur . '"' )
+		->and( $html )->toContain( 'data-src="/img/hero.jpg"' );
+} );
+
+it( 'wraps the img in a skeleton container when placeholder=skeleton', function (): void {
+	$html = Blade::render(
+		'<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" :width="100" :height="50" placeholder="skeleton" />',
+	);
+
+	expect( $html )->toContain( 'class="perf-skeleton"' )
+		->and( $html )->toContain( 'aspect-ratio: 100 / 50;' );
+} );
+
+it( 'emits fetchpriority when a valid value is supplied', function (): void {
+	$html = Blade::render( '<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" fetchpriority="high" />' );
+
+	expect( $html )->toContain( 'fetchpriority="high"' );
+} );
+
+it( 'ignores unknown fetchpriority values', function (): void {
+	$html = Blade::render( '<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" fetchpriority="bogus" />' );
+
+	expect( $html )->not->toContain( 'fetchpriority' );
+} );
+
+it( 'forwards the configured threshold as a data attribute for JS fallback hooks', function (): void {
+	$html = Blade::render( '<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" threshold="200px" />' );
+
+	expect( $html )->toContain( 'data-threshold="200px"' );
+} );
+
+it( 'appends caller-supplied classes to the img element', function (): void {
+	$html = Blade::render( '<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" class="rounded shadow" />' );
+
+	expect( $html )->toContain( 'perf-lazy-image rounded shadow' );
+} );
+
+it( 'forwards srcset and sizes attributes when provided', function (): void {
+	$html = Blade::render(
+		'<x-perf-lazy-image src="/img/hero.jpg" alt="Hero" srcset="/img/h-200.jpg 200w" sizes="100vw" />',
+	);
+
+	expect( $html )->toContain( 'srcset="/img/h-200.jpg 200w"' )
+		->and( $html )->toContain( 'sizes="100vw"' );
+} );
+
+it( 'falls back to none when the placeholder strategy is unknown', function (): void {
+	$component = new LazyImage( '/img/hero.jpg', 'Hero', placeholder: 'mystery' );
+
+	expect( $component->resolvedPlaceholder )->toBe( 'none' )
+		->and( $component->shouldUseSkeleton() )->toBeFalse()
+		->and( $component->shouldUseBlurPlaceholder() )->toBeFalse();
+} );

--- a/tests/Feature/View/Components/ResponsiveImageTest.php
+++ b/tests/Feature/View/Components/ResponsiveImageTest.php
@@ -1,0 +1,286 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Images\ResponsiveImageGenerator;
+use ArtisanPackUI\Performance\Services\Image\FormatConverter;
+use ArtisanPackUI\Performance\Services\ImageService;
+use ArtisanPackUI\Performance\View\Components\ResponsiveImage;
+use Illuminate\Support\Facades\Blade;
+
+/**
+ * Stage path used by tests that need to write source/variant files under
+ * public_path() so the component can resolve a srcset URL prefix. Each test
+ * uses a dedicated subdirectory that is wiped before AND after every test,
+ * so a mid-test failure or crash cannot leak stale JPEGs into the next run.
+ */
+function perfRespTestStageDir(): string
+{
+	$dir = public_path( 'perf-resp-test' );
+
+	if ( ! is_dir( $dir ) ) {
+		mkdir( $dir, 0777, true );
+	}
+
+	return $dir;
+}
+
+function perfRespTestClearStage(): void
+{
+	$dir = public_path( 'perf-resp-test' );
+
+	if ( ! is_dir( $dir ) ) {
+		return;
+	}
+
+	foreach ( glob( $dir . DIRECTORY_SEPARATOR . '*' ) as $entry ) {
+		if ( is_file( $entry ) ) {
+			@unlink( $entry );
+		}
+	}
+}
+
+beforeEach( function (): void {
+	clearImageFixtures();
+	perfRespTestClearStage();
+} );
+
+afterEach( function (): void {
+	clearImageFixtures();
+	perfRespTestClearStage();
+} );
+
+it( 'renders a picture element with an img fallback', function (): void {
+	$html = Blade::render(
+		'<x-perf-responsive-image src="/img/hero.jpg" alt="Hero" />',
+	);
+
+	expect( $html )->toContain( '<picture' )
+		->and( $html )->toContain( '<img' )
+		->and( $html )->toContain( 'alt="Hero"' );
+} );
+
+it( 'emits source elements for AVIF and WebP when generation succeeds', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	// Stage under public_path() so the component can resolve a URL prefix
+	// for the srcset entries (filesystem paths outside public_path are now
+	// correctly refused — see the "refuses to leak filesystem paths" test).
+	$stageDir = perfRespTestStageDir();
+	$source   = $stageDir . DIRECTORY_SEPARATOR . 'multi-fmt.jpg';
+
+	$image = imagecreatetruecolor( 600, 300 );
+	imagefilledrectangle( $image, 0, 0, 600, 300, imagecolorallocate( $image, 50, 100, 150 ) );
+	imagejpeg( $image, $source, 90 );
+	imagedestroy( $image );
+
+	config( [
+		'artisanpack.performance.images.formats' => [
+			'webp' => [ 'enabled' => true, 'quality' => 70 ],
+			'avif' => [ 'enabled' => false, 'quality' => 60 ],
+		],
+	] );
+
+	app()->instance(
+		ResponsiveImageGenerator::class,
+		new ResponsiveImageGenerator( new ImageService( new FormatConverter( 'gd' ) ) ),
+	);
+
+	$html = Blade::render(
+		'<x-perf-responsive-image src="/perf-resp-test/multi-fmt.jpg" alt="Hero" :sizes="[150, 300]" />',
+	);
+
+	expect( $html )->toContain( 'type="image/webp"' )
+		->and( $html )->not->toContain( 'type="image/avif"' );
+} );
+
+it( 'forwards the sizes attribute to every source element', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	$stageDir = perfRespTestStageDir();
+	$source   = $stageDir . DIRECTORY_SEPARATOR . 'sizes-attr.jpg';
+
+	$image = imagecreatetruecolor( 600, 300 );
+	imagefilledrectangle( $image, 0, 0, 600, 300, imagecolorallocate( $image, 80, 120, 40 ) );
+	imagejpeg( $image, $source, 90 );
+	imagedestroy( $image );
+
+	config( [
+		'artisanpack.performance.images.formats' => [
+			'webp' => [ 'enabled' => true, 'quality' => 70 ],
+			'avif' => [ 'enabled' => false, 'quality' => 60 ],
+		],
+	] );
+
+	app()->instance(
+		ResponsiveImageGenerator::class,
+		new ResponsiveImageGenerator( new ImageService( new FormatConverter( 'gd' ) ) ),
+	);
+
+	$html = Blade::render(
+		'<x-perf-responsive-image src="/perf-resp-test/sizes-attr.jpg" alt="Hero" :sizes="[150, 300]" sizes-attr="(max-width: 640px) 100vw, 50vw" />',
+	);
+
+	expect( $html )->toContain( 'sizes="(max-width: 640px) 100vw, 50vw"' );
+} );
+
+it( 'forwards the picture class to the picture element', function (): void {
+	$html = Blade::render( '<x-perf-responsive-image src="/img/hero.jpg" alt="Hero" class="hero" />' );
+
+	expect( $html )->toContain( 'class="perf-responsive-image hero"' );
+} );
+
+it( 'rewrites srcset entries so they use a web URL prefix instead of the filesystem path', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	// Stage the source under the shared perf-resp-test subdirectory so the
+	// beforeEach/afterEach hooks clean it up even if assertions throw.
+	$stageDir = perfRespTestStageDir();
+	$source   = $stageDir . DIRECTORY_SEPARATOR . 'stage.jpg';
+
+	$image = imagecreatetruecolor( 600, 300 );
+	imagefilledrectangle( $image, 0, 0, 600, 300, imagecolorallocate( $image, 50, 100, 150 ) );
+	imagejpeg( $image, $source, 90 );
+	imagedestroy( $image );
+
+	config( [
+		'artisanpack.performance.images.formats' => [
+			'webp' => [ 'enabled' => true, 'quality' => 70 ],
+			'avif' => [ 'enabled' => false, 'quality' => 60 ],
+		],
+	] );
+
+	app()->instance(
+		ResponsiveImageGenerator::class,
+		new ResponsiveImageGenerator( new ImageService( new FormatConverter( 'gd' ) ) ),
+	);
+
+	$component = new ResponsiveImage( '/perf-resp-test/stage.jpg', 'Stage', [ 150, 300 ] );
+
+	expect( $component->webpSrcset )->toContain( '/perf-resp-test/stage-150w.webp 150w' )
+		->and( $component->webpSrcset )->toContain( '/perf-resp-test/stage-300w.webp 300w' )
+		->and( $component->webpSrcset )->not->toContain( $stageDir )
+		->and( $component->fallbackSrcset )->toContain( '/perf-resp-test/stage-150w.jpg 150w' );
+} );
+
+it( 'refuses to leak filesystem paths into srcset when src is an absolute path outside public_path', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	// Source at a `/`-prefixed location that does NOT live under public_path —
+	// the component must decline to compute a URL prefix and degrade to a
+	// bare <img> rather than emit a srcset of `/tmp/...` filesystem paths.
+	$source = makeTestImage( 'fs-leak.jpg', 400, 200 );
+
+	app()->instance(
+		ResponsiveImageGenerator::class,
+		new ResponsiveImageGenerator( new ImageService( new FormatConverter( 'gd' ) ) ),
+	);
+
+	$component = new ResponsiveImage( $source, 'Outside public_path', [ 100, 200 ] );
+
+	expect( $component->webpSrcset )->toBe( '' )
+		->and( $component->fallbackSrcset )->toBe( '' )
+		->and( $component->fallbackSrc )->toBe( $source );
+} );
+
+it( 'preserves the root slash when src is at the web root', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	// This test deliberately writes to public_path() root (NOT the
+	// perf-resp-test subdirectory) because the bug we're guarding against
+	// only triggers when `dirname($src)` resolves to '/'. Clean up explicitly
+	// via try/finally so the file is removed even on assertion failure.
+	$publicRoot = public_path();
+	$source     = $publicRoot . DIRECTORY_SEPARATOR . 'stage-root.jpg';
+	$cleanup    = function () use ( $publicRoot ): void {
+		foreach ( glob( $publicRoot . DIRECTORY_SEPARATOR . 'stage-root*' ) as $f ) {
+			@unlink( $f );
+		}
+	};
+
+	try {
+		$image = imagecreatetruecolor( 300, 150 );
+		imagefilledrectangle( $image, 0, 0, 300, 150, imagecolorallocate( $image, 30, 60, 90 ) );
+		imagejpeg( $image, $source, 90 );
+		imagedestroy( $image );
+
+		app()->instance(
+			ResponsiveImageGenerator::class,
+			new ResponsiveImageGenerator( new ImageService( new FormatConverter( 'gd' ) ) ),
+		);
+
+		$component = new ResponsiveImage( '/stage-root.jpg', 'Web root', [ 100, 200 ] );
+
+		// Every entry must start with a single leading slash. Split on commas
+		// and assert each individually so the test catches both "//foo" and "foo".
+		$entries = array_map( 'trim', explode( ',', $component->fallbackSrcset ) );
+
+		expect( $entries )->toHaveCount( 2 )
+			->and( $entries[0] )->toBe( '/stage-root-100w.jpg 100w' )
+			->and( $entries[1] )->toBe( '/stage-root-200w.jpg 200w' )
+			->and( $component->fallbackSrcset )->not->toContain( '//' );
+	} finally {
+		$cleanup();
+	}
+} );
+
+it( 'falls back to a bare img when the source is a remote URL', function (): void {
+	$html = Blade::render( '<x-perf-responsive-image src="https://cdn.example.com/h.jpg" alt="Hero" />' );
+
+	expect( $html )->toContain( '<picture' )
+		->and( $html )->toContain( 'src="https://cdn.example.com/h.jpg"' )
+		->and( $html )->not->toContain( 'type="image/webp"' )
+		->and( $html )->not->toContain( 'type="image/avif"' );
+} );
+
+it( 'degrades to a bare img when generation throws', function (): void {
+	// Pin a generator whose underlying ImageService throws on resize — the
+	// component must catch and emit a usable picture element rather than
+	// 500. Stage the source under public_path() so the path-safety guard
+	// doesn't short-circuit before generation is even attempted.
+	$stageDir = perfRespTestStageDir();
+	$source   = $stageDir . DIRECTORY_SEPARATOR . 'stage-throws.jpg';
+
+	$image = imagecreatetruecolor( 200, 100 );
+	imagefilledrectangle( $image, 0, 0, 200, 100, imagecolorallocate( $image, 10, 10, 10 ) );
+	imagejpeg( $image, $source, 90 );
+	imagedestroy( $image );
+
+	$brokenImages = new class extends ImageService {
+		public function __construct()
+		{
+		} // bypass FormatConverter wiring
+
+		public function resize( string $path, int $width, ?int $height = null ): string
+		{
+			throw new RuntimeException( 'boom' );
+		}
+
+		public function supportsFormat( string $format ): bool
+		{
+			return true;
+		}
+	};
+
+	app()->instance(
+		ResponsiveImageGenerator::class,
+		new ResponsiveImageGenerator( $brokenImages ),
+	);
+
+	$component = new ResponsiveImage( '/perf-resp-test/stage-throws.jpg', 'Hero' );
+
+	expect( $component->avifSrcset )->toBe( '' )
+		->and( $component->webpSrcset )->toBe( '' )
+		->and( $component->fallbackSrcset )->toBe( '' )
+		->and( $component->fallbackSrc )->toBe( '/perf-resp-test/stage-throws.jpg' );
+} );


### PR DESCRIPTION
## Description

Implements Phase 2 of the image delivery surface in a single PR (issues #11–#15 are tightly coupled and small enough to ship together).

**Closes:** #11, #12, #13, #14, #15

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #11, #12, #13, #14, #15

## Motivation and Context

Phase 2 lands the rendering surface that consumes the format/resize pipeline built in Phase 1: dominant-color extraction, responsive variant generation, two Blade components (lazy `<img>` and `<picture>` with format negotiation), and three queued jobs for background processing. The five issues share architecture (delegation through `ImageService` + `ResponsiveImageGenerator`), so bundling them produces a coherent diff and avoids the noise of staging through five PRs.

## Changes Made

- **#11 DominantColorExtractor** (`src/Images/DominantColorExtractor.php`) — `average` and `quantize` algorithms; transparent-pixel skipping (Imagick flattens to white); cache keyed by path + mtime + algorithm via configurable store/TTL.
- **#12 ResponsiveImageGenerator** (`src/Images/ResponsiveImageGenerator.php`) — `generateSizes`, `generate`, `generateSrcset`, `effectiveSizes`. Clamps widths to source (no upscaling), skips unsupported formats rather than failing.
- **#13 `<x-perf-lazy-image>`** (`src/View/Components/LazyImage.php` + view) — native `loading="lazy"`, `decoding="async"`, fetchpriority, width/height (CLS), four placeholder strategies (`dominant_color`, `blur`, `skeleton`, `none`). Hex validator + raster-only blur whitelist as defense-in-depth against CSS injection and SVG `<image href>` exfil.
- **#14 `<x-perf-responsive-image>`** (`src/View/Components/ResponsiveImage.php` + view) — `<picture>` with AVIF + WebP `<source>` entries and an `<img>` fallback built from `<x-perf-lazy-image>`. Srcset is rewritten through `public_path()` so generation produces filesystem paths while the rendered HTML carries web URLs; refuses to emit srcsets when the source lives outside `public_path()` (prevents leaking filesystem paths).
- **#15 OptimizeImageJob / ConvertImageFormatJob / GenerateResponsiveSizesJob** (`src/Jobs/*`) — implement `ShouldQueue`; honor `images.queue`, `images.jobs.tries`, `images.jobs.backoff`. Chain via `Bus::chain()`. `ConvertImageFormatJob` logs an info line when the driver can't encode the requested format (no silent skips in pipelines).

Config additions: `images.dominant_color.cache_store`, `images.dominant_color.cache_ttl`, `images.jobs.tries`, `images.jobs.backoff`. Service provider registers the new singletons and the two Blade components under the `perf` prefix.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- PHP Version: 8.4.22
- Project Version: 1.0.0 (release/1.0)

**Tests Performed:**
1. Full Pest suite: **127 passed, 281 assertions** — no skips beyond GD-feature gates.
2. PHPCS clean against `ArtisanPackUIStandard`.
3. PHP-CS-Fixer dry-run reports nothing to change.
4. Manual browser verification in the dev app at `/performance-test` — all four sections rendered, WebP variants (15–32 KB) replaced 1.4–1.7 MB JPEG originals via the `<picture>` source negotiation, dominant-color placeholders match the sampled photos, queue dispatch buttons wrote variants to disk.

## Accessibility Tests Run

- [x] Keyboard navigation tested (components emit standard `<img>` / `<picture>` — no custom focusable controls introduced)
- [ ] Screen reader tested (n/a — no new ARIA surface; alt text is forwarded verbatim)
- [x] Color contrast verified (dominant-color extractor rejects fully-transparent alphas so placeholders are guaranteed visible)
- [x] ARIA labels checked (no implicit aria — the components decorate, not replace, native semantics)

**Details:** Components remain semantic `<img>` / `<picture>` — accessibility surface is unchanged from native HTML. Caller-supplied `alt` text is forwarded.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `tests/Feature/Images/DominantColorExtractorTest.php` — both algorithms, config-driven algorithm selection, cache hit/skip, transparent-image fallback (GD branch pinned), error paths.
- `tests/Feature/Images/ResponsiveImageGeneratorTest.php` — size clamping, srcset composition, multi-format generation, unsupported-format skip behavior, error paths.
- `tests/Feature/View/Components/LazyImageTest.php` — every placeholder strategy, fetchpriority gating, CSS-injection regression (hex validator), 3/4/6/8-digit hex acceptance, transparent-alpha rejection, SVG blur rejection, raster-blur acceptance.
- `tests/Feature/View/Components/ResponsiveImageTest.php` — `<picture>` emission, sizes attribute forwarding, srcset URL rewriting, root-slash preservation (`dirname('/foo.jpg') === '/'`), filesystem-path-leak refusal, remote-URL bare-img degradation, generation-throws degradation.
- `tests/Feature/Jobs/ImageJobsTest.php` — queue routing + retry config, synchronous dispatch round-trip, unsupported-format silent skip, `Bus::chain` composition.

## Documentation

- [x] Inline code documentation added (PHPDoc on every public method and class — pattern matches existing package files)
- [ ] README updated (no README changes needed for this PR)
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Config additions are commented in `config/performance.php`. Every new class/method has a `@since 1.0.0` PHPDoc block consistent with the rest of the package.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests (127 / 127)
- [x] Code has been linted (PHPCS + PHP-CS-Fixer clean)
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed (three rounds of adversarial review applied — 12 findings addressed, including 2 security tightenings, a filesystem-path-leak bug, and a path-with-spaces regression)
- [x] Comments added for complex code (path/URL resolution + rewriter math carry inline comments explaining the bug each guard prevents)
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive image rendering with `<picture>` support and format-specific sources.
  * Added lazy image rendering with improved placeholders, loading behavior, and safe attribute handling.
  * Added support for generating responsive image variants, srcsets, and dominant color extraction.
  * Added queued image jobs for optimization, format conversion, and responsive size generation.

* **Bug Fixes**
  * Improved handling for unsupported image formats and unreadable sources.
  * Added safer fallbacks when responsive image generation cannot proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->