### PR TITLE
feat: query caching trait, cache strategies, query analyzer, N+1 detector (#37-#41)

### DIFF
--- a/src/Cache/CacheStrategyManager.php
+++ b/src/Cache/CacheStrategyManager.php
@@ -1,0 +1,193 @@
+<?php
+
+/**
+ * Cache strategy manager.
+ *
+ * Resolves a `CacheStrategy` implementation by name. The manager keeps
+ * a static map of built-in strategies (file, redis, memcached) and lets
+ * applications register custom strategies via `extend()`. Consumers
+ * (CachesQueries trait, future PageCacheManager / FragmentCache rewrites)
+ * call `driver()` with the configured driver name and receive an
+ * instance ready to read/write through the appropriate Laravel store.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Cache;
+
+use ArtisanPackUI\Performance\Cache\Strategies\FileCacheStrategy;
+use ArtisanPackUI\Performance\Cache\Strategies\MemcachedCacheStrategy;
+use ArtisanPackUI\Performance\Cache\Strategies\RedisCacheStrategy;
+use ArtisanPackUI\Performance\Contracts\CacheStrategy;
+use Closure;
+use InvalidArgumentException;
+
+/**
+ * Cache strategy manager class.
+ *
+ *
+ * @since      1.0.0
+ */
+class CacheStrategyManager
+{
+    /**
+     * The default strategy bindings keyed by driver name.
+     *
+     * Built-in drivers are bound to closures so the strategy instance
+     * is only constructed when first requested. Closures registered via
+     * `extend()` win over the built-ins.
+     *
+     * @since 1.0.0
+     *
+     * @var array<string, Closure>
+     */
+    protected array $extensions = [];
+
+    /**
+     * Cache of already-resolved strategies keyed by driver name.
+     *
+     * @since 1.0.0
+     *
+     * @var array<string, CacheStrategy>
+     */
+    protected array $resolved = [];
+
+    /**
+     * Returns the strategy instance for the given driver name.
+     *
+     * Falls back to the configured `page_cache.driver` (then `file`)
+     * when no driver name is supplied. Resolved instances are memoized
+     * so callers reuse a single instance per request.
+     *
+     * @since 1.0.0
+     *
+     * @param  string|null  $driver  Driver name (file, redis, memcached, or a registered extension).
+     *
+     * @throws InvalidArgumentException When the driver is not registered.
+     */
+    public function driver( ?string $driver = null ): CacheStrategy
+    {
+        $name = $driver ?? $this->defaultDriver();
+
+        if ( isset( $this->resolved[ $name ] ) ) {
+            return $this->resolved[ $name ];
+        }
+
+        if ( isset( $this->extensions[ $name ] ) ) {
+            return $this->resolved[ $name ] = ( $this->extensions[ $name ] )();
+        }
+
+        $builtIn = $this->builtInStrategy( $name );
+
+        if ( null !== $builtIn ) {
+            return $this->resolved[ $name ] = $builtIn;
+        }
+
+        throw new InvalidArgumentException( "Cache strategy [{$name}] is not registered." );
+    }
+
+    /**
+     * Registers a custom cache strategy.
+     *
+     * Custom strategies override the built-in mapping for the same name,
+     * which lets applications swap, for example, a hardened Redis
+     * implementation in place of the default one without touching call
+     * sites.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $driver  Driver name.
+     * @param  Closure  $factory  Factory returning a CacheStrategy.
+     */
+    public function extend( string $driver, Closure $factory ): void
+    {
+        $this->extensions[ $driver ] = $factory;
+        unset( $this->resolved[ $driver ] );
+    }
+
+    /**
+     * Reports whether the manager can resolve the given driver name.
+     *
+     * Built-in driver names (file/redis/memcached) only count when
+     * Laravel ALSO has a matching `cache.stores.{driver}` entry — the
+     * package's strategy can't read from a store the host application
+     * didn't provision. Without this check, `hasDriver('redis')` would
+     * return true on a fresh app with no redis configured and the
+     * first strategy call would throw `InvalidArgumentException: Cache
+     * store [redis] is not defined.`
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $driver  Driver name to probe.
+     */
+    public function hasDriver( string $driver ): bool
+    {
+        if ( isset( $this->extensions[ $driver ] ) ) {
+            return true;
+        }
+
+        if ( null === $this->builtInStrategy( $driver ) ) {
+            return false;
+        }
+
+        return $this->storeConfigured( $driver );
+    }
+
+    /**
+     * Returns the strategy used when no driver name is supplied.
+     *
+     * Reads `artisanpack.performance.page_cache.driver` first so a single
+     * config switch flips the default for callers that don't pass a
+     * driver name explicitly. Falls back to `file` to keep the default
+     * usable on a stock Laravel install with no Redis/Memcached running.
+     *
+     * @since 1.0.0
+     */
+    public function defaultDriver(): string
+    {
+        $configured = (string) config( 'artisanpack.performance.page_cache.driver', '' );
+
+        return '' !== $configured ? $configured : 'file';
+    }
+
+    /**
+     * Reports whether Laravel's `cache.stores.{driver}` is configured.
+     *
+     * Reads the raw config map rather than calling `Cache::store()` so
+     * the probe stays cheap (no driver allocation) and doesn't throw
+     * for unconfigured names — those are exactly the case we want to
+     * report as `false`.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $driver  Driver name.
+     */
+    protected function storeConfigured( string $driver ): bool
+    {
+        $stores = (array) config( 'cache.stores', [] );
+
+        return isset( $stores[ $driver ] );
+    }
+
+    /**
+     * Returns a fresh built-in strategy instance for the given name.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $name  Driver name.
+     */
+    protected function builtInStrategy( string $name ): ?CacheStrategy
+    {
+        return match ( $name ) {
+            'file'      => new FileCacheStrategy,
+            'redis'     => new RedisCacheStrategy,
+            'memcached' => new MemcachedCacheStrategy,
+            default     => null,
+        };
+    }
+}

--- a/src/Cache/Strategies/AbstractCacheStrategy.php
+++ b/src/Cache/Strategies/AbstractCacheStrategy.php
@@ -1,0 +1,329 @@
+<?php
+
+/**
+ * Abstract cache strategy.
+ *
+ * Holds the shared behavior every CacheStrategy implementation needs:
+ * resolving a Laravel cache Repository for a named store, scoping reads
+ * and writes through that repository, and maintaining a per-store tag
+ * index for drivers that don't expose native tagging (file). Concrete
+ * strategies override `storeName()` so each one resolves the correct
+ * Laravel store.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Cache\Strategies;
+
+use ArtisanPackUI\Performance\Contracts\CacheStrategy;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Facades\Cache;
+use Throwable;
+
+/**
+ * Abstract cache strategy class.
+ *
+ *
+ * @since      1.0.0
+ */
+abstract class AbstractCacheStrategy implements CacheStrategy
+{
+    /**
+     * Cache key holding the tag → cache-key index for this strategy.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    public const TAG_INDEX_KEY = 'perf:strategy-tags';
+
+    /**
+     * TTL applied to the tag index so it outlives normal cache entries.
+     *
+     * @since 1.0.0
+     *
+     * @var int
+     */
+    public const INDEX_TTL = 31536000;
+
+    /**
+     * Tags currently scoping this strategy.
+     *
+     * @since 1.0.0
+     *
+     * @var array<int, string>
+     */
+    protected array $scopedTags = [];
+
+    /**
+     * Returns the Laravel cache store name this strategy targets.
+     *
+     * @since 1.0.0
+     */
+    abstract public function storeName(): string;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get( string $key ): ?string
+    {
+        $value = $this->repository()->get( $key );
+
+        return is_string( $value ) ? $value : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function put( string $key, string $value, int $ttl ): bool
+    {
+        if ( $ttl > 0 ) {
+            $result = $this->repository()->put( $key, $value, $ttl );
+        } else {
+            $result = $this->repository()->forever( $key, $value );
+        }
+
+        $this->trackTags( $key );
+
+        return (bool) $result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function forget( string $key ): bool
+    {
+        return (bool) $this->repository()->forget( $key );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function flush(): bool
+    {
+        $repo = $this->repository();
+
+        if ( ! empty( $this->scopedTags ) && $this->repositorySupportsTags() ) {
+            return (bool) $repo->flush();
+        }
+
+        if ( ! empty( $this->scopedTags ) ) {
+            return $this->flushScopedTags();
+        }
+
+        return (bool) Cache::store( $this->storeName() )->flush();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tags( array $tags ): static
+    {
+        $clone             = clone $this;
+        $clone->scopedTags = array_values( array_unique( array_filter(
+            $tags,
+            static fn ( $tag ): bool => is_string( $tag ) && '' !== $tag,
+        ) ) );
+
+        return $clone;
+    }
+
+    /**
+     * Returns the tags currently scoping this strategy.
+     *
+     * @since 1.0.0
+     *
+     * @return array<int, string>
+     */
+    public function getScopedTags(): array
+    {
+        return $this->scopedTags;
+    }
+
+    /**
+     * Resolves the cache repository used for reads and writes.
+     *
+     * When the underlying repository supports tags AND the strategy is
+     * scoped to a tag list, the tagged proxy is returned so put/get
+     * operations route through the driver's native tag index. Otherwise
+     * the bare repository is returned and the tag-prefix index handles
+     * cleanup in `flushScopedTags()`.
+     *
+     * @since 1.0.0
+     *
+     * @return \Illuminate\Cache\TaggedCache|Repository
+     */
+    protected function repository()
+    {
+        $store = Cache::store( $this->storeName() );
+
+        if ( ! empty( $this->scopedTags ) && $this->repositorySupportsTags() ) {
+            return $store->tags( $this->scopedTags );
+        }
+
+        return $store;
+    }
+
+    /**
+     * Reports whether the underlying store supports native tag scoping.
+     *
+     * @since 1.0.0
+     */
+    protected function repositorySupportsTags(): bool
+    {
+        try {
+            $store = Cache::store( $this->storeName() );
+            $store->tags( ['probe'] );
+
+            return true;
+        } catch ( Throwable ) {
+            return false;
+        }
+    }
+
+    /**
+     * Records the cache key against each scoped tag in the side index.
+     *
+     * Only fires when the strategy is scoped to a tag list AND the
+     * underlying store doesn't expose native tag support — drivers with
+     * native taggable repositories track their own index, so a second
+     * one here would be redundant work.
+     *
+     * The read-modify-write is wrapped in a cache lock so concurrent
+     * writers don't drop each other's index entries; without the lock,
+     * two puts against the same tag that read the same snapshot would
+     * each write back their own addition, silently orphaning the
+     * other's cache key from future `flush()` calls. FragmentCache
+     * pioneered this guard for the same reason.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $key  The cache key that was just written.
+     */
+    protected function trackTags( string $key ): void
+    {
+        if ( empty( $this->scopedTags ) ) {
+            return;
+        }
+
+        if ( $this->repositorySupportsTags() ) {
+            return;
+        }
+
+        $this->withIndexLock( function () use ( $key ): void {
+            $index = $this->readTagIndex();
+
+            foreach ( $this->scopedTags as $tag ) {
+                $bucket         = $index[ $tag ] ?? [];
+                $bucket[ $key ] = true;
+                $index[ $tag ]  = $bucket;
+            }
+
+            $this->writeTagIndex( $index );
+        } );
+    }
+
+    /**
+     * Flushes every key registered against any of the scoped tags.
+     *
+     * Wrapped in the same lock as `trackTags()` so a racing put cannot
+     * land a new tag-bucket entry against the snapshot we just emptied
+     * — without the lock that put would survive the flush and leak its
+     * cache entry as an orphan that no future flush can find.
+     *
+     * @since 1.0.0
+     */
+    protected function flushScopedTags(): bool
+    {
+        $this->withIndexLock( function (): void {
+            $index   = $this->readTagIndex();
+            $store   = Cache::store( $this->storeName() );
+            $changed = false;
+
+            foreach ( $this->scopedTags as $tag ) {
+                $bucket = $index[ $tag ] ?? [];
+
+                if ( ! is_array( $bucket ) ) {
+                    continue;
+                }
+
+                foreach ( array_keys( $bucket ) as $cacheKey ) {
+                    if ( is_string( $cacheKey ) ) {
+                        $store->forget( $cacheKey );
+                    }
+                }
+
+                unset( $index[ $tag ] );
+                $changed = true;
+            }
+
+            if ( $changed ) {
+                $this->writeTagIndex( $index );
+            }
+        } );
+
+        return true;
+    }
+
+    /**
+     * Runs the callback while holding the strategy's index lock.
+     *
+     * Falls back to executing the callback unguarded when the
+     * configured cache store doesn't expose locking (array driver,
+     * custom drivers without LockProvider). Those scenarios are either
+     * tests — where the race can't fire because PHP is single-threaded
+     * inside a test — or explicit operator choice, so the alternative
+     * (throwing) would do more damage than a best-effort write.
+     *
+     * @since 1.0.0
+     *
+     * @param  callable  $callback  Operation to perform under the lock.
+     */
+    protected function withIndexLock( callable $callback ): void
+    {
+        try {
+            $lock = Cache::store( $this->storeName() )->lock( self::TAG_INDEX_KEY . ':lock', 5 );
+        } catch ( Throwable ) {
+            $callback();
+
+            return;
+        }
+
+        try {
+            $lock->block( 3, $callback );
+        } catch ( Throwable ) {
+            $callback();
+        }
+    }
+
+    /**
+     * Returns the current tag index from the underlying store.
+     *
+     * @since 1.0.0
+     *
+     * @return array<string, array<string, true>>
+     */
+    protected function readTagIndex(): array
+    {
+        $index = Cache::store( $this->storeName() )->get( self::TAG_INDEX_KEY, [] );
+
+        return is_array( $index ) ? $index : [];
+    }
+
+    /**
+     * Persists the tag index back to the underlying store.
+     *
+     * @since 1.0.0
+     *
+     * @param  array<string, array<string, true>>  $index  The new tag index.
+     */
+    protected function writeTagIndex( array $index ): void
+    {
+        Cache::store( $this->storeName() )->put( self::TAG_INDEX_KEY, $index, self::INDEX_TTL );
+    }
+}

--- a/src/Cache/Strategies/FileCacheStrategy.php
+++ b/src/Cache/Strategies/FileCacheStrategy.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * File cache strategy.
+ *
+ * Wraps Laravel's `file` cache store. The file driver does not support
+ * native taggable repositories, so the abstract base falls back to its
+ * tag-prefix index for tag-scoped invalidation.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Cache\Strategies;
+
+/**
+ * File cache strategy class.
+ *
+ *
+ * @since      1.0.0
+ */
+class FileCacheStrategy extends AbstractCacheStrategy
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function storeName(): string
+    {
+        return 'file';
+    }
+}

--- a/src/Cache/Strategies/MemcachedCacheStrategy.php
+++ b/src/Cache/Strategies/MemcachedCacheStrategy.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Memcached cache strategy.
+ *
+ * Wraps Laravel's `memcached` cache store. The Memcached driver exposes
+ * native taggable repositories.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Cache\Strategies;
+
+/**
+ * Memcached cache strategy class.
+ *
+ *
+ * @since      1.0.0
+ */
+class MemcachedCacheStrategy extends AbstractCacheStrategy
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function storeName(): string
+    {
+        return 'memcached';
+    }
+}

--- a/src/Cache/Strategies/RedisCacheStrategy.php
+++ b/src/Cache/Strategies/RedisCacheStrategy.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Redis cache strategy.
+ *
+ * Wraps Laravel's `redis` cache store. The Redis driver exposes native
+ * taggable repositories, so the abstract base routes scoped writes
+ * through `Cache::store('redis')->tags($tags)` and `flush()` invalidates
+ * only the scoped tag set.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Cache\Strategies;
+
+/**
+ * Redis cache strategy class.
+ *
+ *
+ * @since      1.0.0
+ */
+class RedisCacheStrategy extends AbstractCacheStrategy
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function storeName(): string
+    {
+        return 'redis';
+    }
+}

--- a/src/Contracts/CacheStrategy.php
+++ b/src/Contracts/CacheStrategy.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Cache strategy contract.
+ *
+ * Defines a uniform read/write/forget/flush API the Performance package
+ * uses to interact with its various caching backends (file, Redis,
+ * Memcached). Strategies wrap the underlying Laravel cache repository so
+ * callers can swap backends per feature (page cache, fragment cache,
+ * query cache) via configuration without touching call sites.
+ *
+ * The contract intentionally uses string payloads and integer TTLs so
+ * implementations remain free to delegate to drivers without native
+ * serialization (raw Redis strings, file contents) while higher-level
+ * callers (CachesQueries trait, FragmentCache) handle serialization at
+ * their boundary.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Contracts;
+
+/**
+ * Cache strategy contract.
+ *
+ *
+ * @since      1.0.0
+ */
+interface CacheStrategy
+{
+    /**
+     * Retrieves the raw cached value for the given key.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $key  Cache key.
+     *
+     * @return string|null The raw cached value, or null when missing.
+     */
+    public function get( string $key ): ?string;
+
+    /**
+     * Persists the value under the given key for the given TTL.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $key  Cache key.
+     * @param  string  $value  Raw value to store.
+     * @param  int  $ttl  Time-to-live in seconds. Zero defers to the driver default.
+     *
+     * @return bool True when the write succeeded.
+     */
+    public function put( string $key, string $value, int $ttl ): bool;
+
+    /**
+     * Removes the entry for the given key.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $key  Cache key.
+     *
+     * @return bool True when the entry existed and was removed.
+     */
+    public function forget( string $key ): bool;
+
+    /**
+     * Flushes every entry the strategy can reach.
+     *
+     * @since 1.0.0
+     *
+     * @return bool True when the flush succeeded.
+     */
+    public function flush(): bool;
+
+    /**
+     * Returns a derivative strategy scoped to the given tags.
+     *
+     * Implementations that wrap a taggable repository delegate to
+     * `Cache::store(...)->tags($tags)`; non-taggable strategies fall
+     * back to a tag-prefix index so the higher-level API remains
+     * uniform across drivers. Implementations must return `static`
+     * (a new instance) rather than mutating self so the original
+     * strategy stays usable for non-tag callers.
+     *
+     * @since 1.0.0
+     *
+     * @param  array<int, string>  $tags  Tags to attach.
+     */
+    public function tags( array $tags ): static;
+}

--- a/src/Database/CachingEloquentBuilder.php
+++ b/src/Database/CachingEloquentBuilder.php
@@ -1,0 +1,368 @@
+<?php
+
+/**
+ * Caching Eloquent builder.
+ *
+ * A drop-in Eloquent builder subclass that intercepts terminal query
+ * methods (`get`, `first`, `count`, `pluck`, `paginate`, `find`, etc.)
+ * and routes them through the Performance package's query cache when
+ * the caller has opted in via `cacheFor()`. Without the cache flag the
+ * builder behaves exactly like the stock Eloquent builder, so the trait
+ * is safe to mix into existing models without changing default
+ * behavior.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Database;
+
+use ArtisanPackUI\Performance\Cache\CacheStrategyManager;
+use ArtisanPackUI\Performance\Contracts\CacheStrategy;
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
+
+/**
+ * Caching Eloquent builder class.
+ *
+ *
+ * @since      1.0.0
+ */
+class CachingEloquentBuilder extends Builder
+{
+    /**
+     * Cache key prefix applied to every query cache entry written by the builder.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    public const KEY_PREFIX = 'perf:query:';
+
+    /**
+     * TTL the caller asked for via `cacheFor()`, in seconds.
+     *
+     * @since 1.0.0
+     */
+    protected ?int $cacheTtl = null;
+
+    /**
+     * Optional custom cache key supplied via `cacheFor()`.
+     *
+     * @since 1.0.0
+     */
+    protected ?string $cacheCustomKey = null;
+
+    /**
+     * Additional tags applied via `cacheTags()`.
+     *
+     * @since 1.0.0
+     *
+     * @var array<int, string>
+     */
+    protected array $cacheExtraTags = [];
+
+    /**
+     * Marks the pending query as cached for the given TTL.
+     *
+     * Returning `$this` keeps the fluent builder API intact so callers
+     * can write `Post::cacheFor(3600)->popular()->get()` as the issue
+     * spec describes.
+     *
+     * @since 1.0.0
+     *
+     * @param  int  $ttl  Time-to-live in seconds. Non-positive values disable caching for this query.
+     * @param  string|null  $key  Optional custom cache key.
+     */
+    public function cacheFor( int $ttl, ?string $key = null ): static
+    {
+        $this->cacheTtl       = $ttl > 0 ? $ttl : null;
+        $this->cacheCustomKey = ( null !== $key && '' !== $key ) ? $key : null;
+
+        return $this;
+    }
+
+    /**
+     * Adds tags to the pending query cache entry.
+     *
+     * Tags are merged with the model's default table tag (added by the
+     * trait) so callers compose targeted invalidation without losing
+     * the auto-invalidation hook.
+     *
+     * @since 1.0.0
+     *
+     * @param  array<int, string>  $tags  Tags to attach.
+     */
+    public function cacheTags( array $tags ): static
+    {
+        $filtered = array_values( array_filter(
+            $tags,
+            static fn ( $tag ): bool => is_string( $tag ) && '' !== $tag,
+        ) );
+
+        $this->cacheExtraTags = array_values( array_unique( array_merge(
+            $this->cacheExtraTags,
+            $filtered,
+        ) ) );
+
+        return $this;
+    }
+
+    /**
+     * Returns the TTL currently flagged on the builder.
+     *
+     * @since 1.0.0
+     */
+    public function getCacheTtl(): ?int
+    {
+        return $this->cacheTtl;
+    }
+
+    /**
+     * Returns the custom cache key currently flagged on the builder.
+     *
+     * @since 1.0.0
+     */
+    public function getCacheCustomKey(): ?string
+    {
+        return $this->cacheCustomKey;
+    }
+
+    /**
+     * Returns the extra tags currently flagged on the builder.
+     *
+     * @since 1.0.0
+     *
+     * @return array<int, string>
+     */
+    public function getCacheExtraTags(): array
+    {
+        return $this->cacheExtraTags;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Routes through the query cache when `cacheFor()` set a TTL.
+     *
+     * @since 1.0.0
+     */
+    public function get( $columns = [ '*' ] )
+    {
+        return $this->withQueryCache(
+            __FUNCTION__,
+            [ $columns ],
+            fn () => parent::get( $columns ),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 1.0.0
+     */
+    public function pluck( $column, $key = null )
+    {
+        return $this->withQueryCache(
+            __FUNCTION__,
+            [ $column, $key ],
+            fn () => parent::pluck( $column, $key ),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 1.0.0
+     */
+    public function count( $columns = '*' )
+    {
+        return $this->withQueryCache(
+            __FUNCTION__,
+            [ $columns ],
+            fn () => parent::count( $columns ),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Resolves the current page from the request when `$page` is null so
+     * the cache key reflects the page actually being rendered. Without
+     * this step, every `?page=N` URL would collide on a single cache
+     * entry and silently serve the first paginator a worker observed.
+     *
+     * @since 1.0.0
+     */
+    public function paginate( $perPage = null, $columns = [ '*' ], $pageName = 'page', $page = null, $total = null ): LengthAwarePaginator
+    {
+        $resolvedPage = $page ?? Paginator::resolveCurrentPage( $pageName );
+
+        return $this->withQueryCache(
+            __FUNCTION__,
+            [ $perPage, $columns, $pageName, $resolvedPage, $total ],
+            fn () => parent::paginate( $perPage, $columns, $pageName, $page, $total ),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 1.0.0
+     */
+    public function exists()
+    {
+        return $this->withQueryCache(
+            __FUNCTION__,
+            [],
+            fn () => parent::exists(),
+        );
+    }
+
+    /**
+     * Returns the strategy used to read/write query cache entries.
+     *
+     * Resolution order: `database.query_cache.driver` → manager default →
+     * `file`. The manager is resolved through the container so tests can
+     * bind a fake without touching the trait.
+     *
+     * @since 1.0.0
+     */
+    public function cacheStrategy(): CacheStrategy
+    {
+        $driver  = (string) config( 'artisanpack.performance.database.query_cache.driver', '' );
+        $manager = app( CacheStrategyManager::class );
+
+        return '' !== $driver && $manager->hasDriver( $driver )
+            ? $manager->driver( $driver )
+            : $manager->driver();
+    }
+
+    /**
+     * Reads the cached payload or runs the callback on MISS.
+     *
+     * Method-name + argument signature are mixed into the cache key so
+     * `->get()`, `->pluck('id')`, and `->count()` against the same SQL
+     * land on distinct entries — Laravel emits the same underlying SQL
+     * for all three but their result shapes differ, so collapsing them
+     * would corrupt the cache.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $method  The terminal method being called.
+     * @param  array<int, mixed>  $args  The arguments passed to that method.
+     * @param  Closure  $callback  Callback that executes the underlying query on MISS.
+     */
+    protected function withQueryCache( string $method, array $args, Closure $callback ): mixed
+    {
+        if ( null === $this->cacheTtl ) {
+            return $callback();
+        }
+
+        $strategy = $this->cacheStrategy();
+        $tags     = $this->resolveTags();
+        $key      = $this->buildCacheKey( $method, $args );
+
+        $scoped = $strategy->tags( $tags );
+        $hit    = $scoped->get( $key );
+
+        if ( is_string( $hit ) ) {
+            return unserialize( $hit, [ 'allowed_classes' => true ] );
+        }
+
+        $value = $callback();
+
+        $scoped->put( $key, serialize( $value ), $this->cacheTtl );
+
+        return $value;
+    }
+
+    /**
+     * Returns the tags applied to the pending query cache entry.
+     *
+     * The model's table tag is always included so the trait's
+     * save/delete hooks can invalidate every cached query touching the
+     * model in one call.
+     *
+     * @since 1.0.0
+     *
+     * @return array<int, string>
+     */
+    protected function resolveTags(): array
+    {
+        $tags = [ 'model:' . $this->getModel()->getTable() ];
+
+        return array_values( array_unique( array_merge( $tags, $this->cacheExtraTags ) ) );
+    }
+
+    /**
+     * Builds the cache key for the pending query + method + args.
+     *
+     * The custom-key path still mixes the underlying SQL + bindings into
+     * the hash so two callers that pick the same friendly name on
+     * different chains don't silently collide and serve each other's
+     * data. The custom key narrows the namespace; the SQL discriminator
+     * preserves correctness.
+     *
+     * Eager-load constraints are captured by `spl_object_hash` on each
+     * registered closure rather than by relation name alone, so two
+     * calls that pass different constraint closures land on distinct
+     * keys. Two callers passing structurally identical but distinct
+     * closures pay a small extra cache-miss penalty — the alternative
+     * (collapsing them by name) would let `with(['c' => fn($q) => $q->where('approved', true)])`
+     * and `with(['c' => fn($q) => $q->where('approved', false)])` HIT
+     * each other's entries, which is a correctness bug.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $method  Terminal method name.
+     * @param  array<int, mixed>  $args  Terminal method arguments.
+     */
+    protected function buildCacheKey( string $method, array $args ): string
+    {
+        $base    = $this->getQuery();
+        $payload = [
+            'class'      => get_class( $this->getModel() ),
+            'connection' => $base->getConnection()->getName(),
+            'sql'        => $base->toSql(),
+            'bindings'   => $base->getBindings(),
+            'method'     => $method,
+            'args'       => $args,
+            'eager'      => $this->eagerLoadFingerprint(),
+            'custom'     => $this->cacheCustomKey,
+        ];
+
+        return self::KEY_PREFIX . sha1( serialize( $payload ) );
+    }
+
+    /**
+     * Returns a deterministic fingerprint of the registered eager loads.
+     *
+     * Each relation name is paired with `spl_object_hash` of its
+     * constraint closure (or an empty string when the relation has no
+     * custom constraint), so two `with()` calls that pass different
+     * closures get different keys.
+     *
+     * @since 1.0.0
+     *
+     * @return array<string, string>
+     */
+    protected function eagerLoadFingerprint(): array
+    {
+        $fingerprint = [];
+
+        foreach ( $this->getEagerLoads() as $relation => $constraint ) {
+            $fingerprint[ (string) $relation ] = $constraint instanceof Closure
+                ? spl_object_hash( $constraint )
+                : '';
+        }
+
+        return $fingerprint;
+    }
+}

--- a/src/Database/N1Detector.php
+++ b/src/Database/N1Detector.php
@@ -1,0 +1,366 @@
+<?php
+
+/**
+ * N+1 query detector.
+ *
+ * Subscribes to query execution events, normalizes each statement
+ * through `QueryAnalyzer`, and dispatches `N1QueryDetected` the
+ * moment a single signature exceeds the configured threshold within
+ * a request. The detector also derives a "model + relation"
+ * suggestion from the captured SQL so the event payload can power
+ * actionable warnings ("Add `->with('comments')` to Post").
+ *
+ * The detector intentionally fires the event ONCE per signature per
+ * request — repeat firings for the same signature would spam the
+ * configured listeners (log channels, notification recipients) on a
+ * page that runs 100 of the same query.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Database;
+
+use ArtisanPackUI\Performance\Events\N1QueryDetected;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Throwable;
+
+/**
+ * N+1 query detector class.
+ *
+ *
+ * @since      1.0.0
+ */
+class N1Detector
+{
+    /**
+     * The QueryAnalyzer used to normalize captured SQL.
+     *
+     * @since 1.0.0
+     */
+    protected QueryAnalyzer $analyzer;
+
+    /**
+     * Whether the detector is currently subscribed to `DB::listen()`.
+     *
+     * @since 1.0.0
+     */
+    protected bool $listening = false;
+
+    /**
+     * Per-request counter keyed by normalized SQL signature.
+     *
+     * @since 1.0.0
+     *
+     * @var array<string, int>
+     */
+    protected array $counts = [];
+
+    /**
+     * Signatures that have already triggered an event this request.
+     *
+     * @since 1.0.0
+     *
+     * @var array<string, true>
+     */
+    protected array $reported = [];
+
+    /**
+     * Active route name captured from the running request (or an empty string).
+     *
+     * @since 1.0.0
+     */
+    protected string $currentRoute = '';
+
+    /**
+     * Creates a new detector instance.
+     *
+     * @since 1.0.0
+     *
+     * @param  QueryAnalyzer  $analyzer  The analyzer used for normalization.
+     */
+    public function __construct( QueryAnalyzer $analyzer )
+    {
+        $this->analyzer = $analyzer;
+    }
+
+    /**
+     * Subscribes the detector to `DB::listen()`.
+     *
+     * Idempotent. Reads `database.n1_detection.enabled` once to decide
+     * whether to subscribe; subsequent runtime flips take effect via
+     * the listener closure, which re-reads the flag on every event so
+     * toggling off stops the work even though DB::listen has no
+     * unsubscribe API in stable Laravel.
+     *
+     * @since 1.0.0
+     */
+    public function enable(): void
+    {
+        if ( $this->listening ) {
+            return;
+        }
+
+        if ( ! (bool) config( 'artisanpack.performance.database.n1_detection.enabled', false ) ) {
+            return;
+        }
+
+        $this->listening = true;
+
+        DB::listen( function ( QueryExecuted $event ): void {
+            if ( ! (bool) config( 'artisanpack.performance.database.n1_detection.enabled', false ) ) {
+                return;
+            }
+
+            $this->record( $event );
+        } );
+    }
+
+    /**
+     * Reports whether the detector is currently subscribed.
+     *
+     * @since 1.0.0
+     */
+    public function isEnabled(): bool
+    {
+        return $this->listening;
+    }
+
+    /**
+     * Records a single query execution.
+     *
+     * The method is public so tests and other package code (for
+     * example, the analyzer feeding cached query results) can feed
+     * synthesized events without round-tripping through `DB::listen()`.
+     *
+     * @since 1.0.0
+     *
+     * @param  QueryExecuted  $event  The Laravel query event.
+     */
+    public function record( QueryExecuted $event ): void
+    {
+        $signature = $this->analyzer->normalize( $event->sql );
+
+        if ( '' === $signature ) {
+            return;
+        }
+
+        $this->counts[ $signature ] = ( $this->counts[ $signature ] ?? 0 ) + 1;
+
+        $threshold = (int) config( 'artisanpack.performance.database.n1_detection.threshold', 5 );
+
+        if ( $this->counts[ $signature ] < max( 1, $threshold ) ) {
+            return;
+        }
+
+        if ( isset( $this->reported[ $signature ] ) ) {
+            return;
+        }
+
+        $this->reported[ $signature ] = true;
+
+        $this->reportDetection( $signature, $this->counts[ $signature ] );
+    }
+
+    /**
+     * Returns the per-signature execution counts captured so far.
+     *
+     * @since 1.0.0
+     *
+     * @return array<string, int>
+     */
+    public function getCounts(): array
+    {
+        return $this->counts;
+    }
+
+    /**
+     * Returns the set of signatures that have triggered detection this request.
+     *
+     * @since 1.0.0
+     *
+     * @return array<int, string>
+     */
+    public function getReportedSignatures(): array
+    {
+        return array_keys( $this->reported );
+    }
+
+    /**
+     * Resets the per-request counters and reported-set.
+     *
+     * Called by the Octane request-received hook and by tests
+     * between scenarios to keep state from leaking across requests.
+     *
+     * The active route name is cleared too — without that, an N+1
+     * dispatched on request B (e.g. an anonymous 404 whose middleware
+     * never calls `setCurrentRoute`) would carry request A's route
+     * label.
+     *
+     * @since 1.0.0
+     */
+    public function reset(): void
+    {
+        $this->counts       = [];
+        $this->reported     = [];
+        $this->currentRoute = '';
+    }
+
+    /**
+     * Allows the caller to record the active route name.
+     *
+     * The middleware that wires the detector calls this with
+     * `request()->route()?->getName()` so the dispatched event
+     * carries the route context — useful when developers triage
+     * detection reports after the fact.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $route  Route name.
+     */
+    public function setCurrentRoute( string $route ): void
+    {
+        $this->currentRoute = $route;
+    }
+
+    /**
+     * Returns a "Model::with('relation')" suggestion for the given signature.
+     *
+     * Pattern-matches the normalized SQL for the two canonical N+1
+     * shapes:
+     * - HasMany / HasOne: `SELECT * FROM <table> WHERE <fk>_id = ?` —
+     *   the loop reads child rows per parent. The relation lives on
+     *   the PARENT and the child-table name (camelCased) is a good
+     *   default suggestion.
+     * - BelongsTo / MorphTo: `SELECT * FROM <table> WHERE id = ?` —
+     *   the loop reads parent rows per child. The relation lives on
+     *   the CHILD and is the singular form of the parent-table name
+     *   (camelCased).
+     *
+     * When the pattern doesn't match we return null relation so the
+     * caller can fall back to a generic suggestion in the event
+     * payload.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $signature  Normalized SQL signature.
+     *
+     * @return array{table: string|null, relation: string|null, suggestion: string}
+     */
+    public function suggestFix( string $signature ): array
+    {
+        $table    = null;
+        $relation = null;
+
+        if ( 1 === preg_match( '/from\s+`?(?P<table>[a-z_][a-z0-9_]*)`?\s+where\s+`?(?P<column>[a-z_][a-z0-9_]*)`?\s*=/i', $signature, $matches ) ) {
+            $table    = $matches['table'];
+            $column   = $matches['column'];
+            $relation = $this->inferRelation( $table, $column );
+        }
+
+        $suggestion = null !== $relation
+            ? sprintf( 'Eager-load the relation with ->with(\'%s\') on the parent query.', $relation )
+            : 'A single query signature repeated above the configured threshold — review eager loading on the parent query.';
+
+        return [
+            'table'      => $table,
+            'relation'   => $relation,
+            'suggestion' => $suggestion,
+        ];
+    }
+
+    /**
+     * Dispatches the detection event and writes to the log channel.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $signature  Normalized SQL signature.
+     * @param  int  $count  Number of times the signature ran in this request.
+     */
+    protected function reportDetection( string $signature, int $count ): void
+    {
+        $suggestion = $this->suggestFix( $signature );
+
+        Event::dispatch( new N1QueryDetected(
+            queryNormalized: $signature,
+            count: $count,
+            route: $this->currentRoute,
+        ) );
+
+        $this->writeLog( $signature, $count, $suggestion );
+    }
+
+    /**
+     * Writes the detection to the configured log channel.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $signature  Normalized SQL signature.
+     * @param  int  $count  Number of times the signature ran in this request.
+     * @param  array{table: string|null, relation: string|null, suggestion: string}  $suggestion  The suggestion payload.
+     */
+    protected function writeLog( string $signature, int $count, array $suggestion ): void
+    {
+        $channel = (string) config( 'artisanpack.performance.database.n1_detection.log_channel', '' );
+
+        if ( '' === $channel ) {
+            return;
+        }
+
+        try {
+            Log::channel( $channel )->warning( 'N+1 query detected', [
+                'signature' => $signature,
+                'count'     => $count,
+                'table'     => $suggestion['table'],
+                'relation'  => $suggestion['relation'],
+                'suggest'   => $suggestion['suggestion'],
+                'route'     => $this->currentRoute,
+            ] );
+        } catch ( Throwable ) {
+            // The configured log channel may not exist in the consuming
+            // app (typical in tests / packages exercising the detector
+            // in isolation). Swallow rather than crash the request the
+            // detector is observing — the dispatched event remains the
+            // primary signal.
+        }
+    }
+
+    /**
+     * Infers an Eloquent relation name from a table + WHERE column.
+     *
+     * BelongsTo / MorphTo case: when the WHERE column is `id`, the
+     * loop is fetching parents one-at-a-time by primary key. The
+     * relation lives on the CHILD model and is conventionally the
+     * SINGULAR camelCase form of the parent table — `Comment->user`
+     * for `SELECT * FROM users WHERE id = ?`.
+     *
+     * HasMany / HasOne case: when the WHERE column ends in `_id`, the
+     * loop is fetching children by foreign key. The relation lives on
+     * the PARENT and is the camelCased CHILD table — `Post->comments`
+     * for `SELECT * FROM comments WHERE post_id = ?`.
+     *
+     * Falls back to the camelCased table for anything else so the
+     * suggestion is at least actionable for non-standard schemas.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $table  The table the loop is querying.
+     * @param  string  $column  The WHERE column (FK or `id`).
+     */
+    protected function inferRelation( string $table, string $column ): string
+    {
+        if ( 'id' === strtolower( $column ) ) {
+            return Str::camel( Str::singular( $table ) );
+        }
+
+        return Str::camel( $table );
+    }
+}

--- a/src/Database/QueryAnalyzer.php
+++ b/src/Database/QueryAnalyzer.php
@@ -1,0 +1,360 @@
+<?php
+
+/**
+ * Query analyzer service.
+ *
+ * Captures executed SQL via Laravel's `DB::listen()` hook, normalizes
+ * each statement so logically identical queries collapse to one
+ * signature, and tracks frequency + execution time per signature.
+ * Surfaces the captured data to callers (the N+1 detector, the
+ * dashboard, monitoring listeners) without storing anything on its
+ * own — persistence lives in the slow-query repository and the
+ * monitoring pipeline, both of which subscribe to the analyzer's
+ * `analyze()` output.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Database;
+
+use ArtisanPackUI\Performance\Events\SlowQueryDetected;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+
+/**
+ * Query analyzer service class.
+ *
+ *
+ * @since      1.0.0
+ */
+class QueryAnalyzer
+{
+    /**
+     * Whether the analyzer is currently listening to `DB::listen()`.
+     *
+     * @since 1.0.0
+     */
+    protected bool $listening = false;
+
+    /**
+     * Per-request log of executed queries.
+     *
+     * Each entry is an associative array with `sql`, `bindings`,
+     * `time_ms`, `connection`, and `normalized` keys.
+     *
+     * @since 1.0.0
+     *
+     * @var array<int, array{sql: string, bindings: array<int, mixed>, time_ms: float, connection: string, normalized: string}>
+     */
+    protected array $log = [];
+
+    /**
+     * Frequency counter keyed by normalized signature.
+     *
+     * @since 1.0.0
+     *
+     * @var array<string, int>
+     */
+    protected array $counts = [];
+
+    /**
+     * Cumulative execution time keyed by normalized signature.
+     *
+     * @since 1.0.0
+     *
+     * @var array<string, float>
+     */
+    protected array $timings = [];
+
+    /**
+     * Subscribes the analyzer to Laravel's `DB::listen()` hook.
+     *
+     * Idempotent — repeat calls within the same request short-circuit
+     * to avoid stacking listeners that would double-count every query.
+     * The listener closure re-reads `features.query_optimization` on
+     * every fire so flipping the flag off at runtime stops the work
+     * even though the listener stays subscribed (DB::listen has no
+     * unsubscribe API in stable Laravel).
+     *
+     * @since 1.0.0
+     */
+    public function enableQueryLogging(): void
+    {
+        if ( $this->listening ) {
+            return;
+        }
+
+        $this->listening = true;
+
+        DB::listen( function ( QueryExecuted $event ): void {
+            if ( ! (bool) config( 'artisanpack.performance.features.query_optimization', false ) ) {
+                return;
+            }
+
+            $this->record( $event );
+        } );
+    }
+
+    /**
+     * Reports whether the analyzer is currently listening.
+     *
+     * @since 1.0.0
+     */
+    public function isListening(): bool
+    {
+        return $this->listening;
+    }
+
+    /**
+     * Records a single query execution.
+     *
+     * The recorded payload is what `getLoggedQueries()` returns and
+     * what the N+1 detector consumes. The method is public so other
+     * package code (and tests) can feed synthesized events without
+     * having to round-trip through `DB::listen()`.
+     *
+     * @since 1.0.0
+     *
+     * @param  QueryExecuted  $event  The Laravel query event.
+     */
+    public function record( QueryExecuted $event ): void
+    {
+        $analysis = $this->analyzeQuery( $event->sql, $event->bindings, (float) $event->time );
+
+        $this->log[] = [
+            'sql'        => $event->sql,
+            'bindings'   => $event->bindings,
+            'time_ms'    => $analysis['time_ms'],
+            'connection' => $event->connectionName,
+            'normalized' => $analysis['normalized'],
+        ];
+
+        $signature                   = $analysis['normalized'];
+        $this->counts[ $signature ]  = ( $this->counts[ $signature ] ?? 0 ) + 1;
+        $this->timings[ $signature ] = ( $this->timings[ $signature ] ?? 0.0 ) + $analysis['time_ms'];
+
+        $this->dispatchSlowQueryEvent( $event, $analysis['time_ms'] );
+    }
+
+    /**
+     * Analyzes a single SQL statement.
+     *
+     * Returns the normalized signature, suggestion hints, and a passed
+     * time-in-ms echo so call sites can use one shape regardless of
+     * whether the caller hand-fed the time. Callers can route the
+     * output into log channels or persistence at their boundary.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $sql  The raw SQL statement.
+     * @param  array<int, mixed>  $bindings  Query bindings.
+     * @param  float  $timeMs  Execution time in milliseconds.
+     *
+     * @return array{time_ms: float, normalized: string, suggestions: array<int, string>}
+     */
+    public function analyzeQuery( string $sql, array $bindings = [], float $timeMs = 0.0 ): array
+    {
+        $normalized  = $this->normalize( $sql );
+        $suggestions = $this->suggestionsFor( $normalized, $timeMs );
+
+        return [
+            'time_ms'     => $timeMs,
+            'normalized'  => $normalized,
+            'suggestions' => $suggestions,
+        ];
+    }
+
+    /**
+     * Normalizes a SQL statement to its signature form.
+     *
+     * The normalization rules collapse:
+     * - Single-quoted string literals (`'foo'`) → `?`
+     * - Numeric literals → `?`
+     * - `IN (?, ?, ?)` lists with any positive count → `IN (?)`
+     * - Repeated whitespace → single spaces
+     *
+     * Double-quoted tokens are intentionally LEFT ALONE. Standard SQL
+     * (and PostgreSQL specifically) uses double quotes for IDENTIFIERS
+     * — collapsing `"users"` to `?` would normalize every Postgres
+     * query into the same signature and break N+1 detection, slow-query
+     * attribution, and counters wholesale. MySQL apps in non-default
+     * `ANSI_QUOTES` mode use single quotes for strings; double quotes
+     * also denote identifiers there. The few apps that run MySQL with
+     * `ANSI_QUOTES` flipped (where double quotes do denote strings) are
+     * a small minority and still get correct grouping for the dominant
+     * single-quote case.
+     *
+     * Result: every `SELECT * FROM posts WHERE user_id = 1` collapses to
+     * `select * from posts where user_id = ?`, so the analyzer can
+     * group identical-shape queries.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $sql  The raw SQL statement.
+     */
+    public function normalize( string $sql ): string
+    {
+        $normalized = strtolower( trim( $sql ) );
+
+        // Strip single-quoted string literals first so the numeric
+        // replacement below doesn't claw at digits inside string content.
+        $normalized = (string) preg_replace( "/'(?:[^'\\\\]|\\\\.)*'/", '?', $normalized );
+
+        // Replace numeric literals (integers and decimals). The negative
+        // lookbehind keeps us from clobbering identifiers like
+        // `column_1` or `t2.id`.
+        $normalized = (string) preg_replace( '/(?<![a-z0-9_])-?\d+(\.\d+)?/i', '?', $normalized );
+
+        // Collapse IN-lists so `IN (?, ?, ?, ?)` and `IN (?, ?)` share
+        // a signature — the count varies by request, the shape doesn't.
+        $normalized = (string) preg_replace( '/in\s*\(\s*(\?\s*,\s*)*\?\s*\)/i', 'in (?)', $normalized );
+
+        // Final whitespace collapse so newlines / tabs / runs of spaces
+        // all collapse to single spaces.
+        $normalized = (string) preg_replace( '/\s+/', ' ', $normalized );
+
+        return trim( $normalized );
+    }
+
+    /**
+     * Returns every query recorded since logging was enabled.
+     *
+     * @since 1.0.0
+     *
+     * @return array<int, array{sql: string, bindings: array<int, mixed>, time_ms: float, connection: string, normalized: string}>
+     */
+    public function getLoggedQueries(): array
+    {
+        return $this->log;
+    }
+
+    /**
+     * Returns the frequency counter keyed by normalized signature.
+     *
+     * @since 1.0.0
+     *
+     * @return array<string, int>
+     */
+    public function getQueryCounts(): array
+    {
+        return $this->counts;
+    }
+
+    /**
+     * Returns the cumulative execution time keyed by normalized signature, in milliseconds.
+     *
+     * @since 1.0.0
+     *
+     * @return array<string, float>
+     */
+    public function getQueryTimings(): array
+    {
+        return $this->timings;
+    }
+
+    /**
+     * Clears the analyzer's in-memory log and counters.
+     *
+     * Octane workers / long-running test suites call this between
+     * requests so per-request analysis doesn't leak across requests.
+     *
+     * @since 1.0.0
+     */
+    public function reset(): void
+    {
+        $this->log     = [];
+        $this->counts  = [];
+        $this->timings = [];
+    }
+
+    /**
+     * Returns the signatures executed more than `$threshold` times.
+     *
+     * @since 1.0.0
+     *
+     * @param  int  $threshold  Minimum execution count to include.
+     *
+     * @return array<string, int>
+     */
+    public function repeatedSignatures( int $threshold ): array
+    {
+        if ( $threshold < 1 ) {
+            return $this->counts;
+        }
+
+        return array_filter(
+            $this->counts,
+            static fn ( int $count ): bool => $count >= $threshold,
+        );
+    }
+
+    /**
+     * Dispatches `SlowQueryDetected` when the threshold is exceeded.
+     *
+     * The slow-query threshold is the only place the analyzer fires
+     * an event itself — N+1 detection lives in a dedicated service so
+     * applications can disable one feature without losing the other.
+     *
+     * @since 1.0.0
+     *
+     * @param  QueryExecuted  $event  The Laravel query event.
+     * @param  float  $timeMs  Execution time in milliseconds.
+     */
+    protected function dispatchSlowQueryEvent( QueryExecuted $event, float $timeMs ): void
+    {
+        if ( ! (bool) config( 'artisanpack.performance.database.slow_query_logging.enabled', false ) ) {
+            return;
+        }
+
+        $threshold = (float) config( 'artisanpack.performance.database.slow_query_logging.threshold_ms', 100 );
+
+        if ( $timeMs < $threshold ) {
+            return;
+        }
+
+        Event::dispatch( new SlowQueryDetected(
+            query: $event->sql,
+            timeMs: $timeMs,
+            trace: [],
+            bindings: $event->bindings,
+        ) );
+    }
+
+    /**
+     * Returns suggestion hints for a normalized query.
+     *
+     * The hints are intentionally generic — actionable enough for a
+     * developer to dig in without pretending to be a query planner.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $normalized  The normalized query signature.
+     * @param  float  $timeMs  Execution time in milliseconds.
+     *
+     * @return array<int, string>
+     */
+    protected function suggestionsFor( string $normalized, float $timeMs ): array
+    {
+        $hints = [];
+
+        if ( str_contains( $normalized, 'select *' ) ) {
+            $hints[] = 'Avoid SELECT * — list explicit columns to reduce row size and enable covering indexes.';
+        }
+
+        if ( 1 === preg_match( '/where\s+\w+\s+like\s+\?\s*$/i', $normalized ) ) {
+            $hints[] = 'A LIKE filter with a leading wildcard prevents index use — consider full-text search.';
+        }
+
+        if ( $timeMs >= 500.0 ) {
+            $hints[] = 'Query exceeded 500ms — review the query plan with EXPLAIN.';
+        }
+
+        return $hints;
+    }
+}

--- a/src/PerformanceServiceProvider.php
+++ b/src/PerformanceServiceProvider.php
@@ -19,6 +19,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\Performance;
 
 use ArtisanPackUI\Performance\Cache\CacheInvalidator;
+use ArtisanPackUI\Performance\Cache\CacheStrategyManager;
 use ArtisanPackUI\Performance\Cache\FragmentCache;
 use ArtisanPackUI\Performance\Cache\PageCacheManager;
 use ArtisanPackUI\Performance\Console\Commands\GenerateCriticalCssCommand;
@@ -26,6 +27,8 @@ use ArtisanPackUI\Performance\Console\Commands\GenerateWebPCommand;
 use ArtisanPackUI\Performance\Console\Commands\PurgeCacheCommand;
 use ArtisanPackUI\Performance\Console\Commands\WarmCacheCommand;
 use ArtisanPackUI\Performance\Css\CriticalCssExtractor;
+use ArtisanPackUI\Performance\Database\N1Detector;
+use ArtisanPackUI\Performance\Database\QueryAnalyzer;
 use ArtisanPackUI\Performance\Images\DominantColorExtractor;
 use ArtisanPackUI\Performance\Images\ResponsiveImageGenerator;
 use ArtisanPackUI\Performance\JavaScript\ScriptManager;
@@ -138,6 +141,18 @@ class PerformanceServiceProvider extends ServiceProvider
             );
         } );
 
+        $this->app->singleton( CacheStrategyManager::class, function () {
+            return new CacheStrategyManager;
+        } );
+
+        $this->app->singleton( QueryAnalyzer::class, function () {
+            return new QueryAnalyzer;
+        } );
+
+        $this->app->singleton( N1Detector::class, function ( $app ) {
+            return new N1Detector( $app->make( QueryAnalyzer::class ) );
+        } );
+
         $this->app->singleton( 'performance', function ( $app ) {
             return new PerformanceService(
                 $app->make( ImageService::class ),
@@ -205,6 +220,8 @@ class PerformanceServiceProvider extends ServiceProvider
             $sandbox = $event->sandbox ?? $this->app;
             $sandbox->make( PrefetchManager::class )->flush();
             $sandbox->make( PrerenderManager::class )->flush();
+            $sandbox->make( QueryAnalyzer::class )->reset();
+            $sandbox->make( N1Detector::class )->reset();
         } );
     }
 
@@ -542,6 +559,36 @@ class PerformanceServiceProvider extends ServiceProvider
     protected function registerEventListeners(): void
     {
         // Bindings registered by later phases (image, monitoring, alerts).
+        $this->bootDatabaseObservers();
+    }
+
+    /**
+     * Subscribes the QueryAnalyzer and N1Detector to DB events.
+     *
+     * Reads the relevant feature flags so apps that haven't opted into
+     * `query_optimization` pay nothing — no listener bound, no events
+     * fired. The detector also re-reads its own enabled flag inside
+     * `enable()`, so toggling at runtime still works.
+     *
+     * @since 1.0.0
+     */
+    protected function bootDatabaseObservers(): void
+    {
+        if ( $this->app->runningUnitTests() ) {
+            // Tests opt into the observers explicitly so the listener
+            // chain is exactly the surface the test under test cares
+            // about — otherwise every test would inherit a listener
+            // that fires unrelated events.
+            return;
+        }
+
+        if ( (bool) config( 'artisanpack.performance.features.query_optimization', false ) ) {
+            $this->app->make( QueryAnalyzer::class )->enableQueryLogging();
+        }
+
+        if ( (bool) config( 'artisanpack.performance.database.n1_detection.enabled', false ) ) {
+            $this->app->make( N1Detector::class )->enable();
+        }
     }
 
     /**

--- a/src/Traits/CachesQueries.php
+++ b/src/Traits/CachesQueries.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * Caches queries trait.
+ *
+ * Mix this trait into an Eloquent model to opt the model into the
+ * Performance package's query cache. The trait wires the model's
+ * `newEloquentBuilder()` method to return `CachingEloquentBuilder`,
+ * which adds `cacheFor()` / `cacheTags()` to the fluent builder API
+ * and routes terminal query methods (`get`, `first`, `count`, etc.)
+ * through the configured cache strategy.
+ *
+ * Save and delete events flush the model's table tag so any cached
+ * query referencing the model invalidates automatically. Tag-based
+ * invalidation works on every Laravel cache driver — drivers without
+ * native tag support (file, database) fall back to the cache
+ * strategy's tag-prefix index.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Traits;
+
+use ArtisanPackUI\Performance\Cache\CacheStrategyManager;
+use ArtisanPackUI\Performance\Contracts\CacheStrategy;
+use ArtisanPackUI\Performance\Database\CachingEloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+/**
+ * Caches queries trait.
+ *
+ *
+ * @since      1.0.0
+ */
+trait CachesQueries
+{
+    /**
+     * Boots the trait.
+     *
+     * Registers model events so every save / delete invalidates the
+     * tag associated with the model's table. Subsequent reads
+     * recompute and refill the cache transparently to call sites.
+     *
+     * When the save / delete happens inside an open transaction the
+     * flush is DEFERRED to after-commit. Otherwise a concurrent reader
+     * racing between the flush and the COMMIT would refill the cache
+     * with pre-commit state (or with no row at all under READ
+     * COMMITTED), leaving the cache permanently stale until the next
+     * write. After-commit also means the flush silently no-ops when
+     * the transaction rolls back — which is the right behavior, since
+     * the data the would-be flush was reacting to never actually
+     * landed.
+     *
+     * @since 1.0.0
+     */
+    public static function bootCachesQueries(): void
+    {
+        static::saved( static function ( Model $model ): void {
+            static::scheduleQueryCacheFlush( $model );
+        } );
+
+        static::deleted( static function ( Model $model ): void {
+            static::scheduleQueryCacheFlush( $model );
+        } );
+    }
+
+    /**
+     * Flushes immediately or queues an after-commit callback.
+     *
+     * Reads the model's connection transaction level (rather than the
+     * default connection) so a model bound to a different connection
+     * still defers correctly. Falls back to immediate flush when the
+     * connection check throws — the caller would rather double-flush
+     * than skip invalidation entirely.
+     *
+     * @since 1.0.0
+     *
+     * @param  Model  $model  The model whose tag should be flushed.
+     */
+    public static function scheduleQueryCacheFlush( Model $model ): void
+    {
+        try {
+            $connection = DB::connection( $model->getConnectionName() );
+            $level      = $connection->transactionLevel();
+        } catch ( Throwable ) {
+            static::flushQueryCacheFor( $model );
+
+            return;
+        }
+
+        if ( $level > 0 ) {
+            $connection->afterCommit( static function () use ( $model ): void {
+                static::flushQueryCacheFor( $model );
+            } );
+
+            return;
+        }
+
+        static::flushQueryCacheFor( $model );
+    }
+
+    /**
+     * Returns the Eloquent builder used by the model.
+     *
+     * @since 1.0.0
+     *
+     * @param  QueryBuilder  $query  The base query builder instance.
+     */
+    public function newEloquentBuilder( $query ): CachingEloquentBuilder
+    {
+        return new CachingEloquentBuilder( $query );
+    }
+
+    /**
+     * Returns the cache tag for the given model.
+     *
+     * The tag is derived from the table name so subclasses sharing a
+     * table collapse to the same tag — which is the intended behavior
+     * for STI and table-shared queries.
+     *
+     * @since 1.0.0
+     *
+     * @param  Model  $model  The Eloquent model instance.
+     */
+    public static function queryCacheTagFor( Model $model ): string
+    {
+        return 'model:' . $model->getTable();
+    }
+
+    /**
+     * Flushes every cached query tagged for the given model.
+     *
+     * @since 1.0.0
+     *
+     * @param  Model  $model  The model whose cache tag should be flushed.
+     */
+    public static function flushQueryCacheFor( Model $model ): void
+    {
+        static::queryCacheStrategy()
+            ->tags( [ static::queryCacheTagFor( $model ) ] )
+            ->flush();
+    }
+
+    /**
+     * Returns the strategy used to read/write query cache entries.
+     *
+     * The driver is resolved from `artisanpack.performance.database.query_cache.driver`,
+     * falling back to the strategy manager's default driver when the
+     * config value is empty or names an unregistered driver.
+     *
+     * @since 1.0.0
+     */
+    public static function queryCacheStrategy(): CacheStrategy
+    {
+        $driver  = (string) config( 'artisanpack.performance.database.query_cache.driver', '' );
+        $manager = app( CacheStrategyManager::class );
+
+        return '' !== $driver && $manager->hasDriver( $driver )
+            ? $manager->driver( $driver )
+            : $manager->driver();
+    }
+}

--- a/tests/Feature/Cache/CacheStrategyManagerTest.php
+++ b/tests/Feature/Cache/CacheStrategyManagerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Cache\CacheStrategyManager;
+use ArtisanPackUI\Performance\Cache\Strategies\FileCacheStrategy;
+use ArtisanPackUI\Performance\Cache\Strategies\MemcachedCacheStrategy;
+use ArtisanPackUI\Performance\Cache\Strategies\RedisCacheStrategy;
+use ArtisanPackUI\Performance\Contracts\CacheStrategy;
+
+it( 'resolves built-in drivers by name', function (): void {
+    $manager = new CacheStrategyManager;
+
+    expect( $manager->driver( 'file' ) )->toBeInstanceOf( FileCacheStrategy::class );
+    expect( $manager->driver( 'redis' ) )->toBeInstanceOf( RedisCacheStrategy::class );
+    expect( $manager->driver( 'memcached' ) )->toBeInstanceOf( MemcachedCacheStrategy::class );
+} );
+
+it( 'memoizes resolved drivers', function (): void {
+    $manager = new CacheStrategyManager;
+
+    $first  = $manager->driver( 'file' );
+    $second = $manager->driver( 'file' );
+
+    expect( $first )->toBe( $second );
+} );
+
+it( 'falls back to the configured page-cache driver when no name is supplied', function (): void {
+    config( [ 'artisanpack.performance.page_cache.driver' => 'redis' ] );
+
+    expect( ( new CacheStrategyManager )->driver() )->toBeInstanceOf( RedisCacheStrategy::class );
+} );
+
+it( 'falls back to file when no default driver is configured', function (): void {
+    config( [ 'artisanpack.performance.page_cache.driver' => '' ] );
+
+    expect( ( new CacheStrategyManager )->driver() )->toBeInstanceOf( FileCacheStrategy::class );
+} );
+
+it( 'allows extending the manager with custom drivers', function (): void {
+    $manager = new CacheStrategyManager;
+    $custom  = new class extends FileCacheStrategy {
+    };
+
+    $manager->extend( 'custom', static fn (): CacheStrategy => $custom );
+
+    expect( $manager->hasDriver( 'custom' ) )->toBeTrue();
+    expect( $manager->driver( 'custom' ) )->toBe( $custom );
+} );
+
+it( 'throws when asked for an unknown driver', function (): void {
+    ( new CacheStrategyManager )->driver( 'mystery' );
+} )->throws( InvalidArgumentException::class );
+
+it( 'hasDriver returns false for built-in names that have no matching cache.stores config', function (): void {
+    // Strip the redis store from the test app so the probe sees no
+    // configured driver. Without the fix, hasDriver('redis') would
+    // still return true and callers would crash on first ->get().
+    $stores = (array) config( 'cache.stores', [] );
+    unset( $stores['redis'] );
+    config( [ 'cache.stores' => $stores ] );
+
+    $manager = new CacheStrategyManager;
+
+    expect( $manager->hasDriver( 'redis' ) )->toBeFalse();
+} );
+
+it( 'hasDriver returns true for built-in names when the matching cache.stores entry exists', function (): void {
+    config( [ 'cache.stores.file' => [ 'driver' => 'array', 'serialize' => false ] ] );
+
+    $manager = new CacheStrategyManager;
+
+    expect( $manager->hasDriver( 'file' ) )->toBeTrue();
+} );

--- a/tests/Feature/Cache/Strategies/FileCacheStrategyTest.php
+++ b/tests/Feature/Cache/Strategies/FileCacheStrategyTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Cache\Strategies\FileCacheStrategy;
+use Illuminate\Support\Facades\Cache;
+
+beforeEach( function (): void {
+    // The file driver is the realistic "no native tags" backend the
+    // strategy's fallback index needs to cover. We re-point the array
+    // store onto the `file` slot so the suite can exercise the
+    // strategy without writing to disk — same code path, same lack of
+    // native tag support.
+    config( [ 'cache.stores.file' => [ 'driver' => 'array', 'serialize' => false ] ] );
+    Cache::store( 'file' )->flush();
+} );
+
+it( 'reads back a value it wrote', function (): void {
+    $strategy = new FileCacheStrategy;
+
+    $strategy->put( 'foo', 'bar', 60 );
+
+    expect( $strategy->get( 'foo' ) )->toBe( 'bar' );
+} );
+
+it( 'returns null for unknown keys', function (): void {
+    expect( ( new FileCacheStrategy )->get( 'missing' ) )->toBeNull();
+} );
+
+it( 'forgets values on demand', function (): void {
+    $strategy = new FileCacheStrategy;
+    $strategy->put( 'foo', 'bar', 60 );
+
+    expect( $strategy->forget( 'foo' ) )->toBeTrue();
+    expect( $strategy->get( 'foo' ) )->toBeNull();
+} );
+
+it( 'flushes only tag-scoped keys when a tag list is set', function (): void {
+    $strategy = new FileCacheStrategy;
+
+    $strategy->put( 'untagged', 'keep', 60 );
+    $strategy->tags( [ 'posts' ] )->put( 'tagged', 'drop', 60 );
+
+    $strategy->tags( [ 'posts' ] )->flush();
+
+    expect( $strategy->get( 'untagged' ) )->toBe( 'keep' );
+    expect( $strategy->get( 'tagged' ) )->toBeNull();
+} );
+
+it( 'returns a fresh instance from tags() without mutating the original', function (): void {
+    $strategy = new FileCacheStrategy;
+
+    $scoped = $strategy->tags( [ 'a' ] );
+
+    expect( $scoped )->not->toBe( $strategy );
+    expect( $strategy->getScopedTags() )->toBe( [] );
+    expect( $scoped->getScopedTags() )->toBe( [ 'a' ] );
+} );
+
+it( 'persists indefinitely when ttl is zero', function (): void {
+    $strategy = new FileCacheStrategy;
+
+    expect( $strategy->put( 'forever', 'value', 0 ) )->toBeTrue();
+    expect( $strategy->get( 'forever' ) )->toBe( 'value' );
+} );
+
+it( 'flushes the whole store when no tags are scoped', function (): void {
+    $strategy = new FileCacheStrategy;
+
+    $strategy->put( 'a', '1', 60 );
+    $strategy->put( 'b', '2', 60 );
+
+    $strategy->flush();
+
+    expect( $strategy->get( 'a' ) )->toBeNull();
+    expect( $strategy->get( 'b' ) )->toBeNull();
+} );

--- a/tests/Feature/Database/N1DetectorTest.php
+++ b/tests/Feature/Database/N1DetectorTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Database\N1Detector;
+use ArtisanPackUI\Performance\Database\QueryAnalyzer;
+use ArtisanPackUI\Performance\Events\N1QueryDetected;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+
+beforeEach( function (): void {
+    config( [ 'artisanpack.performance.database.n1_detection' => [
+        'enabled'     => true,
+        'threshold'   => 5,
+        'log_channel' => '',
+        'notify'      => false,
+    ] ] );
+} );
+
+it( 'dispatches N1QueryDetected after the configured threshold is reached', function (): void {
+    Event::fake();
+
+    $detector = new N1Detector( new QueryAnalyzer );
+
+    for ( $i = 1; $i <= 5; $i++ ) {
+        $detector->record( new QueryExecuted(
+            'SELECT * FROM comments WHERE post_id = ?',
+            [ $i ],
+            1.0,
+            DB::connection(),
+        ) );
+    }
+
+    Event::assertDispatched( N1QueryDetected::class, function ( N1QueryDetected $event ): bool {
+        return 'select * from comments where post_id = ?' === $event->queryNormalized
+            && 5 === $event->count;
+    } );
+} );
+
+it( 'fires only once per signature per request', function (): void {
+    Event::fake();
+
+    $detector = new N1Detector( new QueryAnalyzer );
+
+    for ( $i = 1; $i <= 12; $i++ ) {
+        $detector->record( new QueryExecuted(
+            'SELECT * FROM comments WHERE post_id = ?',
+            [ $i ],
+            1.0,
+            DB::connection(),
+        ) );
+    }
+
+    Event::assertDispatchedTimes( N1QueryDetected::class, 1 );
+} );
+
+it( 'does not dispatch when the threshold has not been reached', function (): void {
+    Event::fake();
+
+    $detector = new N1Detector( new QueryAnalyzer );
+
+    for ( $i = 1; $i <= 4; $i++ ) {
+        $detector->record( new QueryExecuted( 'SELECT * FROM comments WHERE post_id = ?', [ $i ], 1.0, DB::connection() ) );
+    }
+
+    Event::assertNotDispatched( N1QueryDetected::class );
+} );
+
+it( 'suggests an eager-loaded relation derived from the table and FK', function (): void {
+    $detector = new N1Detector( new QueryAnalyzer );
+
+    $suggestion = $detector->suggestFix( 'select * from comments where post_id = ?' );
+
+    expect( $suggestion['table'] )->toBe( 'comments' );
+    expect( $suggestion['relation'] )->toBe( 'comments' );
+    expect( $suggestion['suggestion'] )->toContain( "->with('comments')" );
+} );
+
+it( 'returns a generic suggestion when the SQL is not N+1 shaped', function (): void {
+    $detector = new N1Detector( new QueryAnalyzer );
+
+    $suggestion = $detector->suggestFix( 'select count(*) from posts' );
+
+    expect( $suggestion['table'] )->toBeNull();
+    expect( $suggestion['relation'] )->toBeNull();
+    expect( $suggestion['suggestion'] )->toContain( 'review eager loading' );
+} );
+
+it( 'resets per-request counters', function (): void {
+    $detector = new N1Detector( new QueryAnalyzer );
+
+    $detector->record( new QueryExecuted( 'SELECT * FROM users WHERE id = ?', [ 1 ], 1.0, DB::connection() ) );
+    $detector->reset();
+
+    expect( $detector->getCounts() )->toBe( [] );
+    expect( $detector->getReportedSignatures() )->toBe( [] );
+} );
+
+it( 'attaches the active route to dispatched events', function (): void {
+    Event::fake();
+
+    $detector = new N1Detector( new QueryAnalyzer );
+    $detector->setCurrentRoute( 'posts.index' );
+
+    for ( $i = 0; $i < 5; $i++ ) {
+        $detector->record( new QueryExecuted( 'SELECT * FROM comments WHERE post_id = ?', [ $i ], 1.0, DB::connection() ) );
+    }
+
+    Event::assertDispatched( N1QueryDetected::class, function ( N1QueryDetected $event ): bool {
+        return 'posts.index' === $event->route;
+    } );
+} );
+
+it( 'respects threshold values configured at runtime', function (): void {
+    Event::fake();
+
+    config( [ 'artisanpack.performance.database.n1_detection.threshold' => 2 ] );
+
+    $detector = new N1Detector( new QueryAnalyzer );
+
+    $detector->record( new QueryExecuted( 'SELECT * FROM tags WHERE post_id = ?', [ 1 ], 1.0, DB::connection() ) );
+    $detector->record( new QueryExecuted( 'SELECT * FROM tags WHERE post_id = ?', [ 2 ], 1.0, DB::connection() ) );
+
+    Event::assertDispatchedTimes( N1QueryDetected::class, 1 );
+} );
+
+it( 'subscribes to DB::listen on enable when the flag is set', function (): void {
+    $detector = new N1Detector( new QueryAnalyzer );
+
+    $detector->enable();
+    $detector->enable();
+
+    expect( $detector->isEnabled() )->toBeTrue();
+} );
+
+it( 'is a no-op when the feature flag is disabled', function (): void {
+    config( [ 'artisanpack.performance.database.n1_detection.enabled' => false ] );
+
+    $detector = new N1Detector( new QueryAnalyzer );
+
+    $detector->enable();
+
+    expect( $detector->isEnabled() )->toBeFalse();
+} );
+
+it( 'reset() clears the active route name', function (): void {
+    $detector = new N1Detector( new QueryAnalyzer );
+    $detector->setCurrentRoute( 'admin.orders.show' );
+
+    $detector->reset();
+
+    // After reset the next dispatched event must NOT carry the prior
+    // route name (this is the cross-request leak in long-running
+    // runtimes the Octane reset hook exists to prevent).
+    Event::fake();
+
+    for ( $i = 0; $i < 5; $i++ ) {
+        $detector->record( new QueryExecuted( 'SELECT * FROM tags WHERE post_id = ?', [ $i ], 1.0, DB::connection() ) );
+    }
+
+    Event::assertDispatched( N1QueryDetected::class, function ( N1QueryDetected $event ): bool {
+        return '' === $event->route;
+    } );
+} );
+
+it( 'suggests the singular relation for a BelongsTo N+1 (WHERE id = ?)', function (): void {
+    $detector = new N1Detector( new QueryAnalyzer );
+
+    // Comment->user style: SELECT * FROM users WHERE id = ?
+    $suggestion = $detector->suggestFix( 'select * from users where id = ?' );
+
+    expect( $suggestion['table'] )->toBe( 'users' );
+    expect( $suggestion['relation'] )->toBe( 'user' );
+    expect( $suggestion['suggestion'] )->toContain( "->with('user')" );
+} );
+
+it( 'suggests camelCase for multi-word tables in BelongsTo N+1', function (): void {
+    $detector = new N1Detector( new QueryAnalyzer );
+
+    // BelongsTo on a multi-word table — relation should be camelCase singular.
+    $suggestion = $detector->suggestFix( 'select * from team_owners where id = ?' );
+
+    expect( $suggestion['relation'] )->toBe( 'teamOwner' );
+} );
+
+it( 'suggests camelCase plural for HasMany N+1 against multi-word tables', function (): void {
+    $detector = new N1Detector( new QueryAnalyzer );
+
+    $suggestion = $detector->suggestFix( 'select * from order_items where order_id = ?' );
+
+    expect( $suggestion['relation'] )->toBe( 'orderItems' );
+} );

--- a/tests/Feature/Database/QueryAnalyzerTest.php
+++ b/tests/Feature/Database/QueryAnalyzerTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Database\QueryAnalyzer;
+use ArtisanPackUI\Performance\Events\SlowQueryDetected;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+
+beforeEach( function (): void {
+    config( [ 'artisanpack.performance.database.slow_query_logging' => [
+        'enabled'           => false,
+        'threshold_ms'      => 100,
+        'log_channel'       => '',
+        'store_in_database' => false,
+        'retention_days'    => 30,
+    ] ] );
+} );
+
+it( 'normalizes string and numeric literals to placeholders', function (): void {
+    $analyzer = new QueryAnalyzer;
+
+    $normalized = $analyzer->normalize( "SELECT * FROM posts WHERE user_id = 5 AND status = 'published'" );
+
+    expect( $normalized )->toBe( 'select * from posts where user_id = ? and status = ?' );
+} );
+
+it( 'collapses IN lists of any size to IN (?)', function (): void {
+    $analyzer = new QueryAnalyzer;
+
+    expect( $analyzer->normalize( 'SELECT * FROM posts WHERE id IN (1, 2, 3)' ) )
+        ->toBe( 'select * from posts where id in (?)' );
+
+    expect( $analyzer->normalize( 'SELECT * FROM posts WHERE id IN (4, 5)' ) )
+        ->toBe( 'select * from posts where id in (?)' );
+} );
+
+it( 'collapses whitespace', function (): void {
+    $analyzer = new QueryAnalyzer;
+
+    $normalized = $analyzer->normalize( "SELECT\t*\nFROM    posts\n  WHERE  id  =  1" );
+
+    expect( $normalized )->toBe( 'select * from posts where id = ?' );
+} );
+
+it( 'records query events into the in-memory log', function (): void {
+    $analyzer = new QueryAnalyzer;
+    $event    = new QueryExecuted( 'SELECT * FROM posts WHERE id = ?', [ 1 ], 12.5, fakeConnection() );
+
+    $analyzer->record( $event );
+
+    $log = $analyzer->getLoggedQueries();
+
+    expect( $log )->toHaveCount( 1 );
+    expect( $log[0]['time_ms'] )->toBe( 12.5 );
+    expect( $log[0]['normalized'] )->toBe( 'select * from posts where id = ?' );
+} );
+
+it( 'tracks per-signature counts and timings', function (): void {
+    $analyzer = new QueryAnalyzer;
+
+    $analyzer->record( new QueryExecuted( 'SELECT * FROM posts WHERE id = ?', [ 1 ], 5.0, fakeConnection() ) );
+    $analyzer->record( new QueryExecuted( 'SELECT * FROM posts WHERE id = ?', [ 2 ], 7.0, fakeConnection() ) );
+
+    $counts  = $analyzer->getQueryCounts();
+    $timings = $analyzer->getQueryTimings();
+
+    expect( $counts['select * from posts where id = ?'] )->toBe( 2 );
+    expect( $timings['select * from posts where id = ?'] )->toBe( 12.0 );
+} );
+
+it( 'returns signatures that exceed the threshold', function (): void {
+    $analyzer = new QueryAnalyzer;
+
+    for ( $i = 0; $i < 6; $i++ ) {
+        $analyzer->record( new QueryExecuted( 'SELECT * FROM posts WHERE id = ?', [ $i ], 1.0, fakeConnection() ) );
+    }
+
+    $analyzer->record( new QueryExecuted( 'SELECT * FROM users', [], 1.0, fakeConnection() ) );
+
+    expect( $analyzer->repeatedSignatures( 5 ) )->toHaveKey( 'select * from posts where id = ?' );
+    expect( $analyzer->repeatedSignatures( 5 ) )->not->toHaveKey( 'select * from users' );
+} );
+
+it( 'dispatches SlowQueryDetected when threshold_ms is exceeded', function (): void {
+    Event::fake();
+
+    config( [ 'artisanpack.performance.database.slow_query_logging.enabled' => true ] );
+    config( [ 'artisanpack.performance.database.slow_query_logging.threshold_ms' => 50 ] );
+
+    $analyzer = new QueryAnalyzer;
+
+    $analyzer->record( new QueryExecuted( 'SELECT * FROM huge_table', [], 250.0, fakeConnection() ) );
+
+    Event::assertDispatched( SlowQueryDetected::class, function ( SlowQueryDetected $event ): bool {
+        return 250.0 === $event->timeMs;
+    } );
+} );
+
+it( 'does not dispatch when below the slow-query threshold', function (): void {
+    Event::fake();
+
+    config( [ 'artisanpack.performance.database.slow_query_logging.enabled' => true ] );
+    config( [ 'artisanpack.performance.database.slow_query_logging.threshold_ms' => 500 ] );
+
+    $analyzer = new QueryAnalyzer;
+    $analyzer->record( new QueryExecuted( 'SELECT 1', [], 1.0, fakeConnection() ) );
+
+    Event::assertNotDispatched( SlowQueryDetected::class );
+} );
+
+it( 'returns suggestions for select-star queries', function (): void {
+    $analyzer = new QueryAnalyzer;
+
+    $analysis = $analyzer->analyzeQuery( 'SELECT * FROM posts', [], 10.0 );
+
+    expect( $analysis['suggestions'] )->toContain( 'Avoid SELECT * — list explicit columns to reduce row size and enable covering indexes.' );
+} );
+
+it( 'is idempotent on enableQueryLogging', function (): void {
+    $analyzer = new QueryAnalyzer;
+
+    $analyzer->enableQueryLogging();
+    $analyzer->enableQueryLogging();
+
+    expect( $analyzer->isListening() )->toBeTrue();
+} );
+
+it( 'resets internal state', function (): void {
+    $analyzer = new QueryAnalyzer;
+    $analyzer->record( new QueryExecuted( 'SELECT 1', [], 1.0, fakeConnection() ) );
+
+    $analyzer->reset();
+
+    expect( $analyzer->getLoggedQueries() )->toBe( [] );
+    expect( $analyzer->getQueryCounts() )->toBe( [] );
+} );
+
+it( 'leaves Postgres double-quoted identifiers intact while collapsing single-quoted literals', function (): void {
+    $analyzer = new QueryAnalyzer;
+
+    // Pgsql-shaped query: double-quoted identifiers, single-quoted literal.
+    $normalized = $analyzer->normalize( 'SELECT "title" FROM "posts" WHERE "id" = 5 AND "status" = \'live\'' );
+
+    // The identifiers MUST survive — otherwise every pgsql query
+    // collapses to the same signature and the analyzer becomes useless.
+    expect( $normalized )->toBe( 'select "title" from "posts" where "id" = ? and "status" = ?' );
+
+    // Two distinct pgsql queries must produce distinct signatures.
+    $a = $analyzer->normalize( 'SELECT "title" FROM "posts" WHERE "id" = 1' );
+    $b = $analyzer->normalize( 'SELECT "name" FROM "users" WHERE "id" = 1' );
+    expect( $a )->not->toBe( $b );
+} );
+
+function fakeConnection(): Illuminate\Database\Connection
+{
+    return DB::connection();
+}

--- a/tests/Feature/Traits/CachesQueriesTest.php
+++ b/tests/Feature/Traits/CachesQueriesTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\Fixtures\CachesQueriesPostStub;
+
+beforeEach( function (): void {
+    config( [ 'cache.default' => 'array' ] );
+    // Force every strategy onto the array driver under test so we can
+    // observe writes via the same store the trait reads from. The file
+    // strategy's `storeName()` returns 'file' — we re-point that store
+    // here so flush() / put() / get() route through `array`.
+    config( [ 'cache.stores.file' => [ 'driver' => 'array', 'serialize' => false ] ] );
+    config( [ 'artisanpack.performance.database.query_cache.driver' => 'file' ] );
+    config( [ 'artisanpack.performance.page_cache.driver' => 'file' ] );
+
+    Schema::create( 'caches_queries_posts', function ( $table ): void {
+        $table->increments( 'id' );
+        $table->string( 'title' );
+        $table->boolean( 'published' )->default( false );
+    } );
+
+    DB::table( 'caches_queries_posts' )->insert( [
+        [ 'title' => 'first', 'published' => true ],
+        [ 'title' => 'second', 'published' => false ],
+        [ 'title' => 'third', 'published' => true ],
+    ] );
+
+    Cache::store( 'file' )->flush();
+} );
+
+afterEach( function (): void {
+    Schema::dropIfExists( 'caches_queries_posts' );
+} );
+
+it( 'serves cached query results on subsequent calls', function (): void {
+    $count = 0;
+    DB::listen( function () use ( &$count ): void { $count++; } );
+
+    $first  = CachesQueriesPostStub::query()->cacheFor( 60 )->get();
+    $second = CachesQueriesPostStub::query()->cacheFor( 60 )->get();
+
+    expect( $first )->toHaveCount( 3 );
+    expect( $second )->toHaveCount( 3 );
+    expect( $count )->toBe( 1 );
+} );
+
+it( 'returns fresh results when the ttl is non-positive', function (): void {
+    $count = 0;
+    DB::listen( function () use ( &$count ): void { $count++; } );
+
+    CachesQueriesPostStub::query()->cacheFor( 0 )->get();
+    CachesQueriesPostStub::query()->cacheFor( 0 )->get();
+
+    expect( $count )->toBe( 2 );
+} );
+
+it( 'invalidates the cache automatically when a model is saved', function (): void {
+    $count = 0;
+    DB::listen( function () use ( &$count ): void { $count++; } );
+
+    CachesQueriesPostStub::query()->cacheFor( 60 )->get();
+
+    $post        = new CachesQueriesPostStub;
+    $post->title = 'fourth';
+    $post->save();
+
+    $count = 0;
+
+    $refreshed = CachesQueriesPostStub::query()->cacheFor( 60 )->get();
+
+    expect( $refreshed )->toHaveCount( 4 );
+    expect( $count )->toBeGreaterThan( 0 );
+} );
+
+it( 'invalidates the cache when a model is deleted', function (): void {
+    $count = 0;
+    DB::listen( function () use ( &$count ): void { $count++; } );
+
+    CachesQueriesPostStub::query()->cacheFor( 60 )->get();
+
+    $first = CachesQueriesPostStub::query()->first();
+    $first->delete();
+
+    $count = 0;
+
+    CachesQueriesPostStub::query()->cacheFor( 60 )->get();
+
+    expect( $count )->toBeGreaterThan( 0 );
+} );
+
+it( 'uses the custom cache key when one is supplied', function (): void {
+    $count = 0;
+    DB::listen( function () use ( &$count ): void { $count++; } );
+
+    CachesQueriesPostStub::query()->cacheFor( 60, 'homepage' )->get();
+    CachesQueriesPostStub::query()->cacheFor( 60, 'homepage' )->get();
+
+    expect( $count )->toBe( 1 );
+} );
+
+it( 'segregates get and count under different cache keys', function (): void {
+    CachesQueriesPostStub::query()->cacheFor( 60 )->get();
+
+    $count = CachesQueriesPostStub::query()->cacheFor( 60 )->count();
+
+    expect( $count )->toBe( 3 );
+} );
+
+it( 'applies extra tags via cacheTags()', function (): void {
+    $builder = CachesQueriesPostStub::query()->cacheFor( 60 )->cacheTags( [ 'homepage' ] );
+
+    expect( $builder->getCacheExtraTags() )->toBe( [ 'homepage' ] );
+} );
+
+it( 'does not cache when cacheFor() was never called', function (): void {
+    $count = 0;
+    DB::listen( function () use ( &$count ): void { $count++; } );
+
+    CachesQueriesPostStub::query()->get();
+    CachesQueriesPostStub::query()->get();
+
+    expect( $count )->toBe( 2 );
+} );
+
+it( 'defers invalidation until after the outer transaction commits', function (): void {
+    // Prime the cache.
+    CachesQueriesPostStub::query()->cacheFor( 60 )->get();
+
+    $count = 0;
+    DB::listen( function () use ( &$count ): void { $count++; } );
+
+    DB::transaction( function (): void {
+        $post        = new CachesQueriesPostStub;
+        $post->title = 'inside-transaction';
+        $post->save();
+
+        // Inside the transaction the flush MUST NOT have happened yet.
+        // A concurrent reader cache-HITs against the still-primed entry,
+        // which is the desired behavior — without it, a racing reader
+        // could refill the cache with pre-commit state and leave it
+        // permanently stale once the COMMIT lands.
+        $cachedDuringTx = CachesQueriesPostStub::query()->cacheFor( 60 )->get();
+
+        expect( $cachedDuringTx )->toHaveCount( 3 );
+    } );
+
+    // After commit, the deferred flush fires and the next read misses.
+    $start = $count;
+    CachesQueriesPostStub::query()->cacheFor( 60 )->get();
+
+    expect( $count )->toBeGreaterThan( $start );
+} );
+
+it( 'does not flush when the outer transaction rolls back', function (): void {
+    CachesQueriesPostStub::query()->cacheFor( 60 )->get();
+
+    try {
+        DB::transaction( function (): void {
+            $post        = new CachesQueriesPostStub;
+            $post->title = 'will-rollback';
+            $post->save();
+
+            throw new RuntimeException( 'roll back' );
+        } );
+    } catch ( RuntimeException ) {
+        // Expected.
+    }
+
+    $count = 0;
+    DB::listen( function () use ( &$count ): void { $count++; } );
+
+    // The flush was registered as an after-commit callback that never
+    // fires because the transaction rolled back. The cache stays
+    // primed, so this read hits the cache and emits zero queries.
+    CachesQueriesPostStub::query()->cacheFor( 60 )->get();
+
+    expect( $count )->toBe( 0 );
+} );
+
+it( 'segregates the cache key by resolved page number on paginate()', function (): void {
+    // Without the fix, both ?page=1 and ?page=2 collapse to the same
+    // cache key and the second URL silently serves page-1 rows.
+    Illuminate\Pagination\Paginator::currentPageResolver( fn (): int => 1 );
+
+    $page1 = CachesQueriesPostStub::query()->cacheFor( 60 )->paginate( 2 );
+
+    Illuminate\Pagination\Paginator::currentPageResolver( fn (): int => 2 );
+
+    $page2 = CachesQueriesPostStub::query()->cacheFor( 60 )->paginate( 2 );
+
+    expect( $page1->items()[0]->id )->not->toBe( $page2->items()[0]->id );
+} );
+
+it( 'segregates the cache key by eager-load constraint closure identity', function (): void {
+    // Two different closures wrapping the same relation name must
+    // produce different cache keys — otherwise a constraint change
+    // silently HITs the wrong result set.
+    $reflect = function ( $builder ): string {
+        $method = new ReflectionMethod( $builder, 'buildCacheKey' );
+        $method->setAccessible( true );
+
+        return $method->invoke( $builder, 'get', [ [ '*' ] ] );
+    };
+
+    $bare = CachesQueriesPostStub::query()->cacheFor( 60 );
+
+    $withA = CachesQueriesPostStub::query()->cacheFor( 60 )->with( [ 'self' => fn ( $q ) => $q ] );
+    $withB = CachesQueriesPostStub::query()->cacheFor( 60 )->with( [ 'self' => fn ( $q ) => $q->limit( 1 ) ] );
+
+    $keyBare  = $reflect( $bare );
+    $keyWithA = $reflect( $withA );
+    $keyWithB = $reflect( $withB );
+
+    expect( $keyWithA )->not->toBe( $keyBare );
+    expect( $keyWithA )->not->toBe( $keyWithB );
+} );
+
+it( 'mixes SQL into the cache key even when a custom key is supplied', function (): void {
+    // Without the fix, both queries collapse to the same key and the
+    // second WHERE clause is silently ignored on cache HIT.
+    $count = 0;
+    DB::listen( function () use ( &$count ): void { $count++; } );
+
+    $publishedOnly = CachesQueriesPostStub::query()
+        ->where( 'published', true )
+        ->cacheFor( 60, 'homepage' )
+        ->get();
+
+    $authorOnly = CachesQueriesPostStub::query()
+        ->where( 'title', 'first' )
+        ->cacheFor( 60, 'homepage' )
+        ->get();
+
+    expect( $count )->toBe( 2 );
+    expect( $publishedOnly->count() )->toBe( 2 );
+    expect( $authorOnly->count() )->toBe( 1 );
+} );
+

--- a/tests/Fixtures/CachesQueriesPostStub.php
+++ b/tests/Fixtures/CachesQueriesPostStub.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Eloquent stub model used by `CachesQueriesTest`.
+ *
+ * Backed by the `caches_queries_posts` table created on the fly in
+ * the test's `beforeEach` hook so the trait can exercise its full
+ * save/delete invalidation path against a real connection.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace Tests\Fixtures;
+
+use ArtisanPackUI\Performance\Traits\CachesQueries;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Stub Eloquent model that exercises `CachesQueries`.
+ *
+ *
+ * @since      1.0.0
+ */
+class CachesQueriesPostStub extends Model
+{
+    use CachesQueries;
+
+    public $timestamps = false;
+
+    protected $table = 'caches_queries_posts';
+
+    protected $guarded = [];
+}


### PR DESCRIPTION
## Description

Bundles Phase 5 (caching) and Phase 6 (database observability) work into one PR. The five issues share a small surface area (the new `CacheStrategy` contract is used by the `CachesQueries` trait, the `N1Detector` composes the `QueryAnalyzer`), so they land cleanly together rather than as five sequential PRs against the same files.

**Closes:** #37, #38, #39, #40, #41

## Type of Change

- [x] New feature (adds new functionality)

## Related Issues

- **#37** — CachesQueries trait
- **#38** — Cache storage strategies (File / Redis / Memcached)
- **#39** — Caching system feature tests
- **#40** — QueryAnalyzer service
- **#41** — N+1 query detection

## Motivation and Context

Phase 5 needed a uniform way to read/write through any Laravel cache backend. Phase 6 needed a query observation pipeline that the trait can also use for query-result caching. The strategy contract serves both. Bundling them avoids two PRs editing the same service provider and the same `Cache::store()` call sites.

## Changes Made

**#37 — CachesQueries trait** (`src/Traits/CachesQueries.php`, `src/Database/CachingEloquentBuilder.php`)
- Custom Eloquent builder intercepts `get`/`first`/`count`/`pluck`/`paginate`/`exists`
- `cacheFor($ttl, $customKey = null)` and `cacheTags(array $tags)` fluent API
- Auto-invalidates on `saved`/`deleted` via a `model:<table>` tag
- **Deferred past commit**: when the save fires inside an open transaction, the flush runs via `connection->afterCommit()` so concurrent readers can't refill the cache with pre-commit state

**#38 — Cache strategies** (`src/Contracts/CacheStrategy.php`, `src/Cache/Strategies/*`, `src/Cache/CacheStrategyManager.php`)
- `CacheStrategy` contract: `get/put/forget/flush/tags`
- File/Redis/Memcached implementations all extend a common abstract base
- Non-taggable stores (file) fall back to a tag-prefix index protected by a cache lock to prevent concurrent read-modify-write from orphaning entries
- `CacheStrategyManager` factory with `extend()` for custom drivers; `hasDriver()` verifies the underlying Laravel `cache.stores.{name}` is actually configured

**#39 — Tests** — 12 new test files covering both phases, 99 new tests, including regression tests for every bug found in the pre-merge code review (paginate page-key segregation, eager-load closure identity, custom-key SQL discrimination, pgsql identifier preservation, transaction defer + rollback no-flush, currentRoute reset, BelongsTo vs HasMany inference, hasDriver store-config probe)

**#40 — QueryAnalyzer** (`src/Database/QueryAnalyzer.php`)
- `DB::listen()` subscription via `enableQueryLogging()`; per-event closure re-checks the feature flag so runtime toggles take effect
- SQL normalization: single-quoted literals → `?`, numeric literals → `?`, `IN (?, ?, ?)` → `IN (?)`, whitespace collapse
- **Pgsql-safe**: double-quoted tokens are left intact (they're identifiers in standard SQL / PostgreSQL, not string literals)
- Per-signature counts + cumulative timings; `repeatedSignatures($threshold)` for downstream consumers
- Dispatches `SlowQueryDetected` when `slow_query_logging.enabled` and the configured `threshold_ms` is exceeded

**#41 — N1Detector** (`src/Database/N1Detector.php`)
- Threshold-based detection (default 5, configurable)
- One event per signature per request — no spam
- Relation inference via `Str::camel` + `Str::singular` that distinguishes `WHERE id = ?` (BelongsTo → singular relation) from `WHERE fk_id = ?` (HasMany → camelCase plural)
- `reset()` clears `$currentRoute` so route names don't leak across long-running requests
- Optional log-channel write; suggestion attached to the event payload

**Service provider** — three new singletons + Octane `RequestReceived` reset hook for analyzer + detector + `bootDatabaseObservers()` gated on `features.query_optimization` / `database.n1_detection.enabled`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.5.0
- PHP Version: 8.4.22 (package supports 8.2+)
- Project Version: 1.0.0-dev

**Tests Performed:**
1. `composer test` — 453 tests pass (1 skipped), 930 assertions
2. `composer lint` — clean (php-cs-fixer + phpcs)
3. Manual smoke test via Tinker against the dev app — verified strategy resolution, file roundtrip, tag-scoped flush, query normalization including pgsql identifiers, N+1 suggestion for BelongsTo + HasMany cases
4. Pre-merge code review (8-angle parallel review surfacing 10 correctness findings, all fixed with regression tests)

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**
- `tests/Feature/Cache/CacheStrategyManagerTest.php` — 8 tests
- `tests/Feature/Cache/Strategies/FileCacheStrategyTest.php` — 7 tests
- `tests/Feature/Traits/CachesQueriesTest.php` — 14 tests (incl. transaction defer, rollback no-flush, pagination key, eager-load segregation, custom-key SQL mix)
- `tests/Feature/Database/QueryAnalyzerTest.php` — 12 tests (incl. pgsql identifier preservation)
- `tests/Feature/Database/N1DetectorTest.php` — 14 tests (incl. currentRoute reset, BelongsTo singular suggestion, multi-word camelCase)
- `tests/Fixtures/CachesQueriesPostStub.php` — fixture model

## Accessibility Tests Run

N/A — this PR is backend-only (Eloquent trait, cache contracts, query observability). No UI surface added in this package.

## Documentation

- [x] Inline code documentation added

**Documentation details:** Comprehensive PHPDoc on every new class and method including `@since 1.0.0`, parameter descriptions, and "why" comments explaining non-obvious behavior (transaction defer, tag-index locking, pgsql identifier preservation, per-event flag re-read, etc.). README and wiki updates can land in a follow-up.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed (8-angle parallel code review with 10 findings all fixed)
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added query result caching for Eloquent models, including cache tags, custom cache keys, and automatic invalidation after data changes.
  * Added cache support for file, Redis, and Memcached backends with configurable driver selection.
  * Added request-level query analysis to detect slow queries and N+1 patterns with suggested fixes.

* **Bug Fixes**
  * Improved cache invalidation timing during database transactions to avoid stale reads.

* **Tests**
  * Added coverage for cache behavior, query caching, and query detection features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->