### PR TITLE
feat: HasOptimizedImages trait, ScriptManager + strategies, critical CSS (#16-#20)

### DIFF
--- a/config/performance.php
+++ b/config/performance.php
@@ -123,10 +123,12 @@ return [
 
 	'css' => [
 		'critical' => [
-			'enabled' => true,
-			'width'   => 1300,
-			'height'  => 900,
-			'cache'   => true,
+			'enabled'   => true,
+			'width'     => 1300,
+			'height'    => 900,
+			'cache'     => true,
+			'selectors' => [],
+			'sources'   => [],
 		],
 		'async_loading' => true,
 	],

--- a/resources/views/components/critical-css.blade.php
+++ b/resources/views/components/critical-css.blade.php
@@ -1,0 +1,10 @@
+{{--
+    Critical CSS component template.
+
+    Emits a `<style>` block containing the cached critical CSS for the
+    resolved route. Returns nothing when the extractor produces an empty
+    bundle so the component can be dropped unconditionally into a layout.
+--}}
+@if ( '' !== $css )
+<style data-critical="{{ $resolvedRoute }}">{!! $css !!}</style>
+@endif

--- a/src/Console/Commands/GenerateCriticalCssCommand.php
+++ b/src/Console/Commands/GenerateCriticalCssCommand.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * `perf:critical-css` artisan command.
+ *
+ * Generates critical CSS for one or more routes and warms the
+ * `CriticalCssExtractor` cache. Run via cron, deploy hook, or manually after
+ * stylesheet changes so the `@criticalCss` directive can serve from cache on
+ * every request.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Console\Commands;
+
+use ArtisanPackUI\Performance\Css\CriticalCssExtractor;
+use Illuminate\Console\Command;
+use Throwable;
+
+/**
+ * Generate critical CSS command class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+class GenerateCriticalCssCommand extends Command
+{
+	/**
+	 * The console command signature.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	protected $signature = 'perf:critical-css
+		{--route=* : Specific route name(s) to generate critical CSS for}
+		{--all : Generate critical CSS for every registered route}
+		{--force : Clear cached entries before regenerating}';
+
+	/**
+	 * The console command description.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	protected $description = 'Generate and cache critical CSS for one or more routes.';
+
+	/**
+	 * Executes the command.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  CriticalCssExtractor $extractor Resolved extractor instance.
+	 *
+	 * @return int
+	 */
+	public function handle( CriticalCssExtractor $extractor ): int
+	{
+		$routes = $this->resolveRoutes( $extractor );
+
+		if ( empty( $routes ) ) {
+			$this->warn( 'No routes selected. Pass --route=<name> (repeatable) or --all.' );
+
+			return self::SUCCESS;
+		}
+
+		if ( $this->option( 'force' ) ) {
+			$extractor->clearCache();
+		}
+
+		$generated = 0;
+		$failed    = 0;
+		$empty     = 0;
+
+		foreach ( $routes as $route ) {
+			try {
+				$css = $extractor->generate( $route );
+			} catch ( Throwable $exception ) {
+				$this->error( "fail: {$route} ({$exception->getMessage()})" );
+				$failed++;
+				continue;
+			}
+
+			if ( '' === $css ) {
+				$this->line( "skip: {$route} (no CSS produced)" );
+				$empty++;
+				continue;
+			}
+
+			// Generation skipped the cache; trigger forRoute() to warm it so
+			// subsequent requests can read straight from the cache layer.
+			$extractor->forRoute( $route );
+
+			$this->line( sprintf( 'ok:   %s (%d bytes)', $route, strlen( $css ) ) );
+			$generated++;
+		}
+
+		$this->info( "Generated {$generated}, empty {$empty}, failed {$failed}." );
+
+		return $failed > 0 ? self::FAILURE : self::SUCCESS;
+	}
+
+	/**
+	 * Resolves the routes to process.
+	 *
+	 * `--route=<name>` accepts multiple values via repeated flags. `--all`
+	 * processes every route the extractor has sources registered for.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  CriticalCssExtractor $extractor Resolved extractor instance.
+	 *
+	 * @return array<int, string>
+	 */
+	protected function resolveRoutes( CriticalCssExtractor $extractor ): array
+	{
+		$explicit = (array) $this->option( 'route' );
+		$explicit = array_values( array_filter( array_map( 'strval', $explicit ) ) );
+
+		if ( ! empty( $explicit ) ) {
+			return $explicit;
+		}
+
+		if ( ! $this->option( 'all' ) ) {
+			return [];
+		}
+
+		// Reach into the extractor to discover registered routes. We only need
+		// the set of keys, so list them via the public `sourcesFor()` accessor
+		// after pulling the configured registrations.
+		$registered = (array) config( 'artisanpack.performance.css.critical.sources', [] );
+		$routes     = array_keys( $registered );
+
+		// Application code may also register at runtime via service providers;
+		// pull from the extractor itself when it exposes the routes.
+		if ( method_exists( $extractor, 'registeredRoutes' ) ) {
+			$routes = array_merge( $routes, $extractor->registeredRoutes() );
+		}
+
+		return array_values( array_unique( array_map( 'strval', $routes ) ) );
+	}
+}

--- a/src/Css/CriticalCssExtractor.php
+++ b/src/Css/CriticalCssExtractor.php
@@ -1,0 +1,850 @@
+<?php
+
+/**
+ * Critical CSS extractor.
+ *
+ * Picks the subset of a stylesheet that an above-the-fold render needs and
+ * caches the result per route so a `@criticalCss` directive in the head can
+ * inline it without re-parsing on every request.
+ *
+ * The extractor uses a rule-based heuristic rather than a headless browser:
+ * we keep `@font-face` and `@keyframes` at-rules (they're nearly always
+ * critical), drop `@media (min-width: …)` queries that target viewports
+ * larger than the configured critical viewport, and accept rules whose
+ * selectors match a curated list of above-the-fold patterns (resets, layout
+ * shell elements, fold markers like `.hero` / `[data-critical]`). The
+ * heuristic is intentionally conservative — false positives bloat the inline
+ * style block but don't break the page, while false negatives would leave
+ * the page rendering against a partial stylesheet.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Css;
+
+use Illuminate\Contracts\Cache\Repository;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Critical CSS extractor class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+class CriticalCssExtractor
+{
+	/**
+	 * Default critical viewport width when none is configured.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var int
+	 */
+	public const DEFAULT_WIDTH = 1300;
+
+	/**
+	 * Default critical viewport height when none is configured.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var int
+	 */
+	public const DEFAULT_HEIGHT = 900;
+
+	/**
+	 * Default cache namespace for stored critical CSS.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public const CACHE_KEY_PREFIX = 'performance:critical-css:';
+
+	/**
+	 * Fallback route key used when a caller doesn't supply one.
+	 *
+	 * Consumed by both the `@criticalCss` Blade directive compiler (when the
+	 * request route is unnamed) and `generate()` (when a registered route
+	 * has no specific sources). Exposing this as a constant prevents the two
+	 * call sites from drifting apart if the sentinel ever changes.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public const DEFAULT_ROUTE = 'default';
+
+	/**
+	 * Curated selectors treated as above-the-fold by default.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array<int, string>
+	 */
+	public const DEFAULT_CRITICAL_SELECTORS = [
+		'*',
+		':root',
+		'html',
+		'body',
+		'header',
+		'nav',
+		'main',
+		'.container',
+		'.wrapper',
+		'.layout',
+		'.hero',
+		'.above-fold',
+		'.site-header',
+		'.site-nav',
+		'[data-critical]',
+		'h1',
+		'h2',
+	];
+
+	/**
+	 * At-rules whose blocks are always preserved.
+	 *
+	 * Includes both block-style at-rules (`@font-face { ... }`,
+	 * `@keyframes ...`) and body-less at-rules that terminate with `;`
+	 * (`@import url(...)`, `@charset "UTF-8"`, `@namespace ...`). All of
+	 * these are stylesheet-level declarations that affect the entire
+	 * cascade, so dropping them from the critical block would silently
+	 * break above-the-fold rendering.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array<int, string>
+	 */
+	protected const ALWAYS_PRESERVE_AT_RULES = [
+		'font-face',
+		'keyframes',
+		'supports',
+		'page',
+		'import',
+		'charset',
+		'namespace',
+		'layer',
+	];
+
+	/**
+	 * Source CSS bundles registered per route.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array<string, array<int, string>>
+	 */
+	protected array $sources = [];
+
+	/**
+	 * Optional cache override pinned at construction time.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var Repository|null
+	 */
+	protected ?Repository $cache;
+
+	/**
+	 * Creates a new extractor.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param Repository|null $cache Optional cache repository override.
+	 */
+	public function __construct( ?Repository $cache = null )
+	{
+		$this->cache = $cache;
+	}
+
+	/**
+	 * Registers a CSS source (path or raw content) for the given route.
+	 *
+	 * Use the literal `default` route name to register CSS that applies to
+	 * every route that doesn't have its own registration. Multiple sources
+	 * registered against the same route are concatenated before extraction.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $route             Route name or path key.
+	 * @param  string $cssPathOrContent  Absolute path to a CSS file, or raw CSS content.
+	 *
+	 * @return $this
+	 */
+	public function registerSource( string $route, string $cssPathOrContent ): self
+	{
+		$this->sources[ $route ] ??= [];
+		$this->sources[ $route ][]   = $cssPathOrContent;
+
+		return $this;
+	}
+
+	/**
+	 * Returns every CSS source registered against the given route.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $route Route name or path key.
+	 *
+	 * @return array<int, string>
+	 */
+	public function sourcesFor( string $route ): array
+	{
+		return $this->sources[ $route ] ?? [];
+	}
+
+	/**
+	 * Returns every route name that has at least one registered source.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	public function registeredRoutes(): array
+	{
+		return array_values( array_map( 'strval', array_keys( $this->sources ) ) );
+	}
+
+	/**
+	 * Extracts critical rules from the given raw CSS.
+	 *
+	 * Returns the subset of rules whose selectors match the critical-selector
+	 * heuristic plus every always-preserved at-rule. `@media (min-width: …)`
+	 * blocks that target viewports larger than the critical width are dropped
+	 * wholesale.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string   $css    Raw CSS content.
+	 * @param  int|null $width  Critical viewport width (defaults to config).
+	 * @param  int|null $height Critical viewport height (defaults to config).
+	 *
+	 * @return string
+	 */
+	public function extract( string $css, ?int $width = null, ?int $height = null ): string
+	{
+		$width ??= $this->configuredWidth();
+		// The height parameter is forwarded for forward-compatibility with a
+		// future viewport-aware sampling backend (e.g. a Playwright bridge).
+		// Today the heuristic only consults width because the only
+		// dimension-driven decision is "drop large `min-width` queries". We
+		// still surface `$height` in the public signature so callers don't
+		// have to rewrite their bindings when that bridge lands.
+		unset( $height );
+
+		if ( '' === trim( $css ) ) {
+			return '';
+		}
+
+		$css        = $this->stripComments( $css );
+		$tokens     = $this->tokenizeRules( $css );
+		$selectors  = $this->criticalSelectors();
+		$output     = [];
+
+		foreach ( $tokens as $token ) {
+			$preserved = $this->preserveToken( $token, $selectors, $width );
+
+			if ( null !== $preserved ) {
+				$output[] = $preserved;
+			}
+		}
+
+		return trim( implode( "\n", $output ) );
+	}
+
+	/**
+	 * Returns the cached critical CSS for the given route, generating it on miss.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $route Route name or path key.
+	 *
+	 * @return string
+	 */
+	public function forRoute( string $route ): string
+	{
+		$store = $this->cacheRepository();
+
+		if ( null === $store || ! $this->cachingEnabled() ) {
+			return $this->generate( $route );
+		}
+
+		return (string) $store->rememberForever(
+			self::CACHE_KEY_PREFIX . $route,
+			fn (): string => $this->generate( $route ),
+		);
+	}
+
+	/**
+	 * Generates critical CSS for the given route without consulting the cache.
+	 *
+	 * Concatenates every source registered for the route (and falls through to
+	 * the `default` route when none are registered) before running the rule
+	 * extractor.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $route Route name or path key.
+	 *
+	 * @return string
+	 */
+	public function generate( string $route ): string
+	{
+		$sources = $this->sources[ $route ]
+			?? $this->sources[ self::DEFAULT_ROUTE ]
+			?? [];
+
+		if ( empty( $sources ) ) {
+			return '';
+		}
+
+		$bundles = [];
+
+		foreach ( $sources as $source ) {
+			$bundles[] = $this->readSource( $source );
+		}
+
+		return $this->extract( implode( "\n", $bundles ) );
+	}
+
+	/**
+	 * Returns the inline `<style>` block for the given route.
+	 *
+	 * Returns an empty string when no critical CSS was produced so callers can
+	 * unconditionally inject the result into the document head.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $route Route name or path key.
+	 *
+	 * @return string
+	 */
+	public function inlineFor( string $route ): string
+	{
+		$css = $this->forRoute( $route );
+
+		if ( '' === $css ) {
+			return '';
+		}
+
+		return '<style data-critical="' . $this->escape( $route ) . '">' . $css . '</style>';
+	}
+
+	/**
+	 * Clears the cached critical CSS for a route, or every route when null.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string|null $route Route name or null for "every cached route".
+	 *
+	 * @return void
+	 */
+	public function clearCache( ?string $route = null ): void
+	{
+		$store = $this->cacheRepository();
+
+		if ( null === $store ) {
+			return;
+		}
+
+		if ( null === $route ) {
+			foreach ( array_keys( $this->sources ) as $registered ) {
+				$store->forget( self::CACHE_KEY_PREFIX . $registered );
+			}
+
+			return;
+		}
+
+		$store->forget( self::CACHE_KEY_PREFIX . $route );
+	}
+
+	/**
+	 * Reports whether caching is enabled in the package config.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool
+	 */
+	public function cachingEnabled(): bool
+	{
+		return (bool) config( 'artisanpack.performance.css.critical.cache', true );
+	}
+
+	/**
+	 * Reads a source string as a CSS file path or returns it as raw content.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $source Source string (path or content).
+	 *
+	 * @throws RuntimeException When the source looks like a path but cannot be read.
+	 *
+	 * @return string
+	 */
+	protected function readSource( string $source ): string
+	{
+		// Treat anything that looks like CSS (contains `{`) as raw content. A
+		// bare path can never contain `{` (it would be an invalid filename on
+		// every supported filesystem) so the discriminator is reliable.
+		if ( false !== strpos( $source, '{' ) ) {
+			return $source;
+		}
+
+		if ( ! is_file( $source ) ) {
+			throw new RuntimeException( "Critical CSS source is not readable: {$source}" );
+		}
+
+		$contents = file_get_contents( $source );
+
+		if ( false === $contents ) {
+			throw new RuntimeException( "Failed to read critical CSS source: {$source}" );
+		}
+
+		return $contents;
+	}
+
+	/**
+	 * Decides whether a tokenized rule should be preserved.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array{type: string, body: string, query?: string, selectors?: string, declarations?: string} $token       Tokenized rule.
+	 * @param  array<int, string>                                                                            $selectors  Critical selector patterns.
+	 * @param  int                                                                                           $width      Critical viewport width.
+	 *
+	 * @return string|null Preserved CSS block, or null when the token should be dropped.
+	 */
+	protected function preserveToken( array $token, array $selectors, int $width ): ?string
+	{
+		if ( 'at-rule' === $token['type'] ) {
+			return $this->preserveAtRule( $token, $selectors, $width );
+		}
+
+		if ( 'rule' === $token['type'] ) {
+			return $this->preserveRule( $token, $selectors );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Preserves an at-rule when it is in the always-preserve list or the inner
+	 * rules survive critical-selector filtering.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array{type: string, body: string, query?: string} $token     Tokenized at-rule.
+	 * @param  array<int, string>                                $selectors Critical selector patterns.
+	 * @param  int                                               $width     Critical viewport width.
+	 *
+	 * @return string|null
+	 */
+	protected function preserveAtRule( array $token, array $selectors, int $width ): ?string
+	{
+		$query = trim( (string) ( $token['query'] ?? '' ) );
+
+		$matches = [];
+
+		if ( 1 === preg_match( '/^@([a-z-]+)/i', $query, $matches ) ) {
+			$name = strtolower( $matches[1] );
+
+			if ( in_array( $name, self::ALWAYS_PRESERVE_AT_RULES, true ) ) {
+				// Body-less at-rules (`@import url(...)`, `@charset "UTF-8"`,
+				// `@namespace ...`) terminate with `;` — the tokenizer stores
+				// them with `body === ''`. Emit them in their declaration
+				// form rather than as empty blocks.
+				if ( '' === $token['body'] ) {
+					return rtrim( $query, ';' ) . ';';
+				}
+
+				return $query . ' {' . $token['body'] . '}';
+			}
+
+			if ( 'media' === $name && ! $this->mediaQueryAppliesToCritical( $query, $width ) ) {
+				return null;
+			}
+		}
+
+		$innerTokens    = $this->tokenizeRules( $token['body'] );
+		$innerPreserved = [];
+
+		foreach ( $innerTokens as $inner ) {
+			$preserved = $this->preserveToken( $inner, $selectors, $width );
+
+			if ( null !== $preserved ) {
+				$innerPreserved[] = $preserved;
+			}
+		}
+
+		if ( empty( $innerPreserved ) ) {
+			return null;
+		}
+
+		return $query . ' {' . "\n" . implode( "\n", $innerPreserved ) . "\n" . '}';
+	}
+
+	/**
+	 * Preserves a flat rule when any of its selectors matches the critical list.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array{type: string, selectors?: string, declarations?: string} $token     Tokenized rule.
+	 * @param  array<int, string>                                             $selectors Critical selector patterns.
+	 *
+	 * @return string|null
+	 */
+	protected function preserveRule( array $token, array $selectors ): ?string
+	{
+		$selectorText = trim( (string) ( $token['selectors'] ?? '' ) );
+
+		if ( '' === $selectorText ) {
+			return null;
+		}
+
+		$selectorParts = array_map( 'trim', explode( ',', $selectorText ) );
+		$kept          = [];
+
+		foreach ( $selectorParts as $selector ) {
+			if ( $this->isCriticalSelector( $selector, $selectors ) ) {
+				$kept[] = $selector;
+			}
+		}
+
+		if ( empty( $kept ) ) {
+			return null;
+		}
+
+		$declarations = trim( (string) ( $token['declarations'] ?? '' ) );
+
+		return implode( ', ', $kept ) . ' {' . $declarations . '}';
+	}
+
+	/**
+	 * Reports whether the given selector should be treated as critical.
+	 *
+	 * Matches when the selector starts with, equals, or contains any of the
+	 * critical-selector patterns as a standalone token (so `.hero` matches
+	 * `.hero .title` and `.hero` but not `.heroic`).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string             $selector Selector to test.
+	 * @param  array<int, string> $patterns Critical selector patterns.
+	 *
+	 * @return bool
+	 */
+	protected function isCriticalSelector( string $selector, array $patterns ): bool
+	{
+		foreach ( $patterns as $pattern ) {
+			if ( '' === $pattern ) {
+				continue;
+			}
+
+			if ( $selector === $pattern ) {
+				return true;
+			}
+
+			// `*` is the universal selector — match only when it appears as a
+			// standalone token. A naive `str_contains($selector, '*')` would
+			// also fire on attribute substring selectors like
+			// `[data-name*="footer"]`, sweeping clearly below-the-fold rules
+			// into the critical block. Restrict to the bare universal token
+			// or the `* + *` / `* > *` selector-of-selectors shapes by
+			// requiring `*` to sit at a combinator/edge boundary, and
+			// `continue` rather than falling through to selectorContainsToken
+			// (whose own fallback would re-introduce the same false positive).
+			if ( '*' === $pattern ) {
+				if ( 1 === preg_match( '/(?:^|[\s>+~,])\*(?:[\s>+~,]|$)/', $selector ) ) {
+					return true;
+				}
+
+				continue;
+			}
+
+			if ( $this->selectorContainsToken( $selector, $pattern ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Reports whether the selector contains the pattern as a complete token.
+	 *
+	 * "Complete token" means the pattern is bounded by start/end of string or
+	 * by a CSS combinator (` `, `>`, `+`, `~`, `,`) so `.hero` matches
+	 * `.hero .title` and `body.has-hero` but not `.heroic`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $selector Selector to test.
+	 * @param  string $pattern  Pattern fragment.
+	 *
+	 * @return bool
+	 */
+	protected function selectorContainsToken( string $selector, string $pattern ): bool
+	{
+		// Identifier-like patterns (h1, body, header, html) must be bounded by
+		// combinators/edges so the pattern `body` doesn't accept `body-text`.
+		// Class- and ID-like patterns (`.hero`, `#main`) also need a trailing
+		// boundary so `.hero` doesn't match `.heroic` — the leading `.`/`#` is
+		// only a start-of-token marker, the end is still arbitrary. Attribute
+		// selectors (`[data-critical]`) are self-bounded by the brackets.
+		$escaped       = preg_quote( $pattern, '/' );
+		$leadBoundary  = '(?:^|[\s>+~,])';
+		$trailBoundary = '(?:[\s>+~,:.\[]|$)';
+
+		if ( 1 === preg_match( '/^[a-z][a-z0-9_-]*$/i', $pattern ) ) {
+			return 1 === preg_match( '/' . $leadBoundary . $escaped . $trailBoundary . '/i', $selector );
+		}
+
+		if ( 1 === preg_match( '/^[.#][a-z][a-z0-9_-]*$/i', $pattern ) ) {
+			return 1 === preg_match( '/' . $escaped . $trailBoundary . '/i', $selector );
+		}
+
+		return str_contains( $selector, $pattern );
+	}
+
+	/**
+	 * Reports whether the given `@media` query applies to the critical viewport.
+	 *
+	 * Drops queries that target only viewports larger than the critical width
+	 * (`min-width: 1400px` for a critical width of 1300). Queries we can't
+	 * parse with confidence are kept so we never silently drop something that
+	 * matters.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $query Full `@media …` query string.
+	 * @param  int    $width Critical viewport width.
+	 *
+	 * @return bool
+	 */
+	protected function mediaQueryAppliesToCritical( string $query, int $width ): bool
+	{
+		$matches = [];
+
+		if ( 1 !== preg_match_all( '/min-width\s*:\s*(\d+)/i', $query, $matches ) ) {
+			return true;
+		}
+
+		foreach ( $matches[1] as $minWidth ) {
+			if ( (int) $minWidth <= $width ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns the configured critical viewport width.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return int
+	 */
+	protected function configuredWidth(): int
+	{
+		return (int) config( 'artisanpack.performance.css.critical.width', self::DEFAULT_WIDTH );
+	}
+
+	/**
+	 * Returns the merged critical-selector list (defaults plus config).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, string>
+	 */
+	protected function criticalSelectors(): array
+	{
+		$configured = (array) config( 'artisanpack.performance.css.critical.selectors', [] );
+		$selectors  = array_merge( self::DEFAULT_CRITICAL_SELECTORS, $configured );
+
+		return array_values( array_unique( array_filter( array_map( 'strval', $selectors ) ) ) );
+	}
+
+	/**
+	 * Strips CSS block comments.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $css Raw CSS.
+	 *
+	 * @return string
+	 */
+	protected function stripComments( string $css ): string
+	{
+		return preg_replace( '#/\*[\s\S]*?\*/#', '', $css ) ?? $css;
+	}
+
+	/**
+	 * Tokenizes CSS into a flat list of `rule` and `at-rule` entries.
+	 *
+	 * Hand-rolled to avoid a CSS parser dependency. Supports nested at-rules
+	 * (e.g. `@media { .foo {} }`) by walking the source character-by-character
+	 * and tracking brace depth — the body of an at-rule is the substring
+	 * between its first `{` and the matching `}`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $css Raw CSS.
+	 *
+	 * @return array<int, array{type: string, body: string, query?: string, selectors?: string, declarations?: string}>
+	 */
+	protected function tokenizeRules( string $css ): array
+	{
+		$tokens   = [];
+		$cursor   = 0;
+		$length   = strlen( $css );
+		$prefix   = '';
+
+		while ( $cursor < $length ) {
+			$char = $css[ $cursor ];
+
+			if ( '{' === $char ) {
+				$body   = $this->captureBalancedBody( $css, $cursor, $length );
+				$head   = trim( $prefix );
+				$prefix = '';
+
+				if ( '' === $head ) {
+					continue;
+				}
+
+				if ( '@' === $head[0] ) {
+					$tokens[] = [
+						'type'  => 'at-rule',
+						'query' => $head,
+						'body'  => $body,
+					];
+				} else {
+					$tokens[] = [
+						'type'         => 'rule',
+						'selectors'    => $head,
+						'declarations' => $body,
+						'body'         => $body,
+					];
+				}
+
+				continue;
+			}
+
+			if ( ';' === $char ) {
+				$head = trim( $prefix );
+
+				// Body-less at-rules (`@import url(...)`, `@charset "UTF-8"`,
+				// `@namespace ...`) terminate with `;` instead of `{ ... }`.
+				// Emit them as standalone at-rules so the `;` doesn't pollute
+				// the head of the next rule that follows. Falling through here
+				// would concatenate `@import url(x.css)` with the next
+				// selector and yield invalid CSS.
+				if ( '' !== $head && '@' === $head[0] ) {
+					$tokens[] = [
+						'type'  => 'at-rule',
+						'query' => $head,
+						'body'  => '',
+					];
+				}
+
+				$cursor++;
+				$prefix = '';
+				continue;
+			}
+
+			$prefix .= $char;
+			$cursor++;
+		}
+
+		return $tokens;
+	}
+
+	/**
+	 * Captures the body of a brace-balanced block starting at the current cursor.
+	 *
+	 * Assumes `$css[$cursor]` is `{`. Advances `$cursor` to one past the
+	 * matching `}` and returns the inner contents. Falls back to capturing
+	 * to end-of-string when no matching brace exists (malformed CSS).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $css    Raw CSS.
+	 * @param  int    $cursor Reference to the cursor position.
+	 * @param  int    $length Source length cache.
+	 *
+	 * @return string
+	 */
+	protected function captureBalancedBody( string $css, int &$cursor, int $length ): string
+	{
+		$depth = 0;
+		$start = $cursor + 1;
+
+		while ( $cursor < $length ) {
+			$char = $css[ $cursor ];
+
+			if ( '{' === $char ) {
+				$depth++;
+			} elseif ( '}' === $char ) {
+				$depth--;
+
+				if ( 0 === $depth ) {
+					$body = substr( $css, $start, $cursor - $start );
+					$cursor++;
+
+					return $body;
+				}
+			}
+
+			$cursor++;
+		}
+
+		return substr( $css, $start );
+	}
+
+	/**
+	 * Returns the cache repository the extractor should use.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return Repository|null
+	 */
+	protected function cacheRepository(): ?Repository
+	{
+		if ( null !== $this->cache ) {
+			return $this->cache;
+		}
+
+		if ( ! function_exists( 'cache' ) ) {
+			return null;
+		}
+
+		try {
+			return cache()->store();
+		} catch ( Throwable ) {
+			return null;
+		}
+	}
+
+	/**
+	 * HTML-escapes the given value for safe interpolation into attribute syntax.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $value Caller-supplied value.
+	 *
+	 * @return string
+	 */
+	protected function escape( string $value ): string
+	{
+		return htmlspecialchars( $value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8' );
+	}
+}

--- a/src/JavaScript/AbstractScriptStrategy.php
+++ b/src/JavaScript/AbstractScriptStrategy.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * Shared base for script loading strategies.
+ *
+ * Centralizes the attribute-escaping and `data-load-on`/`data-target` emission
+ * so the concrete strategies stay focused on the loading semantic they encode.
+ * Attribute values are HTML-escaped before composition so callers can pass
+ * user-controlled data (script names, target selectors) into the registration
+ * builder without opening an XSS hole when the rendered HTML is echoed into
+ * a Blade layout.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\JavaScript;
+
+/**
+ * Shared base for script loading strategies.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+abstract class AbstractScriptStrategy implements ScriptStrategy
+{
+	/**
+	 * Returns the strategy's canonical name.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	abstract public function name(): string;
+
+	/**
+	 * Renders the registration to an HTML `<script>` element.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  ScriptRegistration $script The script registration to render.
+	 *
+	 * @return string
+	 */
+	abstract public function render( ScriptRegistration $script ): string;
+
+	/**
+	 * Returns the additional attributes shared by every external strategy.
+	 *
+	 * Conditional-loading hints (`data-load-on`, `data-target`) and arbitrary
+	 * attributes attached via `ScriptRegistration::attribute()` are emitted
+	 * here so each concrete strategy only owns its loading-semantic attribute.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  ScriptRegistration $script The registration being rendered.
+	 *
+	 * @return string Pre-spaced attribute string (empty when there are none).
+	 */
+	protected function sharedAttributes( ScriptRegistration $script ): string
+	{
+		$parts = [];
+
+		if ( ! empty( $script->loadOn ) ) {
+			$parts[] = 'data-load-on="' . $this->escape( implode( ' ', $script->loadOn ) ) . '"';
+		}
+
+		if ( null !== $script->target && '' !== $script->target ) {
+			$parts[] = 'data-target="' . $this->escape( $script->target ) . '"';
+		}
+
+		if ( null !== $script->name && '' !== $script->name ) {
+			$parts[] = 'data-script-name="' . $this->escape( $script->name ) . '"';
+		}
+
+		foreach ( $script->attributes as $name => $value ) {
+			if ( ! $this->isSafeAttributeName( $name ) ) {
+				continue;
+			}
+
+			$parts[] = $this->escape( $name ) . '="' . $this->escape( $value ) . '"';
+		}
+
+		return empty( $parts ) ? '' : ' ' . implode( ' ', $parts );
+	}
+
+	/**
+	 * HTML-escapes the given value for safe interpolation into attribute syntax.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $value Caller-supplied value.
+	 *
+	 * @return string
+	 */
+	protected function escape( string $value ): string
+	{
+		return htmlspecialchars( $value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8' );
+	}
+
+	/**
+	 * Reports whether the given string is a syntactically valid HTML attribute name.
+	 *
+	 * Restricts to ASCII letters, digits, dashes, and underscores so malicious
+	 * attribute names (`onclick`, `"><script>`, …) can't be smuggled through
+	 * the arbitrary-attribute escape hatch.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $name Attribute name.
+	 *
+	 * @return bool
+	 */
+	protected function isSafeAttributeName( string $name ): bool
+	{
+		return 1 === preg_match( '/^[A-Za-z_][A-Za-z0-9_-]*$/', $name );
+	}
+}

--- a/src/JavaScript/AsyncStrategy.php
+++ b/src/JavaScript/AsyncStrategy.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Async script loading strategy.
+ *
+ * Emits `<script src="..." async></script>`. Browsers download the file in
+ * parallel with HTML parsing and execute it as soon as the download finishes
+ * — execution order between async scripts is not guaranteed. Reserve for
+ * independent scripts (analytics, third-party widgets) that don't depend on
+ * each other or on the rest of the application bundle.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\JavaScript;
+
+/**
+ * Async script loading strategy.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+class AsyncStrategy extends AbstractScriptStrategy
+{
+	/**
+	 * Returns the strategy's canonical name.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function name(): string
+	{
+		return 'async';
+	}
+
+	/**
+	 * Renders the registration as `<script src="..." async></script>`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  ScriptRegistration $script The registration to render.
+	 *
+	 * @return string
+	 */
+	public function render( ScriptRegistration $script ): string
+	{
+		return sprintf(
+			'<script src="%s" async%s></script>',
+			$this->escape( $script->src ),
+			$this->sharedAttributes( $script ),
+		);
+	}
+}

--- a/src/JavaScript/DeferStrategy.php
+++ b/src/JavaScript/DeferStrategy.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Defer script loading strategy.
+ *
+ * Emits `<script src="..." defer></script>`. Browsers download the file in
+ * parallel with HTML parsing and execute it after parsing completes, in the
+ * order the scripts appear in the document — the right default for most
+ * application scripts that depend on the DOM but don't need to block render.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\JavaScript;
+
+/**
+ * Defer script loading strategy.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+class DeferStrategy extends AbstractScriptStrategy
+{
+	/**
+	 * Returns the strategy's canonical name.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function name(): string
+	{
+		return 'defer';
+	}
+
+	/**
+	 * Renders the registration as `<script src="..." defer></script>`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  ScriptRegistration $script The registration to render.
+	 *
+	 * @return string
+	 */
+	public function render( ScriptRegistration $script ): string
+	{
+		return sprintf(
+			'<script src="%s" defer%s></script>',
+			$this->escape( $script->src ),
+			$this->sharedAttributes( $script ),
+		);
+	}
+}

--- a/src/JavaScript/InlineStrategy.php
+++ b/src/JavaScript/InlineStrategy.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Inline script loading strategy.
+ *
+ * Emits `<script>...body...</script>` for the registration's inline content
+ * (set via `ScriptRegistration::inline($body)`). Reserve for tiny, critical
+ * scripts where the network round-trip outweighs the bytes — large inline
+ * blobs defeat HTTP caching and add to first-paint cost.
+ *
+ * The inline body is rendered verbatim; callers MUST ensure it is trusted
+ * content they own (string literals in their codebase, build artifacts), not
+ * user-controlled input. Inlining user-supplied content would constitute an
+ * XSS sink. The `</script>` end-tag sequence is escaped at render time so
+ * accidentally-bundled markup can't break out of the script block.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\JavaScript;
+
+/**
+ * Inline script loading strategy.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+class InlineStrategy extends AbstractScriptStrategy
+{
+	/**
+	 * Returns the strategy's canonical name.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function name(): string
+	{
+		return 'inline';
+	}
+
+	/**
+	 * Renders the registration as `<script>...inlineContent...</script>`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  ScriptRegistration $script The registration to render.
+	 *
+	 * @return string
+	 */
+	public function render( ScriptRegistration $script ): string
+	{
+		return sprintf(
+			'<script%s>%s</script>',
+			$this->sharedAttributes( $script ),
+			$this->escapeInlineBody( $script->inlineContent ),
+		);
+	}
+
+	/**
+	 * Escapes the inline body so it cannot break out of the `<script>` block.
+	 *
+	 * Only the `</script` sequence is dangerous in an HTML `<script>` body —
+	 * everything else is treated as JS source by the parser. Escaping the `<`
+	 * (rather than the `/`) keeps the runtime JS semantically equivalent
+	 * (`<\/script>` is still parsed as `</script>` by the JS engine) while
+	 * preventing the HTML parser from closing the tag early.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $body Inline script body.
+	 *
+	 * @return string
+	 */
+	protected function escapeInlineBody( string $body ): string
+	{
+		return preg_replace( '#</(script)#i', '<\\/$1', $body ) ?? '';
+	}
+}

--- a/src/JavaScript/ModuleStrategy.php
+++ b/src/JavaScript/ModuleStrategy.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * ES module script loading strategy.
+ *
+ * Emits `<script type="module" src="..."></script>`. Browsers download the
+ * module in parallel with HTML parsing and execute it after parsing completes
+ * (module scripts are defer-by-default per the HTML spec). Use for modern ES
+ * module entry points.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\JavaScript;
+
+/**
+ * ES module script loading strategy.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+class ModuleStrategy extends AbstractScriptStrategy
+{
+	/**
+	 * Returns the strategy's canonical name.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function name(): string
+	{
+		return 'module';
+	}
+
+	/**
+	 * Renders the registration as `<script type="module" src="..."></script>`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  ScriptRegistration $script The registration to render.
+	 *
+	 * @return string
+	 */
+	public function render( ScriptRegistration $script ): string
+	{
+		return sprintf(
+			'<script type="module" src="%s"%s></script>',
+			$this->escape( $script->src ),
+			$this->sharedAttributes( $script ),
+		);
+	}
+}

--- a/src/JavaScript/ScriptManager.php
+++ b/src/JavaScript/ScriptManager.php
@@ -1,0 +1,267 @@
+<?php
+
+/**
+ * Script manager service.
+ *
+ * Central registry for application JavaScript. Callers register scripts via
+ * the fluent `ScriptRegistration` builder (typically `Performance::script($src)`)
+ * and the manager keeps them in registration order while exposing them in
+ * priority order for rendering. Strategy resolution is pluggable: every
+ * registered strategy is looked up by name when `render()` builds the HTML
+ * block, so applications can override or extend the four bundled strategies.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\JavaScript;
+
+use RuntimeException;
+
+/**
+ * Script manager service.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+class ScriptManager
+{
+	/**
+	 * Registered scripts in insertion order.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array<int, ScriptRegistration>
+	 */
+	protected array $scripts = [];
+
+	/**
+	 * Strategy renderers keyed by canonical name.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array<string, ScriptStrategy>
+	 */
+	protected array $strategies;
+
+	/**
+	 * Creates a new script manager seeded with the four bundled strategies.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<int, ScriptStrategy>|null $strategies Optional strategy overrides. When null the four
+	 *                                                    bundled strategies (defer/async/module/inline) are
+	 *                                                    registered.
+	 */
+	public function __construct( ?array $strategies = null )
+	{
+		$this->strategies = [];
+
+		$bundled = $strategies ?? [
+			new DeferStrategy(),
+			new AsyncStrategy(),
+			new ModuleStrategy(),
+			new InlineStrategy(),
+		];
+
+		foreach ( $bundled as $strategy ) {
+			$this->registerStrategy( $strategy );
+		}
+	}
+
+	/**
+	 * Registers a script source and returns its fluent registration.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $src Script source URL or path. Pass any placeholder for `inline` scripts.
+	 *
+	 * @return ScriptRegistration
+	 */
+	public function register( string $src ): ScriptRegistration
+	{
+		$registration    = new ScriptRegistration( $src );
+		$this->scripts[] = $registration;
+
+		return $registration;
+	}
+
+	/**
+	 * Registers (or replaces) a strategy renderer.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  ScriptStrategy $strategy Strategy instance.
+	 *
+	 * @return void
+	 */
+	public function registerStrategy( ScriptStrategy $strategy ): void
+	{
+		$this->strategies[ strtolower( $strategy->name() ) ] = $strategy;
+	}
+
+	/**
+	 * Returns every registered script in priority order.
+	 *
+	 * Lower priorities render first. Registrations sharing a priority preserve
+	 * their relative insertion order so the result is deterministic.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, ScriptRegistration>
+	 */
+	public function all(): array
+	{
+		$indexed = [];
+
+		foreach ( $this->scripts as $index => $script ) {
+			$indexed[] = [ 'order' => $index, 'script' => $script ];
+		}
+
+		usort(
+			$indexed,
+			static function ( array $a, array $b ): int {
+				if ( $a['script']->priority === $b['script']->priority ) {
+					return $a['order'] <=> $b['order'];
+				}
+
+				return $a['script']->priority <=> $b['script']->priority;
+			},
+		);
+
+		return array_map( static fn ( array $entry ): ScriptRegistration => $entry['script'], $indexed );
+	}
+
+	/**
+	 * Returns the registration with the given handle name.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $name Handle assigned via `ScriptRegistration::name()`.
+	 *
+	 * @return ScriptRegistration|null
+	 */
+	public function find( string $name ): ?ScriptRegistration
+	{
+		foreach ( $this->scripts as $script ) {
+			if ( $script->name === $name ) {
+				return $script;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns true when at least one script has been registered.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool
+	 */
+	public function hasScripts(): bool
+	{
+		return ! empty( $this->scripts );
+	}
+
+	/**
+	 * Renders every registered script to a newline-joined HTML block.
+	 *
+	 * Registrations whose strategy isn't known are skipped silently so
+	 * application code never explodes when a strategy is renamed or removed
+	 * mid-deploy. Strict callers can introspect `all()` and call
+	 * `renderOne()` themselves to fail loudly.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function render(): string
+	{
+		$html = [];
+
+		foreach ( $this->all() as $script ) {
+			$strategy = $this->resolveStrategy( $script->strategy() );
+
+			if ( null === $strategy ) {
+				continue;
+			}
+
+			$html[] = $strategy->render( $script );
+		}
+
+		return implode( "\n", $html );
+	}
+
+	/**
+	 * Renders a single registration, throwing when its strategy is unknown.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  ScriptRegistration $script Registration to render.
+	 *
+	 * @throws RuntimeException When no strategy matches the registration.
+	 *
+	 * @return string
+	 */
+	public function renderOne( ScriptRegistration $script ): string
+	{
+		$name     = $script->strategy();
+		$strategy = $this->resolveStrategy( $name );
+
+		if ( null === $strategy ) {
+			throw new RuntimeException( "No script strategy registered for '{$name}'." );
+		}
+
+		return $strategy->render( $script );
+	}
+
+	/**
+	 * Removes every registered script.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function clear(): void
+	{
+		$this->scripts = [];
+	}
+
+	/**
+	 * Returns the strategy renderers keyed by canonical name.
+	 *
+	 * Exposed primarily for tests and applications that want to introspect
+	 * the strategy registry without invoking `render()`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, ScriptStrategy>
+	 */
+	public function strategies(): array
+	{
+		return $this->strategies;
+	}
+
+	/**
+	 * Resolves a strategy by name.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $name Strategy name.
+	 *
+	 * @return ScriptStrategy|null
+	 */
+	protected function resolveStrategy( string $name ): ?ScriptStrategy
+	{
+		return $this->strategies[ strtolower( $name ) ] ?? null;
+	}
+}

--- a/src/JavaScript/ScriptRegistration.php
+++ b/src/JavaScript/ScriptRegistration.php
@@ -1,0 +1,325 @@
+<?php
+
+/**
+ * Script registration descriptor.
+ *
+ * Fluent builder returned by `ScriptManager::register()` (and `Performance::script()`).
+ * Holds the source URL, loading strategy, priority, optional name, inline
+ * body, and conditional-loading hints. Doesn't render HTML itself — the
+ * configured strategy is responsible for that — so the descriptor stays
+ * cheap to construct, serialize, and inspect in tests.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\JavaScript;
+
+/**
+ * Script registration descriptor.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+class ScriptRegistration
+{
+	/**
+	 * Default priority assigned to scripts that don't call `priority()`.
+	 *
+	 * Mirrors WordPress's `wp_enqueue_script` default so the values feel
+	 * familiar to anyone coming from the WP ecosystem (lower = earlier).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var int
+	 */
+	public const DEFAULT_PRIORITY = 10;
+
+	/**
+	 * Resolved strategy name (`defer`, `async`, `module`, `inline`).
+	 *
+	 * Null until either an explicit setter (`defer()`, `async()`, …) pins it
+	 * or `strategy()` is called and lazily resolves the configured default.
+	 * Lazy resolution matters because registrations can be built during a
+	 * sibling provider's `register()` phase — before `PerformanceServiceProvider::boot()`
+	 * has merged the package's config — so a constructor-time read of
+	 * `artisanpack.performance.javascript.default_strategy` would always
+	 * miss user overrides.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string|null
+	 */
+	public ?string $strategy = null;
+
+	/**
+	 * Priority used to order scripts when rendering.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var int
+	 */
+	public int $priority = self::DEFAULT_PRIORITY;
+
+	/**
+	 * Optional name used as a lookup handle.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string|null
+	 */
+	public ?string $name = null;
+
+	/**
+	 * Conditional-loading triggers (e.g. `interaction`, `visible`, `idle`).
+	 *
+	 * Emitted as `data-load-on="..."` so application JS can pick up the hint.
+	 * Empty when no conditional loading is configured.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array<int, string>
+	 */
+	public array $loadOn = [];
+
+	/**
+	 * Optional CSS selector used by conditional loaders.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string|null
+	 */
+	public ?string $target = null;
+
+	/**
+	 * Inline body when the registration uses the `inline` strategy.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public string $inlineContent = '';
+
+	/**
+	 * Extra `<script>` attributes appended verbatim during rendering.
+	 *
+	 * Values are escaped so callers can pass user-supplied input safely; keys
+	 * are restricted to a conservative attribute-name pattern.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array<string, string>
+	 */
+	public array $attributes = [];
+
+	/**
+	 * Creates a new registration.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $src The script source URL or path. Ignored when `inline` is used.
+	 */
+	public function __construct( public string $src )
+	{
+		// Strategy is intentionally NOT resolved here — see the docblock on
+		// $strategy for why. `strategy()` performs the lazy lookup on first read.
+	}
+
+	/**
+	 * Returns the resolved strategy name, lazily reading config on first call.
+	 *
+	 * Explicit calls to `defer()`/`async()`/`module()`/`inline()` short-circuit
+	 * this lookup since they pin `$strategy` directly.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function strategy(): string
+	{
+		if ( null === $this->strategy ) {
+			$default        = (string) config( 'artisanpack.performance.javascript.default_strategy', 'defer' );
+			$this->strategy = strtolower( $default );
+		}
+
+		return $this->strategy;
+	}
+
+	/**
+	 * Assigns a lookup handle for the registration.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $name Handle name.
+	 *
+	 * @return $this
+	 */
+	public function name( string $name ): self
+	{
+		$this->name = $name;
+
+		return $this;
+	}
+
+	/**
+	 * Switches the strategy to `defer`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return $this
+	 */
+	public function defer(): self
+	{
+		$this->strategy = 'defer';
+
+		return $this;
+	}
+
+	/**
+	 * Switches the strategy to `async`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return $this
+	 */
+	public function async(): self
+	{
+		$this->strategy = 'async';
+
+		return $this;
+	}
+
+	/**
+	 * Switches the strategy to `module` (ES module).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return $this
+	 */
+	public function module(): self
+	{
+		$this->strategy = 'module';
+
+		return $this;
+	}
+
+	/**
+	 * Switches the strategy to `inline` and optionally captures the body.
+	 *
+	 * The `src` already attached to the registration is preserved (renderers
+	 * ignore it for inline scripts) so the caller can toggle between strategies
+	 * without losing the original URL.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string|null $content Optional inline body. Pass null to set the strategy without overwriting an existing body.
+	 *
+	 * @return $this
+	 */
+	public function inline( ?string $content = null ): self
+	{
+		$this->strategy = 'inline';
+
+		if ( null !== $content ) {
+			$this->inlineContent = $content;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Sets the rendering priority. Lower values render first.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  int $priority Priority value.
+	 *
+	 * @return $this
+	 */
+	public function priority( int $priority ): self
+	{
+		$this->priority = $priority;
+
+		return $this;
+	}
+
+	/**
+	 * Sets conditional-loading triggers.
+	 *
+	 * Accepts a single trigger string, a list, or multiple positional
+	 * arguments — `loadOn('interaction')`, `loadOn(['click', 'visible'])`, and
+	 * `loadOn('click', 'visible')` all yield the same registration.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, string>|string $triggers          First trigger, or an array of triggers.
+	 * @param  string                    ...$additional     Additional triggers.
+	 *
+	 * @return $this
+	 */
+	public function loadOn( string|array $triggers, string ...$additional ): self
+	{
+		$normalized = is_array( $triggers ) ? $triggers : [ $triggers ];
+		$normalized = array_merge( $normalized, $additional );
+
+		$this->loadOn = array_values( array_filter( array_map(
+			static fn ( string $trigger ): string => strtolower( trim( $trigger ) ),
+			$normalized,
+		) ) );
+
+		return $this;
+	}
+
+	/**
+	 * Sets the CSS selector used by conditional loaders.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $selector CSS selector.
+	 *
+	 * @return $this
+	 */
+	public function target( string $selector ): self
+	{
+		$this->target = $selector;
+
+		return $this;
+	}
+
+	/**
+	 * Attaches an arbitrary `<script>` attribute (e.g. `integrity`, `crossorigin`).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $name  Attribute name.
+	 * @param  string $value Attribute value.
+	 *
+	 * @return $this
+	 */
+	public function attribute( string $name, string $value ): self
+	{
+		$this->attributes[ $name ] = $value;
+
+		return $this;
+	}
+
+	/**
+	 * Reports whether the registration uses the inline strategy.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool
+	 */
+	public function isInline(): bool
+	{
+		return 'inline' === $this->strategy();
+	}
+}

--- a/src/JavaScript/ScriptStrategy.php
+++ b/src/JavaScript/ScriptStrategy.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Script loading strategy contract.
+ *
+ * Every concrete strategy describes how a single `ScriptRegistration` should
+ * be rendered into HTML — defer attribute, async attribute, module type, or
+ * inline body. `ScriptManager` resolves a strategy by name when rendering so
+ * registrations stay decoupled from their final HTML representation and
+ * applications can swap in their own strategies via the manager's resolver.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\JavaScript;
+
+/**
+ * Script loading strategy contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+interface ScriptStrategy
+{
+	/**
+	 * Returns the strategy's canonical name (`defer`, `async`, `module`, `inline`).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function name(): string;
+
+	/**
+	 * Renders the given registration to an HTML `<script>` element.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  ScriptRegistration $script The script registration to render.
+	 *
+	 * @return string
+	 */
+	public function render( ScriptRegistration $script ): string;
+}

--- a/src/PerformanceServiceProvider.php
+++ b/src/PerformanceServiceProvider.php
@@ -20,14 +20,19 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Performance;
 
+use ArtisanPackUI\Performance\Console\Commands\GenerateCriticalCssCommand;
 use ArtisanPackUI\Performance\Console\Commands\GenerateWebPCommand;
+use ArtisanPackUI\Performance\Css\CriticalCssExtractor;
 use ArtisanPackUI\Performance\Images\DominantColorExtractor;
 use ArtisanPackUI\Performance\Images\ResponsiveImageGenerator;
+use ArtisanPackUI\Performance\JavaScript\ScriptManager;
 use ArtisanPackUI\Performance\Services\Image\FormatConverter;
 use ArtisanPackUI\Performance\Services\ImageService;
 use ArtisanPackUI\Performance\Services\PerformanceService;
+use ArtisanPackUI\Performance\View\Components\CriticalCss;
 use ArtisanPackUI\Performance\View\Components\LazyImage;
 use ArtisanPackUI\Performance\View\Components\ResponsiveImage;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -77,8 +82,21 @@ class PerformanceServiceProvider extends ServiceProvider
 			return new ResponsiveImageGenerator( $app->make( ImageService::class ) );
 		} );
 
+		$this->app->singleton( ScriptManager::class, function () {
+			return new ScriptManager();
+		} );
+
+		$this->app->singleton( CriticalCssExtractor::class, function () {
+			return new CriticalCssExtractor();
+		} );
+
 		$this->app->singleton( 'performance', function ( $app ) {
-			return new PerformanceService( $app->make( ImageService::class ) );
+			return new PerformanceService(
+				$app->make( ImageService::class ),
+				null,
+				$app->make( ScriptManager::class ),
+				$app->make( CriticalCssExtractor::class ),
+			);
 		} );
 
 		$this->app->singleton( PerformanceService::class, function ( $app ) {
@@ -99,6 +117,8 @@ class PerformanceServiceProvider extends ServiceProvider
 		$this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
 		$this->loadViewsFrom( __DIR__ . '/../resources/views', 'performance' );
 		$this->loadBladeComponents();
+		$this->registerBladeDirectives();
+		$this->registerCriticalCssSources();
 		$this->registerEventListeners();
 		$this->registerCommands();
 		$this->publishConfiguration();
@@ -120,6 +140,7 @@ class PerformanceServiceProvider extends ServiceProvider
 		$this->loadViewComponentsAs( 'perf', [
 			LazyImage::class,
 			ResponsiveImage::class,
+			CriticalCss::class,
 		] );
 	}
 
@@ -135,7 +156,71 @@ class PerformanceServiceProvider extends ServiceProvider
 		if ( $this->app->runningInConsole() ) {
 			$this->commands( [
 				GenerateWebPCommand::class,
+				GenerateCriticalCssCommand::class,
 			] );
+		}
+	}
+
+	/**
+	 * Registers the package's Blade directives.
+	 *
+	 * `@criticalCss` resolves the current route name (falling back to
+	 * `default` when none is named) and emits the cached critical-CSS
+	 * `<style>` block produced by `CriticalCssExtractor`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function registerBladeDirectives(): void
+	{
+		Blade::directive( 'criticalCss', function ( string $expression ): string {
+			$argument = trim( $expression );
+
+			if ( '' === $argument ) {
+				$argument = 'null';
+			}
+
+			// Route-name fallback uses CriticalCssExtractor::DEFAULT_ROUTE so
+			// the sentinel stays in lockstep with the extractor's own
+			// `generate()` fallback. Hardcoding the literal here would let
+			// the two call sites drift if the sentinel ever changes.
+			return sprintf(
+				'<?php echo app(%s)->inlineFor(%s ?? (request()->route()?->getName() ?? %s)); ?>',
+				CriticalCssExtractor::class . '::class',
+				$argument,
+				var_export( CriticalCssExtractor::DEFAULT_ROUTE, true ),
+			);
+		} );
+	}
+
+	/**
+	 * Registers critical CSS sources declared in package config.
+	 *
+	 * Reads `artisanpack.performance.css.critical.sources` (a map of
+	 * `route => path-or-content` or `route => [paths-or-contents]`) and feeds
+	 * each entry into the singleton extractor so application service providers
+	 * don't have to wire registration themselves for static, config-driven
+	 * setups.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function registerCriticalCssSources(): void
+	{
+		$sources = (array) config( 'artisanpack.performance.css.critical.sources', [] );
+
+		if ( empty( $sources ) ) {
+			return;
+		}
+
+		$extractor = $this->app->make( CriticalCssExtractor::class );
+
+		foreach ( $sources as $route => $entries ) {
+			foreach ( (array) $entries as $entry ) {
+				$extractor->registerSource( (string) $route, (string) $entry );
+			}
 		}
 	}
 

--- a/src/Services/PerformanceService.php
+++ b/src/Services/PerformanceService.php
@@ -20,7 +20,10 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Performance\Services;
 
+use ArtisanPackUI\Performance\Css\CriticalCssExtractor;
 use ArtisanPackUI\Performance\Images\ResponsiveImageGenerator;
+use ArtisanPackUI\Performance\JavaScript\ScriptManager;
+use ArtisanPackUI\Performance\JavaScript\ScriptRegistration;
 use Closure;
 use RuntimeException;
 
@@ -55,19 +58,49 @@ class PerformanceService
 	protected ?ResponsiveImageGenerator $responsiveImages = null;
 
 	/**
+	 * Script manager service (lazily instantiated when first accessed).
+	 *
+	 * Defaulted to `null` so subclasses that touch the property before
+	 * `parent::__construct()` runs don't trip the typed-property-uninitialized
+	 * AccessError — matches the convention used by `$responsiveImages` above.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var ScriptManager|null
+	 */
+	protected ?ScriptManager $scripts = null;
+
+	/**
+	 * Critical CSS extractor (lazily instantiated when first accessed).
+	 *
+	 * Defaulted to `null` for the same reason as `$scripts`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var CriticalCssExtractor|null
+	 */
+	protected ?CriticalCssExtractor $criticalCss = null;
+
+	/**
 	 * Creates a new performance service.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @param ImageService|null             $images           Optional image service override.
 	 * @param ResponsiveImageGenerator|null $responsiveImages Optional responsive generator override.
+	 * @param ScriptManager|null            $scripts          Optional script manager override.
+	 * @param CriticalCssExtractor|null     $criticalCss      Optional critical CSS extractor override.
 	 */
 	public function __construct(
 		?ImageService $images = null,
 		?ResponsiveImageGenerator $responsiveImages = null,
+		?ScriptManager $scripts = null,
+		?CriticalCssExtractor $criticalCss = null,
 	) {
 		$this->images           = $images ?? new ImageService();
 		$this->responsiveImages = $responsiveImages;
+		$this->scripts          = $scripts;
+		$this->criticalCss      = $criticalCss;
 	}
 
 	/**
@@ -210,20 +243,65 @@ class PerformanceService
 	}
 
 	/**
-	 * Registers a script with the package's script manager.
-	 *
-	 * Phase 1 returns an empty array so callers can't couple to a fabricated
-	 * shape. Phase 3 will swap the return type to a fluent ScriptBuilder.
+	 * Returns the script manager, instantiating one on first access.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $src The script source URL or path.
-	 *
-	 * @return array<string, mixed> A descriptor for the registered script.
+	 * @return ScriptManager
 	 */
-	public function script( string $src ): array
+	public function scripts(): ScriptManager
 	{
-		return [];
+		return $this->scripts ??= new ScriptManager();
+	}
+
+	/**
+	 * Returns the critical CSS extractor, instantiating one on first access.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return CriticalCssExtractor
+	 */
+	public function criticalCss(): CriticalCssExtractor
+	{
+		return $this->criticalCss ??= new CriticalCssExtractor();
+	}
+
+	/**
+	 * Registers a script with the script manager and returns its registration.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $src Script source URL or path.
+	 *
+	 * @return ScriptRegistration
+	 */
+	public function script( string $src ): ScriptRegistration
+	{
+		return $this->scripts()->register( $src );
+	}
+
+	/**
+	 * Returns every registered script in priority order.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, ScriptRegistration>
+	 */
+	public function getScripts(): array
+	{
+		return $this->scripts()->all();
+	}
+
+	/**
+	 * Renders every registered script to an HTML block.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function renderScripts(): string
+	{
+		return $this->scripts()->render();
 	}
 
 	/**

--- a/src/Traits/HasOptimizedImages.php
+++ b/src/Traits/HasOptimizedImages.php
@@ -1,0 +1,532 @@
+<?php
+
+/**
+ * `HasOptimizedImages` Eloquent trait.
+ *
+ * Adds the model-level image optimization surface that complements the
+ * package's image service: callers declare which attributes hold image paths
+ * (and how to optimize them) on the model and then read URLs, srcsets, and
+ * dominant colors back through a small handful of helpers.
+ *
+ * Models opt in by `use`-ing the trait and overriding `optimizableImages()`
+ * with a map keyed by attribute name. Each entry may carry:
+ *  - `sizes`                  array<int> Widths to generate (defaults to package config).
+ *  - `formats`                array<string> Format keys (defaults to enabled formats).
+ *  - `quality`                int  Override quality for every produced format.
+ *  - `extract_dominant_color` bool Whether `getImageDominantColor()` returns a value.
+ *  - `auto_optimize`          bool Dispatch `OptimizeImageJob` on save when the attribute changes.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Traits;
+
+use ArtisanPackUI\Performance\Images\ResponsiveImageGenerator;
+use ArtisanPackUI\Performance\Jobs\OptimizeImageJob;
+use ArtisanPackUI\Performance\Services\ImageService;
+use Throwable;
+
+/**
+ * `HasOptimizedImages` Eloquent trait.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+trait HasOptimizedImages
+{
+	/**
+	 * Boots the trait.
+	 *
+	 * Wires the `saved` model event to dispatch `OptimizeImageJob` for every
+	 * `auto_optimize`-enabled attribute that changed since the last save.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public static function bootHasOptimizedImages(): void
+	{
+		static::saved( function ( $model ): void {
+			$model->autoOptimizeChangedImages();
+		} );
+	}
+
+	/**
+	 * Returns the optimized variant URL for the given field/format/size.
+	 *
+	 * Resolves the attribute value (web path or filesystem path), generates the
+	 * resized + format-converted variant on demand, and returns the URL the
+	 * browser can fetch. Returns `null` when the attribute is empty, not a
+	 * declared field, the file can't be resolved on disk, or the active driver
+	 * cannot produce the requested format.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $field  Attribute name (must appear in `optimizableImages()`).
+	 * @param  string $format Target format key (`webp`, `avif`, …).
+	 * @param  int    $size   Target width in pixels.
+	 *
+	 * @return string|null
+	 */
+	public function getOptimizedImageUrl( string $field, string $format, int $size ): ?string
+	{
+		$config = $this->resolveImageConfig( $field );
+
+		if ( null === $config ) {
+			return null;
+		}
+
+		$source = $this->resolveSourceFile( $field );
+
+		if ( null === $source ) {
+			return null;
+		}
+
+		$format    = strtolower( $format );
+		$generator = $this->responsiveGenerator();
+		$images    = $generator->images();
+
+		if ( ! $images->supportsFormat( $format ) ) {
+			return null;
+		}
+
+		try {
+			$resized   = $images->resize( $source, $size );
+			$converted = $images->convertFormat( $resized, $format, $this->qualityFor( $format, $config ) );
+		} catch ( Throwable ) {
+			return null;
+		}
+
+		return $this->mapFilesystemPathToUrl( $field, $converted );
+	}
+
+	/**
+	 * Returns the srcset value for the given field.
+	 *
+	 * When `$format` is null the source-format derivatives are used; otherwise
+	 * each width is converted to the requested format first. Falls back to an
+	 * empty string when nothing could be produced (unknown field, unresolved
+	 * source, unsupported format).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string      $field  Attribute name.
+	 * @param  string|null $format Optional format to convert each variant to.
+	 *
+	 * @return string
+	 */
+	public function getImageSrcset( string $field, ?string $format = null ): string
+	{
+		$config = $this->resolveImageConfig( $field );
+
+		if ( null === $config ) {
+			return '';
+		}
+
+		$source = $this->resolveSourceFile( $field );
+
+		if ( null === $source ) {
+			return '';
+		}
+
+		$sizes = $config['sizes'] ?? null;
+
+		try {
+			$srcset = $this->responsiveGenerator()->generateSrcset(
+				$source,
+				is_array( $sizes ) ? array_values( array_map( 'intval', $sizes ) ) : null,
+				$format,
+			);
+		} catch ( Throwable ) {
+			return '';
+		}
+
+		return $this->rewriteSrcsetToUrls( $field, $srcset );
+	}
+
+	/**
+	 * Returns the dominant color hex for the given field.
+	 *
+	 * Returns `null` when the field is unknown, the source can't be resolved,
+	 * the configuration disables dominant color extraction, or extraction
+	 * fails. Callers wanting a guaranteed value should fall back themselves
+	 * (e.g. `?? '#ffffff'`).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $field Attribute name.
+	 *
+	 * @return string|null
+	 */
+	public function getImageDominantColor( string $field ): ?string
+	{
+		$config = $this->resolveImageConfig( $field );
+
+		if ( null === $config ) {
+			return null;
+		}
+
+		// Default to enabled when the per-field flag is absent — the package's
+		// global dominant-color toggle in config/performance.php already gates
+		// whether extraction is meaningful, so opting in per-field every time
+		// would be noisy.
+		$extract = array_key_exists( 'extract_dominant_color', $config )
+			? (bool) $config['extract_dominant_color']
+			: true;
+
+		if ( ! $extract ) {
+			return null;
+		}
+
+		$source = $this->resolveSourceFile( $field );
+
+		if ( null === $source ) {
+			return null;
+		}
+
+		try {
+			return $this->imageService()->extractDominantColor( $source );
+		} catch ( Throwable ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Dispatches `OptimizeImageJob` for every changed `auto_optimize` field.
+	 *
+	 * Invoked from the `saved` event registered in `bootHasOptimizedImages()`.
+	 * Made `public` rather than `protected` so the closure-bound static event
+	 * listener can call it (closures invoked through Eloquent's event
+	 * dispatcher run outside the model's protection scope).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function autoOptimizeChangedImages(): void
+	{
+		foreach ( $this->optimizableImages() as $field => $config ) {
+			if ( empty( $config['auto_optimize'] ) ) {
+				continue;
+			}
+
+			if ( method_exists( $this, 'wasChanged' ) && ! $this->wasChanged( $field ) ) {
+				continue;
+			}
+
+			$source = $this->resolveSourceFile( (string) $field );
+
+			if ( null === $source ) {
+				continue;
+			}
+
+			OptimizeImageJob::dispatch( $source, $this->jobOptionsFor( $config ) );
+		}
+	}
+
+	/**
+	 * Returns the optimizable image declaration for this model.
+	 *
+	 * Override on the model to enumerate the attributes the trait should treat
+	 * as image fields and any per-attribute optimization overrides.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected function optimizableImages(): array
+	{
+		return [];
+	}
+
+	/**
+	 * Resolves the per-field config block from `optimizableImages()`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $field Attribute name.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	protected function resolveImageConfig( string $field ): ?array
+	{
+		$images = $this->optimizableImages();
+
+		if ( ! array_key_exists( $field, $images ) || ! is_array( $images[ $field ] ) ) {
+			return null;
+		}
+
+		return $images[ $field ];
+	}
+
+	/**
+	 * Resolves the attribute value to an absolute filesystem path.
+	 *
+	 * Mirrors `ResponsiveImage::resolveSourceFile()` so the trait handles the
+	 * same mix of inputs callers already pass to the Blade components: bare
+	 * filesystem paths, web-relative paths under `public_path()`, and remote
+	 * URLs (which are rejected — there's nothing to optimize on this host).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $field Attribute name.
+	 *
+	 * @return string|null
+	 */
+	protected function resolveSourceFile( string $field ): ?string
+	{
+		$value = $this->getAttribute( $field );
+
+		if ( ! is_string( $value ) || '' === $value ) {
+			return null;
+		}
+
+		if ( str_contains( $value, '://' ) ) {
+			return null;
+		}
+
+		if ( is_file( $value ) ) {
+			return $value;
+		}
+
+		if ( ! function_exists( 'public_path' ) ) {
+			return null;
+		}
+
+		$candidate = public_path( ltrim( $value, '/' ) );
+
+		return is_file( $candidate ) ? $candidate : null;
+	}
+
+	/**
+	 * Maps a generated filesystem path back to a public URL.
+	 *
+	 * Uses the directory of the attribute value as the URL prefix when the
+	 * value is a web-relative path that actually resolves under
+	 * `public_path()`; otherwise strips `public_path()` from the generated
+	 * path. Returns `null` when no clean public URL can be derived — the
+	 * trait must never return a raw filesystem path masquerading as a URL,
+	 * which would both 404 in the browser and leak the host filesystem
+	 * layout into the rendered href.
+	 *
+	 * The `/`-prefix branch is gated on a real public-path check because
+	 * raw filesystem paths can also start with `/` (e.g.
+	 * `/Users/jacob/secret/image.jpg`).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $field            Attribute name.
+	 * @param  string $generatedFsPath  Absolute filesystem path of the produced variant.
+	 *
+	 * @return string|null
+	 */
+	protected function mapFilesystemPathToUrl( string $field, string $generatedFsPath ): ?string
+	{
+		$value = (string) $this->getAttribute( $field );
+
+		if ( '' !== $value && str_starts_with( $value, '/' ) && $this->attributeIsUnderPublicPath( $value ) ) {
+			$dir = dirname( $value );
+
+			if ( '/' === $dir ) {
+				return '/' . basename( $generatedFsPath );
+			}
+
+			return rtrim( $dir, '/' ) . '/' . basename( $generatedFsPath );
+		}
+
+		if ( function_exists( 'public_path' ) ) {
+			$publicRoot = rtrim( public_path(), DIRECTORY_SEPARATOR );
+
+			if ( str_starts_with( $generatedFsPath, $publicRoot . DIRECTORY_SEPARATOR ) ) {
+				$relative = substr( $generatedFsPath, strlen( $publicRoot ) );
+
+				return '/' . ltrim( str_replace( DIRECTORY_SEPARATOR, '/', $relative ), '/' );
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Reports whether the given web-relative-looking attribute value actually
+	 * resolves to a real file under `public_path()`.
+	 *
+	 * Mirrors the same guard used by `View\Components\ResponsiveImage` so a
+	 * value like `/Users/jacob/secret/image.jpg` (a raw filesystem path that
+	 * happens to start with `/`) is not mistaken for a web-relative path
+	 * served from the application's public root.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $value Attribute value.
+	 *
+	 * @return bool
+	 */
+	protected function attributeIsUnderPublicPath( string $value ): bool
+	{
+		if ( ! function_exists( 'public_path' ) ) {
+			return false;
+		}
+
+		$candidate = public_path( ltrim( $value, '/' ) );
+
+		return is_file( $candidate );
+	}
+
+	/**
+	 * Rewrites every entry in a srcset string so each path becomes a public URL.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $field  Attribute name (used for URL prefix derivation).
+	 * @param  string $srcset Raw srcset string from the responsive generator.
+	 *
+	 * @return string
+	 */
+	protected function rewriteSrcsetToUrls( string $field, string $srcset ): string
+	{
+		if ( '' === $srcset ) {
+			return '';
+		}
+
+		$entries = array_map( 'trim', explode( ',', $srcset ) );
+		$mapped  = [];
+
+		foreach ( $entries as $entry ) {
+			if ( '' === $entry ) {
+				continue;
+			}
+
+			// Split on the LAST space — descriptors (`<n>w`/`<n>x`) are the
+			// trailing token, and filesystem paths can legitimately contain
+			// spaces (the project's own packages directory has them).
+			$lastSpace = strrpos( $entry, ' ' );
+
+			if ( false === $lastSpace ) {
+				$url = $this->mapFilesystemPathToUrl( $field, $entry );
+
+				if ( null !== $url ) {
+					$mapped[] = $url;
+				}
+
+				continue;
+			}
+
+			$path       = substr( $entry, 0, $lastSpace );
+			$descriptor = substr( $entry, $lastSpace + 1 );
+			$url        = $this->mapFilesystemPathToUrl( $field, $path );
+
+			if ( null !== $url ) {
+				$mapped[] = $url . ' ' . $descriptor;
+			}
+		}
+
+		return implode( ', ', $mapped );
+	}
+
+	/**
+	 * Resolves the quality value for the given format.
+	 *
+	 * Per-field config wins; otherwise the package's configured format quality
+	 * applies; otherwise reasonable encoder defaults.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string               $format Format key.
+	 * @param  array<string, mixed> $config Per-field config block.
+	 *
+	 * @return int
+	 */
+	protected function qualityFor( string $format, array $config ): int
+	{
+		if ( isset( $config['quality'] ) ) {
+			return max( 0, min( 100, (int) $config['quality'] ) );
+		}
+
+		$default = 'webp' === $format ? 80 : 70;
+		$value   = (int) config( "artisanpack.performance.images.formats.{$format}.quality", $default );
+
+		return max( 0, min( 100, $value ) );
+	}
+
+	/**
+	 * Builds the options array forwarded to `OptimizeImageJob`.
+	 *
+	 * Only forwards keys the underlying `ImageService::optimize()` understands
+	 * so unrelated trait-specific keys (`auto_optimize`,
+	 * `extract_dominant_color`) don't leak into the service contract.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<string, mixed> $config Per-field config block.
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function jobOptionsFor( array $config ): array
+	{
+		$options = [];
+
+		if ( isset( $config['sizes'] ) ) {
+			$options['sizes'] = array_values( array_map( 'intval', (array) $config['sizes'] ) );
+		}
+
+		if ( isset( $config['formats'] ) ) {
+			$options['formats'] = array_values( array_map( 'strtolower', (array) $config['formats'] ) );
+		}
+
+		if ( isset( $config['quality'] ) ) {
+			$options['quality'] = max( 0, min( 100, (int) $config['quality'] ) );
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Resolves the `ResponsiveImageGenerator` from the container with a fallback.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return ResponsiveImageGenerator
+	 */
+	protected function responsiveGenerator(): ResponsiveImageGenerator
+	{
+		if ( function_exists( 'app' ) ) {
+			try {
+				return app( ResponsiveImageGenerator::class );
+			} catch ( Throwable ) {
+				// Container missing the binding — fall through.
+			}
+		}
+
+		return new ResponsiveImageGenerator();
+	}
+
+	/**
+	 * Resolves the `ImageService` from the container with a fallback.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return ImageService
+	 */
+	protected function imageService(): ImageService
+	{
+		if ( function_exists( 'app' ) ) {
+			try {
+				return app( ImageService::class );
+			} catch ( Throwable ) {
+				// Container missing the binding — fall through.
+			}
+		}
+
+		return new ImageService();
+	}
+}

--- a/src/View/Components/CriticalCss.php
+++ b/src/View/Components/CriticalCss.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * Critical CSS Blade component.
+ *
+ * Companion to the `@criticalCss` directive — renders the cached critical
+ * CSS `<style>` block for the given route as a self-contained component.
+ * Used as `<x-perf-critical-css :route="..." />`. Pass `route` explicitly
+ * for static layouts or omit it to resolve from `request()->route()->getName()`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\View\Components;
+
+use ArtisanPackUI\Performance\Css\CriticalCssExtractor;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+use Throwable;
+
+/**
+ * Critical CSS component class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+final class CriticalCss extends Component
+{
+	/**
+	 * Resolved critical CSS body.
+	 *
+	 * Empty string when no critical CSS is registered for the resolved route
+	 * (the view template skips emission entirely in that case).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public string $css = '';
+
+	/**
+	 * Resolved route name used to look up cached CSS.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public string $resolvedRoute;
+
+	/**
+	 * Creates a new component instance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string|null $route Optional route name; null resolves from the request.
+	 */
+	public function __construct( public ?string $route = null )
+	{
+		$this->resolvedRoute = $this->resolveRoute( $route );
+		$this->css           = $this->extract( $this->resolvedRoute );
+	}
+
+	/**
+	 * Returns the view to render.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return View
+	 */
+	public function render(): View
+	{
+		return view( 'performance::components.critical-css' );
+	}
+
+	/**
+	 * Resolves the route name, defaulting to the current request's route.
+	 *
+	 * Falls back to the literal `default` key so callers can register a
+	 * fallback CSS bundle once and have unnamed routes pick it up.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string|null $route Explicit route name (may be null).
+	 *
+	 * @return string
+	 */
+	protected function resolveRoute( ?string $route ): string
+	{
+		if ( null !== $route && '' !== $route ) {
+			return $route;
+		}
+
+		if ( function_exists( 'request' ) ) {
+			try {
+				$current = request()->route()?->getName();
+			} catch ( Throwable ) {
+				$current = null;
+			}
+
+			if ( null !== $current && '' !== $current ) {
+				return $current;
+			}
+		}
+
+		return CriticalCssExtractor::DEFAULT_ROUTE;
+	}
+
+	/**
+	 * Resolves the extractor and pulls cached CSS for the route.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $route Resolved route name.
+	 *
+	 * @return string
+	 */
+	protected function extract( string $route ): string
+	{
+		if ( ! function_exists( 'app' ) ) {
+			return '';
+		}
+
+		try {
+			return app( CriticalCssExtractor::class )->forRoute( $route );
+		} catch ( Throwable ) {
+			return '';
+		}
+	}
+}

--- a/tests/Feature/Css/CriticalCssExtractorTest.php
+++ b/tests/Feature/Css/CriticalCssExtractorTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Css\CriticalCssExtractor;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
+
+it( 'returns an empty string for empty input', function (): void {
+	$extractor = new CriticalCssExtractor();
+
+	expect( $extractor->extract( '' ) )->toBe( '' );
+} );
+
+it( 'keeps rules whose selectors match the critical heuristic', function (): void {
+	$css = <<<CSS
+body { margin: 0; }
+.hero { background: red; }
+.footer { color: gray; }
+.heroic-stat { color: orange; }
+CSS;
+
+	$result = ( new CriticalCssExtractor() )->extract( $css );
+
+	expect( $result )->toContain( 'body' )
+		->and( $result )->toContain( '.hero' )
+		->and( $result )->not->toContain( '.footer' )
+		->and( $result )->not->toContain( '.heroic-stat' );
+} );
+
+it( 'matches critical selectors at any token position', function (): void {
+	$css = <<<CSS
+.hero .title { font-size: 32px; }
+.wrapper > .col { padding: 16px; }
+CSS;
+
+	$result = ( new CriticalCssExtractor() )->extract( $css );
+
+	expect( $result )->toContain( '.hero .title' )
+		->and( $result )->toContain( '.wrapper > .col' );
+} );
+
+it( 'always preserves @font-face and @keyframes', function (): void {
+	$css = <<<CSS
+@font-face { font-family: 'Foo'; src: url(/f.woff2); }
+@keyframes spin { from { transform: rotate(0); } to { transform: rotate(360deg); } }
+.unused { color: red; }
+CSS;
+
+	$result = ( new CriticalCssExtractor() )->extract( $css );
+
+	expect( $result )->toContain( '@font-face' )
+		->and( $result )->toContain( '@keyframes spin' )
+		->and( $result )->not->toContain( '.unused' );
+} );
+
+it( 'drops @media min-width queries above the critical viewport', function (): void {
+	$css = <<<CSS
+@media (min-width: 2000px) {
+	body { background: green; }
+}
+@media (min-width: 600px) {
+	.hero { padding: 32px; }
+}
+CSS;
+
+	$result = ( new CriticalCssExtractor() )->extract( $css, 1300 );
+
+	expect( $result )->toContain( '@media (min-width: 600px)' )
+		->and( $result )->not->toContain( '@media (min-width: 2000px)' )
+		->and( $result )->not->toContain( 'background: green' );
+} );
+
+it( 'strips block comments before parsing', function (): void {
+	$css = '/* comment */ body { color: red; } /* trailing */';
+
+	$result = ( new CriticalCssExtractor() )->extract( $css );
+
+	expect( $result )->toContain( 'body' )
+		->and( $result )->not->toContain( 'comment' );
+} );
+
+it( 'accepts user-supplied critical selectors from config', function (): void {
+	config( [ 'artisanpack.performance.css.critical.selectors' => [ '.brand' ] ] );
+
+	$result = ( new CriticalCssExtractor() )->extract( '.brand { color: gold; } .ignore { color: gray; }' );
+
+	expect( $result )->toContain( '.brand' )
+		->and( $result )->not->toContain( '.ignore' );
+} );
+
+it( 'registers raw CSS content per route and extracts on demand', function (): void {
+	$extractor = new CriticalCssExtractor();
+
+	$extractor->registerSource( 'home', 'body { color: red; } .footer { color: gray; }' );
+
+	expect( $extractor->generate( 'home' ) )->toContain( 'body' )
+		->and( $extractor->generate( 'home' ) )->not->toContain( 'footer' );
+} );
+
+it( 'registers a CSS file path per route and reads the file at generate time', function (): void {
+	$file = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'critical-source.css';
+	file_put_contents( $file, 'header { padding: 8px; } .footer { color: gray; }' );
+
+	$extractor = new CriticalCssExtractor();
+	$extractor->registerSource( 'home', $file );
+
+	$result = $extractor->generate( 'home' );
+
+	expect( $result )->toContain( 'header' )
+		->and( $result )->not->toContain( '.footer' );
+
+	@unlink( $file );
+} );
+
+it( 'throws when a registered path cannot be read', function (): void {
+	$extractor = new CriticalCssExtractor();
+	$extractor->registerSource( 'home', '/does/not/exist.css' );
+
+	expect( fn () => $extractor->generate( 'home' ) )
+		->toThrow( RuntimeException::class, 'is not readable' );
+} );
+
+it( 'falls back to the default route when no sources are registered for the route', function (): void {
+	$extractor = new CriticalCssExtractor();
+	$extractor->registerSource( 'default', 'body { color: red; }' );
+
+	expect( $extractor->generate( 'home' ) )->toContain( 'body' );
+} );
+
+it( 'caches generated CSS per route when caching is enabled', function (): void {
+	config( [ 'artisanpack.performance.css.critical.cache' => true ] );
+
+	$cache     = new Repository( new ArrayStore() );
+	$extractor = new CriticalCssExtractor( $cache );
+
+	$extractor->registerSource( 'home', 'body { color: red; }' );
+
+	$first  = $extractor->forRoute( 'home' );
+	// Mutate the registered source — cached result should NOT change.
+	$extractor->registerSource( 'home', '.hero { color: blue; }' );
+	$second = $extractor->forRoute( 'home' );
+
+	expect( $second )->toBe( $first );
+} );
+
+it( 'skips the cache when caching is disabled', function (): void {
+	config( [ 'artisanpack.performance.css.critical.cache' => false ] );
+
+	$cache     = new Repository( new ArrayStore() );
+	$extractor = new CriticalCssExtractor( $cache );
+
+	$extractor->registerSource( 'home', 'body { color: red; }' );
+	$first = $extractor->forRoute( 'home' );
+
+	$extractor->registerSource( 'home', '.hero { color: blue; }' );
+	$second = $extractor->forRoute( 'home' );
+
+	expect( $second )->not->toBe( $first );
+} );
+
+it( 'clears cached entries via clearCache()', function (): void {
+	config( [ 'artisanpack.performance.css.critical.cache' => true ] );
+
+	$cache     = new Repository( new ArrayStore() );
+	$extractor = new CriticalCssExtractor( $cache );
+
+	$extractor->registerSource( 'home', 'body { color: red; }' );
+	$extractor->forRoute( 'home' );
+
+	$extractor->clearCache( 'home' );
+	$extractor->registerSource( 'home', '.hero { color: blue; }' );
+
+	expect( $extractor->forRoute( 'home' ) )->toContain( '.hero' );
+} );
+
+it( 'inlines a <style data-critical> block when CSS is registered', function (): void {
+	$extractor = new CriticalCssExtractor();
+	$extractor->registerSource( 'home', 'body { margin: 0; }' );
+
+	$inline = $extractor->inlineFor( 'home' );
+
+	expect( $inline )->toStartWith( '<style data-critical="home">' )
+		->and( $inline )->toContain( 'body' )
+		->and( $inline )->toEndWith( '</style>' );
+} );
+
+it( 'returns an empty inline block when no critical CSS exists', function (): void {
+	$extractor = new CriticalCssExtractor();
+
+	expect( $extractor->inlineFor( 'missing' ) )->toBe( '' );
+} );
+
+it( 'preserves body-less at-rules like @import and @charset', function (): void {
+	$css = <<<CSS
+@charset "UTF-8";
+@import url('reset.css');
+body { margin: 0; }
+.footer { color: gray; }
+CSS;
+
+	$result = ( new CriticalCssExtractor() )->extract( $css );
+
+	expect( $result )->toContain( '@charset "UTF-8"' )
+		->and( $result )->toContain( "@import url('reset.css')" )
+		->and( $result )->toContain( 'body' )
+		->and( $result )->not->toContain( '.footer' );
+} );
+
+it( 'does not classify attribute substring selectors as critical via the universal selector', function (): void {
+	// Regression: `*` as a critical pattern previously matched any selector
+	// containing `*` (including `[data-name*="footer"]`), wrongly preserving
+	// below-the-fold rules.
+	$css = <<<CSS
+[data-name*="footer"] { display: none; }
+.footer { display: none; }
+CSS;
+
+	$result = ( new CriticalCssExtractor() )->extract( $css );
+
+	expect( $result )->not->toContain( 'data-name' )
+		->and( $result )->not->toContain( '.footer' );
+} );
+
+it( 'lists registered routes', function (): void {
+	$extractor = new CriticalCssExtractor();
+	$extractor->registerSource( 'home', 'body{}' );
+	$extractor->registerSource( 'contact', 'header{}' );
+
+	expect( $extractor->registeredRoutes() )->toEqualCanonicalizing( [ 'home', 'contact' ] );
+} );

--- a/tests/Feature/Images/ImageOptimizationFeatureTest.php
+++ b/tests/Feature/Images/ImageOptimizationFeatureTest.php
@@ -1,0 +1,221 @@
+<?php
+
+/*
+ * End-to-end feature coverage for the image optimization pipeline.
+ *
+ * Issue #17 asked for "comprehensive feature tests" across the whole
+ * pipeline — WebP/AVIF on both drivers, dominant color extraction,
+ * responsive size generation, the lazy and responsive Blade components,
+ * the HasOptimizedImages trait, queued jobs, the perf:generate-webp
+ * command, and a sweep across JPEG/PNG/GIF sources. The per-class tests
+ * already cover unit-level behavior in `tests/Feature/Services/Image`,
+ * `tests/Feature/Images`, `tests/Feature/View/Components`, etc. — this
+ * file adds the integration glue that wires several pieces together so
+ * regressions in cross-component contracts surface here even when the
+ * per-class tests still pass.
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Events\ImageOptimized;
+use ArtisanPackUI\Performance\Images\DominantColorExtractor;
+use ArtisanPackUI\Performance\Images\ResponsiveImageGenerator;
+use ArtisanPackUI\Performance\Jobs\OptimizeImageJob;
+use ArtisanPackUI\Performance\Services\Image\FormatConverter;
+use ArtisanPackUI\Performance\Services\ImageService;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Event;
+
+beforeEach( function (): void {
+	clearImageFixtures();
+} );
+
+afterEach( function (): void {
+	clearImageFixtures();
+} );
+
+it( 'converts JPEG sources to WebP via the GD driver', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	$source    = makeTestImage( 'jpeg-source.jpg', 100, 100, 'jpeg' );
+	$converter = new FormatConverter( 'gd' );
+
+	$result = $converter->convert( $source, 'webp', 75 );
+
+	expect( file_exists( $result ) )->toBeTrue()
+		->and( getimagesize( $result )[2] )->toBe( IMAGETYPE_WEBP );
+} );
+
+it( 'converts PNG sources to WebP and preserves transparency', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	$source = makeTestImage( 'png-source.png', 80, 80, 'png' );
+
+	$result = ( new FormatConverter( 'gd' ) )->convert( $source, 'webp', 80 );
+
+	expect( file_exists( $result ) )->toBeTrue()
+		->and( getimagesize( $result )[2] )->toBe( IMAGETYPE_WEBP );
+} );
+
+it( 'converts GIF sources to WebP', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	$source = makeTestImage( 'gif-source.gif', 60, 60, 'gif' );
+
+	$result = ( new FormatConverter( 'gd' ) )->convert( $source, 'webp', 80 );
+
+	expect( file_exists( $result ) )->toBeTrue()
+		->and( getimagesize( $result )[2] )->toBe( IMAGETYPE_WEBP );
+} );
+
+it( 'converts JPEG sources to AVIF when the driver supports it', function (): void {
+	$converter = new FormatConverter();
+
+	if ( ! $converter->supports( 'avif' ) ) {
+		$this->markTestSkipped( 'AVIF encoding is not available on this driver' );
+	}
+
+	$source = makeTestImage( 'avif-source.jpg', 80, 80 );
+
+	$result = $converter->convert( $source, 'avif', 60 );
+
+	expect( file_exists( $result ) )->toBeTrue();
+} );
+
+it( 'extracts a hex dominant color from a solid-color JPEG', function (): void {
+	$source    = makeTestImage( 'dominant-color.jpg', 60, 60, 'jpeg', [ 25, 50, 200 ] );
+	$extractor = new DominantColorExtractor();
+
+	$color = $extractor->extract( $source, null, false );
+
+	expect( $color )->toMatch( '/^#[0-9a-f]{6}$/i' );
+} );
+
+it( 'extracts dominant color from PNG sources', function (): void {
+	$source = makeTestImage( 'dominant-color.png', 60, 60, 'png', [ 200, 30, 30 ] );
+
+	$color = ( new DominantColorExtractor() )->extract( $source, null, false );
+
+	expect( $color )->toMatch( '/^#[0-9a-f]{6}$/i' );
+} );
+
+it( 'generates responsive sizes via the responsive generator', function (): void {
+	$source    = makeTestImage( 'responsive.jpg', 800, 600 );
+	$generator = new ResponsiveImageGenerator( new ImageService() );
+
+	$sizes = $generator->generateSizes( $source, [ 200, 400, 800 ] );
+
+	expect( $sizes )->toHaveKey( 200 )
+		->and( $sizes )->toHaveKey( 400 )
+		->and( $sizes )->toHaveKey( 800 )
+		->and( file_exists( $sizes[200] ) )->toBeTrue()
+		->and( file_exists( $sizes[400] ) )->toBeTrue();
+} );
+
+it( 'composes a srcset string with width descriptors', function (): void {
+	$source    = makeTestImage( 'srcset.jpg', 600, 400 );
+	$generator = new ResponsiveImageGenerator( new ImageService() );
+
+	$srcset = $generator->generateSrcset( $source, [ 200, 400 ] );
+
+	expect( $srcset )->toContain( '200w' )
+		->and( $srcset )->toContain( '400w' );
+} );
+
+it( 'renders the lazy image component with native lazy attributes', function (): void {
+	$html = Blade::render( '<x-perf-lazy-image src="/test.jpg" alt="Test" />' );
+
+	expect( $html )->toContain( 'loading="lazy"' )
+		->and( $html )->toContain( 'decoding="async"' )
+		->and( $html )->toContain( 'src="/test.jpg"' )
+		->and( $html )->toContain( 'alt="Test"' );
+} );
+
+it( 'renders the responsive image component as a <picture>', function (): void {
+	$source = makeTestImage( 'picture.jpg', 200, 100 );
+
+	$html = Blade::render(
+		'<x-perf-responsive-image :src="$src" alt="Pic" :sizes="[100]" />',
+		[ 'src' => $source ],
+	);
+
+	expect( $html )->toContain( '<picture' )
+		->and( $html )->toContain( '<img' );
+} );
+
+it( 'fires ImageOptimized after running the optimization pipeline', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	Event::fake();
+
+	$source = makeTestImage( 'optimize-event.jpg', 200, 200 );
+
+	( new ImageService() )->optimize( $source, [
+		'sizes'   => [ 100 ],
+		'formats' => [ 'webp' ],
+	] );
+
+	Event::assertDispatched( ImageOptimized::class );
+} );
+
+it( 'processes OptimizeImageJob synchronously without throwing', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	$source = makeTestImage( 'sync-opt.jpg', 200, 200 );
+
+	OptimizeImageJob::dispatchSync( $source, [
+		'sizes'   => [ 100 ],
+		'formats' => [ 'webp' ],
+	] );
+
+	expect( true )->toBeTrue();
+} );
+
+it( 'runs the perf:generate-webp command against a directory of mixed sources', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	makeTestImage( 'cmd-a.jpg', 80, 80, 'jpeg' );
+	makeTestImage( 'cmd-b.png', 80, 80, 'png' );
+	makeTestImage( 'cmd-c.gif', 80, 80, 'gif' );
+
+	$exit = Artisan::call( 'perf:generate-webp', [
+		'path'       => imageFixturesDir(),
+		'--quality'  => 75,
+		'--force'    => true,
+	] );
+
+	$dir = imageFixturesDir();
+
+	expect( $exit )->toBe( 0 )
+		->and( file_exists( $dir . DIRECTORY_SEPARATOR . 'cmd-a.webp' ) )->toBeTrue()
+		->and( file_exists( $dir . DIRECTORY_SEPARATOR . 'cmd-b.webp' ) )->toBeTrue()
+		->and( file_exists( $dir . DIRECTORY_SEPARATOR . 'cmd-c.webp' ) )->toBeTrue();
+} );
+
+it( 'reports per-driver format support honestly', function (): void {
+	$converter = new FormatConverter( 'gd' );
+
+	expect( $converter->supports( 'webp' ) )->toBe( function_exists( 'imagewebp' ) )
+		->and( $converter->supports( 'avif' ) )->toBe( function_exists( 'imageavif' ) )
+		->and( $converter->supports( 'unsupported' ) )->toBeFalse();
+} );
+
+it( 'rejects an unsupported source format when converting', function (): void {
+	$source = makeTestImage( 'unsupported-target.jpg', 80, 80 );
+
+	expect( fn () => ( new FormatConverter( 'gd' ) )->convert( $source, 'tiff', 80 ) )
+		->toThrow( RuntimeException::class, 'Unsupported target format' );
+} );

--- a/tests/Feature/JavaScript/ScriptManagerTest.php
+++ b/tests/Feature/JavaScript/ScriptManagerTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Facades\Performance;
+use ArtisanPackUI\Performance\JavaScript\AsyncStrategy;
+use ArtisanPackUI\Performance\JavaScript\DeferStrategy;
+use ArtisanPackUI\Performance\JavaScript\InlineStrategy;
+use ArtisanPackUI\Performance\JavaScript\ModuleStrategy;
+use ArtisanPackUI\Performance\JavaScript\ScriptManager;
+use ArtisanPackUI\Performance\JavaScript\ScriptRegistration;
+use ArtisanPackUI\Performance\JavaScript\ScriptStrategy;
+
+it( 'registers a script and returns a fluent ScriptRegistration', function (): void {
+	$manager = new ScriptManager();
+
+	$registration = $manager->register( '/js/app.js' );
+
+	expect( $registration )->toBeInstanceOf( ScriptRegistration::class )
+		->and( $registration->src )->toBe( '/js/app.js' );
+} );
+
+it( 'seeds the four bundled strategies by default', function (): void {
+	$strategies = ( new ScriptManager() )->strategies();
+
+	expect( $strategies )->toHaveKey( 'defer' )
+		->and( $strategies )->toHaveKey( 'async' )
+		->and( $strategies )->toHaveKey( 'module' )
+		->and( $strategies )->toHaveKey( 'inline' )
+		->and( $strategies['defer'] )->toBeInstanceOf( DeferStrategy::class )
+		->and( $strategies['async'] )->toBeInstanceOf( AsyncStrategy::class )
+		->and( $strategies['module'] )->toBeInstanceOf( ModuleStrategy::class )
+		->and( $strategies['inline'] )->toBeInstanceOf( InlineStrategy::class );
+} );
+
+it( 'sorts registered scripts by priority ascending', function (): void {
+	$manager = new ScriptManager();
+
+	$manager->register( '/js/late.js' )->priority( 50 );
+	$manager->register( '/js/early.js' )->priority( 5 );
+	$manager->register( '/js/middle.js' );
+
+	$all = $manager->all();
+
+	expect( $all[0]->src )->toBe( '/js/early.js' )
+		->and( $all[1]->src )->toBe( '/js/middle.js' )
+		->and( $all[2]->src )->toBe( '/js/late.js' );
+} );
+
+it( 'preserves registration order between scripts of equal priority', function (): void {
+	$manager = new ScriptManager();
+
+	$manager->register( '/js/first.js' );
+	$manager->register( '/js/second.js' );
+	$manager->register( '/js/third.js' );
+
+	$all = $manager->all();
+
+	expect( array_map( static fn ( ScriptRegistration $r ): string => $r->src, $all ) )
+		->toBe( [ '/js/first.js', '/js/second.js', '/js/third.js' ] );
+} );
+
+it( 'finds scripts by their declared name', function (): void {
+	$manager = new ScriptManager();
+
+	$manager->register( '/js/x.js' )->name( 'analytics' );
+
+	$found = $manager->find( 'analytics' );
+
+	expect( $found )->not->toBeNull()
+		->and( $found->src )->toBe( '/js/x.js' );
+} );
+
+it( 'renders every registered script to a newline-joined HTML block', function (): void {
+	$manager = new ScriptManager();
+
+	$manager->register( '/js/app.js' )->defer()->priority( 1 );
+	$manager->register( '/js/analytics.js' )->async()->priority( 5 );
+
+	$html = $manager->render();
+
+	expect( $html )->toContain( '<script src="/js/app.js" defer></script>' )
+		->and( $html )->toContain( '<script src="/js/analytics.js" async></script>' )
+		->and( $html )->toContain( "\n" );
+} );
+
+it( 'silently skips registrations with an unknown strategy when rendering', function (): void {
+	$manager          = new ScriptManager();
+	$script           = $manager->register( '/js/x.js' );
+	$script->strategy = 'unknown';
+
+	expect( $manager->render() )->toBe( '' );
+} );
+
+it( 'throws via renderOne() when a strategy is missing', function (): void {
+	$manager          = new ScriptManager();
+	$script           = $manager->register( '/js/x.js' );
+	$script->strategy = 'unknown';
+
+	expect( fn () => $manager->renderOne( $script ) )
+		->toThrow( RuntimeException::class, 'unknown' );
+} );
+
+it( 'allows replacing or extending strategy renderers', function (): void {
+	$custom = new class implements ScriptStrategy {
+		public function name(): string
+		{
+			return 'defer';
+		}
+
+		public function render( ScriptRegistration $script ): string
+		{
+			return '<!-- replaced ' . $script->src . ' -->';
+		}
+	};
+
+	$manager = new ScriptManager();
+	$manager->registerStrategy( $custom );
+	$manager->register( '/js/x.js' );
+
+	expect( $manager->render() )->toBe( '<!-- replaced /js/x.js -->' );
+} );
+
+it( 'clears all registered scripts', function (): void {
+	$manager = new ScriptManager();
+	$manager->register( '/js/x.js' );
+
+	expect( $manager->hasScripts() )->toBeTrue();
+
+	$manager->clear();
+
+	expect( $manager->hasScripts() )->toBeFalse();
+} );
+
+it( 'returns a ScriptRegistration from the Performance facade', function (): void {
+	$registration = Performance::script( '/js/facade.js' );
+
+	expect( $registration )->toBeInstanceOf( ScriptRegistration::class )
+		->and( $registration->src )->toBe( '/js/facade.js' );
+
+	expect( Performance::getScripts() )->toHaveCount( 1 );
+} );
+
+it( 'renders every facade-registered script via renderScripts()', function (): void {
+	// Reset the singleton so prior tests don't leak registrations.
+	app()->forgetInstance( ScriptManager::class );
+
+	Performance::script( '/js/one.js' )->defer();
+	Performance::script( '/js/two.js' )->async();
+
+	$html = Performance::renderScripts();
+
+	expect( $html )->toContain( '/js/one.js' )
+		->and( $html )->toContain( '/js/two.js' );
+} );
+
+it( 'reads the default strategy from package config when none is chosen', function (): void {
+	$script = new ScriptRegistration( '/js/y.js' );
+
+	// Set config AFTER construction to prove the strategy is resolved lazily —
+	// constructor-time reads would miss user overrides applied later in the
+	// boot sequence (e.g. a sibling service provider's boot() phase).
+	config( [ 'artisanpack.performance.javascript.default_strategy' => 'async' ] );
+
+	expect( $script->strategy() )->toBe( 'async' );
+} );
+
+it( 'pins the strategy through explicit setters and short-circuits the lazy lookup', function (): void {
+	$script = ( new ScriptRegistration( '/js/x.js' ) )->module();
+
+	config( [ 'artisanpack.performance.javascript.default_strategy' => 'async' ] );
+
+	expect( $script->strategy() )->toBe( 'module' );
+} );

--- a/tests/Feature/JavaScript/ScriptStrategiesTest.php
+++ b/tests/Feature/JavaScript/ScriptStrategiesTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\JavaScript\AsyncStrategy;
+use ArtisanPackUI\Performance\JavaScript\DeferStrategy;
+use ArtisanPackUI\Performance\JavaScript\InlineStrategy;
+use ArtisanPackUI\Performance\JavaScript\ModuleStrategy;
+use ArtisanPackUI\Performance\JavaScript\ScriptRegistration;
+
+it( 'DeferStrategy renders src with defer attribute', function (): void {
+	$script = ( new ScriptRegistration( '/js/app.js' ) )->defer();
+
+	$html = ( new DeferStrategy() )->render( $script );
+
+	expect( $html )->toBe( '<script src="/js/app.js" defer></script>' );
+} );
+
+it( 'AsyncStrategy renders src with async attribute', function (): void {
+	$script = ( new ScriptRegistration( '/js/widget.js' ) )->async();
+
+	$html = ( new AsyncStrategy() )->render( $script );
+
+	expect( $html )->toBe( '<script src="/js/widget.js" async></script>' );
+} );
+
+it( 'ModuleStrategy renders src with type=module', function (): void {
+	$script = ( new ScriptRegistration( '/js/app.mjs' ) )->module();
+
+	$html = ( new ModuleStrategy() )->render( $script );
+
+	expect( $html )->toBe( '<script type="module" src="/js/app.mjs"></script>' );
+} );
+
+it( 'InlineStrategy renders inline content between script tags', function (): void {
+	$script = ( new ScriptRegistration( 'inline' ) )->inline( "console.log('hi');" );
+
+	$html = ( new InlineStrategy() )->render( $script );
+
+	expect( $html )->toBe( "<script>console.log('hi');</script>" );
+} );
+
+it( 'InlineStrategy escapes embedded </script> sequences', function (): void {
+	$script = ( new ScriptRegistration( 'inline' ) )->inline( 'var s = "</script>";' );
+
+	$html = ( new InlineStrategy() )->render( $script );
+
+	expect( $html )->toContain( '<\\/script>' )
+		->and( $html )->not->toContain( '"</script>";' );
+} );
+
+it( 'escapes hostile content in src and shared attributes', function (): void {
+	$script = ( new ScriptRegistration( '/js/x.js?q="><script>alert(1)</script>' ) )
+		->defer()
+		->name( '"><script>name</script>' )
+		->target( '#a"' );
+
+	$html = ( new DeferStrategy() )->render( $script );
+
+	expect( $html )->not->toContain( '"><script>alert' )
+		->and( $html )->not->toContain( '"><script>name' )
+		->and( $html )->toContain( 'data-target="#a&quot;"' );
+} );
+
+it( 'emits data-load-on for conditional triggers', function (): void {
+	$script = ( new ScriptRegistration( '/js/widget.js' ) )
+		->async()
+		->loadOn( 'visible', 'idle' )
+		->target( '#widget' );
+
+	$html = ( new AsyncStrategy() )->render( $script );
+
+	expect( $html )->toContain( 'data-load-on="visible idle"' )
+		->and( $html )->toContain( 'data-target="#widget"' );
+} );
+
+it( 'reports the canonical strategy name', function (): void {
+	expect( ( new DeferStrategy() )->name() )->toBe( 'defer' )
+		->and( ( new AsyncStrategy() )->name() )->toBe( 'async' )
+		->and( ( new ModuleStrategy() )->name() )->toBe( 'module' )
+		->and( ( new InlineStrategy() )->name() )->toBe( 'inline' );
+} );
+
+it( 'allows additional attributes attached via the escape hatch', function (): void {
+	$script = ( new ScriptRegistration( '/js/x.js' ) )
+		->defer()
+		->attribute( 'integrity', 'sha384-abc' )
+		->attribute( 'crossorigin', 'anonymous' );
+
+	$html = ( new DeferStrategy() )->render( $script );
+
+	expect( $html )->toContain( 'integrity="sha384-abc"' )
+		->and( $html )->toContain( 'crossorigin="anonymous"' );
+} );
+
+it( 'drops attribute names with disallowed characters', function (): void {
+	$script = ( new ScriptRegistration( '/js/x.js' ) )
+		->defer()
+		->attribute( '"><script', 'x' );
+
+	$html = ( new DeferStrategy() )->render( $script );
+
+	expect( $html )->not->toContain( '"><script' );
+} );

--- a/tests/Feature/PerformanceServiceTest.php
+++ b/tests/Feature/PerformanceServiceTest.php
@@ -118,13 +118,22 @@ it( 'delegates image methods to the ImageService', function (): void {
 	expect( $srcset )->toContain( '100w' );
 } );
 
-it( 'returns no-op defaults for script and metric and recommendation methods', function (): void {
+it( 'returns no-op defaults for metric and recommendation methods', function (): void {
 	$service = app( PerformanceService::class );
 
-	expect( $service->script( '/js/app.js' ) )->toBe( [] )
-		->and( $service->getRecommendations() )->toBe( [] );
+	expect( $service->getRecommendations() )->toBe( [] );
 
 	// recordMetric is a no-op; just assert it returns void without throwing.
 	$service->recordMetric( 'LCP', 1234.5 );
 	expect( true )->toBeTrue();
+} );
+
+it( 'returns a ScriptRegistration from the script() facade entry point', function (): void {
+	$service = app( PerformanceService::class );
+
+	$registration = $service->script( '/js/app.js' );
+
+	expect( $registration )->toBeInstanceOf( ArtisanPackUI\Performance\JavaScript\ScriptRegistration::class )
+		->and( $registration->src )->toBe( '/js/app.js' )
+		->and( $service->getScripts() )->toContain( $registration );
 } );

--- a/tests/Feature/Traits/HasOptimizedImagesTest.php
+++ b/tests/Feature/Traits/HasOptimizedImagesTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Images\ResponsiveImageGenerator;
+use ArtisanPackUI\Performance\Jobs\OptimizeImageJob;
+use ArtisanPackUI\Performance\Services\ImageService;
+use Illuminate\Support\Facades\Queue;
+use Tests\Fixtures\HasOptimizedImagesModelStub as TraitModelStub;
+
+beforeEach( function (): void {
+	clearImageFixtures();
+	// Trait URL derivation requires sources to live under public_path() — the
+	// trait now returns null for anything outside it (so a raw fs path can't
+	// masquerade as a public URL). Point public_path at the fixtures dir so
+	// the per-test images are URL-mappable without having to wire a real
+	// public storage tree.
+	app()->usePublicPath( imageFixturesDir() );
+} );
+
+afterEach( function (): void {
+	clearImageFixtures();
+} );
+
+it( 'returns null when the field is not declared as optimizable', function (): void {
+	$model = new TraitModelStub();
+
+	expect( $model->getOptimizedImageUrl( 'missing', 'webp', 320 ) )->toBeNull()
+		->and( $model->getImageSrcset( 'missing' ) )->toBe( '' )
+		->and( $model->getImageDominantColor( 'missing' ) )->toBeNull();
+} );
+
+it( 'returns null when the attribute value cannot be resolved on disk', function (): void {
+	$model               = new TraitModelStub();
+	$model->imageConfig  = [ 'photo' => [ 'sizes' => [ 100 ] ] ];
+	$model->setRawAttributes( [ 'photo' => '/does/not/exist.jpg' ] );
+
+	expect( $model->getOptimizedImageUrl( 'photo', 'webp', 100 ) )->toBeNull()
+		->and( $model->getImageSrcset( 'photo' ) )->toBe( '' )
+		->and( $model->getImageDominantColor( 'photo' ) )->toBeNull();
+} );
+
+it( 'produces an optimized image URL when the active driver supports the format', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	$source             = makeTestImage( 'trait-photo.jpg', 400, 300 );
+	$model              = new TraitModelStub();
+	$model->imageConfig = [
+		'photo' => [
+			'sizes'   => [ 200 ],
+			'formats' => [ 'webp' ],
+			'quality' => 70,
+		],
+	];
+	$model->setRawAttributes( [ 'photo' => $source ] );
+
+	$url = $model->getOptimizedImageUrl( 'photo', 'webp', 200 );
+
+	expect( $url )->not->toBeNull()
+		->and( $url )->toEndWith( '.webp' );
+} );
+
+it( 'returns null when the active driver cannot encode the requested format', function (): void {
+	$source             = makeTestImage( 'unsupported.jpg', 80, 80 );
+	$model              = new TraitModelStub();
+	$model->imageConfig = [ 'photo' => [ 'sizes' => [ 80 ] ] ];
+	$model->setRawAttributes( [ 'photo' => $source ] );
+
+	// Inject a stub ImageService that always returns false from supportsFormat.
+	app()->instance( ImageService::class, new class extends ImageService {
+		public function __construct()
+		{
+		}
+
+		public function supportsFormat( string $format ): bool
+		{
+		return false;
+		}
+	} );
+	app()->instance( ResponsiveImageGenerator::class, new ResponsiveImageGenerator(
+		app( ImageService::class ),
+	) );
+
+	expect( $model->getOptimizedImageUrl( 'photo', 'webp', 80 ) )->toBeNull();
+} );
+
+it( 'returns the srcset for the configured sizes', function (): void {
+	$source             = makeTestImage( 'srcset-photo.jpg', 600, 400 );
+	$model              = new TraitModelStub();
+	$model->imageConfig = [ 'photo' => [ 'sizes' => [ 320, 640 ] ] ];
+	$model->setRawAttributes( [ 'photo' => $source ] );
+
+	$srcset = $model->getImageSrcset( 'photo' );
+
+	expect( $srcset )->not->toBe( '' )
+		->and( $srcset )->toContain( '320w' )
+		->and( $srcset )->toContain( '600w' ); // 640 clamped to source width 600
+} );
+
+it( 'returns a dominant color hex string when extraction is enabled', function (): void {
+	$source             = makeTestImage( 'color-photo.jpg', 60, 60, 'jpeg', [ 10, 200, 50 ] );
+	$model              = new TraitModelStub();
+	$model->imageConfig = [ 'photo' => [ 'sizes' => [ 60 ], 'extract_dominant_color' => true ] ];
+	$model->setRawAttributes( [ 'photo' => $source ] );
+
+	$color = $model->getImageDominantColor( 'photo' );
+
+	expect( $color )->not->toBeNull()
+		->and( $color )->toMatch( '/^#[0-9a-f]{6}$/i' );
+} );
+
+it( 'returns null for dominant color when extraction is disabled', function (): void {
+	$source             = makeTestImage( 'no-color.jpg', 60, 60 );
+	$model              = new TraitModelStub();
+	$model->imageConfig = [ 'photo' => [ 'extract_dominant_color' => false ] ];
+	$model->setRawAttributes( [ 'photo' => $source ] );
+
+	expect( $model->getImageDominantColor( 'photo' ) )->toBeNull();
+} );
+
+it( 'dispatches OptimizeImageJob for changed fields when auto_optimize is enabled', function (): void {
+	Queue::fake();
+
+	$source             = makeTestImage( 'auto-opt.jpg', 200, 200 );
+	$model              = new TraitModelStub();
+	$model->imageConfig = [
+		'photo' => [
+			'sizes'         => [ 100 ],
+			'formats'       => [ 'webp' ],
+			'auto_optimize' => true,
+		],
+	];
+	$model->setRawAttributes( [ 'photo' => $source ] );
+	$model->changedFields = [ 'photo' ];
+
+	$model->autoOptimizeChangedImages();
+
+	Queue::assertPushed( OptimizeImageJob::class );
+} );
+
+it( 'does not dispatch OptimizeImageJob when auto_optimize is false', function (): void {
+	Queue::fake();
+
+	$source             = makeTestImage( 'no-auto.jpg', 200, 200 );
+	$model              = new TraitModelStub();
+	$model->imageConfig = [ 'photo' => [ 'auto_optimize' => false ] ];
+	$model->setRawAttributes( [ 'photo' => $source ] );
+
+	$model->autoOptimizeChangedImages();
+
+	Queue::assertNotPushed( OptimizeImageJob::class );
+} );
+
+it( 'does not leak absolute filesystem paths as public URLs', function (): void {
+	if ( ! function_exists( 'imagewebp' ) ) {
+		$this->markTestSkipped( 'GD WebP support is not available' );
+	}
+
+	// Regression: an attribute whose value happens to start with "/" but
+	// isn't actually under public_path() must not be returned as a URL —
+	// using its directory as a URL prefix would leak the host filesystem
+	// layout AND produce a 404 in the browser. Point public_path at a
+	// separate directory so the fixture is provably NOT under it.
+	$leakyDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'perf-trait-leak-source';
+	@mkdir( $leakyDir, 0777, true );
+
+	$source = $leakyDir . DIRECTORY_SEPARATOR . 'fs-leak.jpg';
+	$image  = imagecreatetruecolor( 200, 200 );
+	imagefilledrectangle( $image, 0, 0, 200, 200, imagecolorallocate( $image, 100, 100, 100 ) );
+	imagejpeg( $image, $source, 90 );
+	imagedestroy( $image );
+
+	// public_path is set in beforeEach to the fixtures dir, NOT $leakyDir.
+	$model              = new TraitModelStub();
+	$model->imageConfig = [ 'photo' => [ 'sizes' => [ 100 ], 'formats' => [ 'webp' ] ] ];
+	$model->setRawAttributes( [ 'photo' => $source ] );
+
+	$url    = $model->getOptimizedImageUrl( 'photo', 'webp', 100 );
+	$srcset = $model->getImageSrcset( 'photo' );
+
+	// The trait must refuse to expose the fs path — getOptimizedImageUrl
+	// returns null and getImageSrcset returns empty rather than emitting
+	// the leaked path.
+	expect( $url )->toBeNull()
+		->and( $srcset )->toBe( '' );
+
+	@unlink( $source );
+	@unlink( $leakyDir . DIRECTORY_SEPARATOR . 'fs-leak-100w.jpg' );
+	@unlink( $leakyDir . DIRECTORY_SEPARATOR . 'fs-leak-100w.webp' );
+	@rmdir( $leakyDir );
+} );
+
+it( 'rejects remote URL values', function (): void {
+	$model              = new TraitModelStub();
+	$model->imageConfig = [ 'photo' => [ 'sizes' => [ 100 ] ] ];
+	$model->setRawAttributes( [ 'photo' => 'https://example.com/foo.jpg' ] );
+
+	expect( $model->getOptimizedImageUrl( 'photo', 'webp', 100 ) )->toBeNull()
+		->and( $model->getImageDominantColor( 'photo' ) )->toBeNull();
+} );
+
+it( 'falls back to public_path resolution when the value is web-relative', function (): void {
+	$publicDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'perf-trait-public';
+	@mkdir( $publicDir, 0777, true );
+
+	$source = $publicDir . DIRECTORY_SEPARATOR . 'web-relative.jpg';
+	$image  = imagecreatetruecolor( 200, 100 );
+	imagefilledrectangle( $image, 0, 0, 200, 100, imagecolorallocate( $image, 0, 0, 200 ) );
+	imagejpeg( $image, $source, 90 );
+	imagedestroy( $image );
+
+	// Rebind public_path to point at our temp dir. usePublicPath() updates
+	// both the container binding and the private Application::$publicPath
+	// property that public_path() actually consults.
+	app()->usePublicPath( $publicDir );
+
+	$model              = new TraitModelStub();
+	$model->imageConfig = [ 'photo' => [ 'sizes' => [ 100 ] ] ];
+	$model->setRawAttributes( [ 'photo' => '/web-relative.jpg' ] );
+
+	$srcset = $model->getImageSrcset( 'photo' );
+
+	expect( $srcset )->toContain( '100w' )
+		->and( $srcset )->toStartWith( '/' );
+
+	@unlink( $source );
+	@rmdir( $publicDir );
+} );

--- a/tests/Fixtures/HasOptimizedImagesModelStub.php
+++ b/tests/Fixtures/HasOptimizedImagesModelStub.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Eloquent stub model used by `HasOptimizedImagesTest`.
+ *
+ * Lives in `tests/Fixtures` rather than inline in the test file so it owns its
+ * own file (per the package's "one class per file" convention) and so the
+ * class name doesn't collide if another suite ever needs a similarly-named
+ * stub. The model is not backed by a real table — tests hydrate instances
+ * via `setRawAttributes()` and never persist.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace Tests\Fixtures;
+
+use ArtisanPackUI\Performance\Traits\HasOptimizedImages;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Stub Eloquent model that exercises `HasOptimizedImages`.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.0.0
+ */
+class HasOptimizedImagesModelStub extends Model
+{
+	use HasOptimizedImages;
+
+	public $timestamps = false;
+
+	/**
+	 * Per-test optimizable image config; populated before each assertion.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
+	public array $imageConfig = [];
+
+	/**
+	 * Fields the stub should report as changed via `wasChanged()`.
+	 *
+	 * Eloquent's real `wasChanged()` only returns true after a successful
+	 * save; the stub overrides it so tests can drive the trait's auto-optimize
+	 * code path without actually persisting the model.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array<int, string>
+	 */
+	public array $changedFields = [];
+
+	protected $guarded = [];
+
+	/**
+	 * Trait override — returns the per-test image config.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function optimizableImages(): array
+	{
+		return $this->imageConfig;
+	}
+
+	/**
+	 * Test override for Eloquent's `wasChanged()`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  array<int, string>|string|null $attributes Attribute name(s) to test.
+	 *
+	 * @return bool
+	 */
+	public function wasChanged( $attributes = null ): bool
+	{
+		if ( null === $attributes ) {
+			return ! empty( $this->changedFields );
+		}
+
+		$names = is_array( $attributes ) ? $attributes : [ $attributes ];
+
+		foreach ( $names as $name ) {
+			if ( in_array( $name, $this->changedFields, true ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
## Description

Bundles five related Phase 2/3 features into a single PR per request — the five issues are individually small and tightly thematic (image model surface + script/CSS optimization primitives), so they're easier to review together than separately.

**Closes:** #16, #17, #18, #19, #20

## Type of Change

- [x] New feature (adds new functionality)

## Related Issues

- **#16** — Create `HasOptimizedImages` trait
- **#17** — Create image optimization feature tests
- **#18** — Implement `ScriptManager` service
- **#19** — Implement script loading strategies
- **#20** — Implement critical CSS extraction

## Motivation and Context

Phase 2 wraps up by giving consuming Eloquent models a clean way to expose optimized variants (`#16`) and locking the image pipeline behind a broad feature-test sweep (`#17`). Phase 3 opens with the script-loading primitives (`#18` + `#19`) and the critical-CSS extractor (`#20`) — the four building blocks every host app needs to ship the package's perf wins to the browser without writing its own scaffolding.

## Changes Made

**#16 — `HasOptimizedImages` trait** (`src/Traits/HasOptimizedImages.php`)
- `getOptimizedImageUrl($field, $format, $size)`, `getImageSrcset($field, $format = null)`, `getImageDominantColor($field)`
- Optional `auto_optimize` flag wires `OptimizeImageJob` to the `saved` model event for changed fields
- Source resolution mirrors `ResponsiveImage` (web-relative paths via `public_path()`, remote URLs rejected, raw fs paths refused as public URLs to prevent path leaks)

**#17 — Image optimization feature tests** (`tests/Feature/Images/ImageOptimizationFeatureTest.php`)
- End-to-end coverage glueing the image service, format converter, dominant-color extractor, responsive generator, Blade components, queued jobs, and the `perf:generate-webp` command — JPEG/PNG/GIF sources, WebP/AVIF formats, both GD + Imagick when available
- Per-class tests already cover unit-level behavior; this file adds the integration glue

**#18 — `ScriptManager` service** (`src/JavaScript/ScriptManager.php` + `ScriptRegistration.php`)
- Fluent builder returned by `Performance::script($src)` — `defer()`, `async()`, `module()`, `inline($body)`, `priority(N)`, `loadOn(...)`, `target($selector)`, `attribute(name, value)`, `name(string)`
- `Performance::renderScripts()` emits a deterministic priority-ordered HTML block

**#19 — Loading strategies** (`src/JavaScript/{Defer,Async,Module,Inline,Abstract}Strategy.php` + `ScriptStrategy.php`)
- Four bundled strategies + an interface so applications can swap their own
- `</script>` end-tag escape applied to inline bodies; arbitrary attribute names whitelisted to ASCII identifier characters
- Conditional-loading hints emitted as `data-load-on` / `data-target`

**#20 — Critical CSS extractor** (`src/Css/CriticalCssExtractor.php` + `Console/Commands/GenerateCriticalCssCommand.php` + `View/Components/CriticalCss.php`)
- Rule-based extractor (no headless-browser dep): always preserves `@font-face`, `@keyframes`, `@supports`, `@page`, `@import`, `@charset`, `@namespace`, `@layer`; drops `@media (min-width: …)` queries above the configured viewport; matches a curated critical-selector list with proper token boundaries
- `@criticalCss` Blade directive resolves the current route and inlines the cached `<style data-critical="…">` block
- `<x-perf-critical-css :route="…" />` component for explicit-route usage
- `php artisan perf:critical-css {--route=* --all --force}` warms the cache
- Sources registered via config (`artisanpack.performance.css.critical.sources`) or programmatically (`$extractor->registerSource($route, $cssPathOrContent)`)

**Wiring** — `PerformanceServiceProvider` binds `ScriptManager` and `CriticalCssExtractor` as singletons, registers the `@criticalCss` directive, the `<x-perf-critical-css>` component, the `perf:critical-css` artisan command, and feeds config-declared sources into the extractor on boot. `PerformanceService` gains accessors (`scripts()`, `criticalCss()`) and the `script()`/`getScripts()`/`renderScripts()` surface.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS Darwin 25.5.0
- Browser: Safari (Herd HTTPS)
- PHP Version: 8.4.22
- Project Version: 1.0.0 (release/1.0)

**Tests Performed:**
1. Pest suite — 197 passing, 1 skipped (Imagick-only), 0 failing
2. `vendor/bin/php-cs-fixer fix` — 0 of 53 files modified
3. `vendor/bin/phpcs` — clean across all 53 files
4. Manual surface at `/performance-test` in the dev app, exercising all five features against three real photos in `storage/app/public/perf-test/` — `@criticalCss` directive emits the inline `<style>` block in `<head>`; trait helpers (`getOptimizedImageUrl`, `getImageSrcset`, `getImageDominantColor`) return well-formed `/storage/perf-test/…` URLs; ScriptManager renders 5 registered scripts in correct priority order spanning all four strategies; critical-CSS source vs. extracted output side-by-side confirms `.footer`/`.related-articles` rules + `@media (min-width: 2000px)` are dropped while `*`/`body`/`header`/`.container`/`.hero` survive and `@media (min-width: 600px)` is kept
5. Pre-commit code-review pass surfaced 7 findings (path leak, universal-selector false positive, body-less at-rule tokenization, eager config read, test stub collision, missing property defaults, duplicated 'default' literal) — all fixed in this PR with regression tests added

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Backend-only PR — no new user-facing UI introduced by the package itself. The optional `<x-perf-critical-css>` Blade component emits a `<style>` block in `<head>`, which is inert from an a11y perspective.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `tests/Feature/Traits/HasOptimizedImagesTest.php` — 11 tests covering field-resolution, URL/srcset/dominant-color helpers, auto_optimize job dispatch, remote-URL rejection, public_path fallback, and the path-leak regression
- `tests/Feature/JavaScript/ScriptManagerTest.php` — manager lifecycle, priority ordering, lazy strategy resolution, facade integration
- `tests/Feature/JavaScript/ScriptStrategiesTest.php` — render output + XSS escaping for all four strategies
- `tests/Feature/Css/CriticalCssExtractorTest.php` — selector heuristics, body-less at-rule preservation, `@media` width filtering, cache lifecycle, route-fallback chain
- `tests/Feature/Images/ImageOptimizationFeatureTest.php` — integration glue per #17
- `tests/Fixtures/HasOptimizedImagesModelStub.php` — namespaced model stub (per the "one class per file" convention)

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Every new class/trait/component carries a file-level docblock + class docblock + per-method docblocks following the package's existing PHPDoc style. README / Wiki updates can land in a separate doc PR once the public-facing copy is finalized.

## Screenshots

The manual test surface lives at `/performance-test` in the dev app; HTML output captured during testing is in the PR conversation.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed (N/A — backend-only)
- [x] Code follows project style guide
- [x] Self-review completed (multi-angle code-review skill run; 7 findings actioned)
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added critical CSS support, including on-page injection and a command to generate cached critical styles for routes.
  * Introduced flexible script loading options such as async, defer, module, and inline rendering.
  * Added image optimization helpers for responsive images, optimized URLs, dominant color extraction, and automatic optimization on save.

* **Bug Fixes**
  * Improved handling of empty or missing critical CSS so layouts render safely without extra output.
  * Strengthened HTML escaping for script output and inline content to reduce rendering issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->