### PR TITLE
feat(monitoring,livewire): metrics API + dashboard + chart + cache manager (#52-#56)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,12 @@
     "artisanpack-ui/code-style-pint": "^1.1",
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
     "laravel/pint": "^1.26",
+    "livewire/livewire": "^3.6",
     "orchestra/testbench": "^10.2|^11.0",
     "friendsofphp/php-cs-fixer": "^3.75"
+  },
+  "suggest": {
+    "livewire/livewire": "Required for the bundled performance dashboard, metrics chart, and cache manager Livewire components (^3.6)."
   },
   "scripts": {
     "lint": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4706ce89b3eadcfd63d66274266b9075",
+    "content-hash": "4d8cbcda9e309698933189af15b8ba02",
     "packages": [
         {
             "name": "artisanpack-ui/core",
@@ -7263,6 +7263,82 @@
             "time": "2026-02-06T14:12:35+00:00"
         },
         {
+            "name": "livewire/livewire",
+            "version": "v3.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/livewire/livewire.git",
+                "reference": "e77fce60d0615d68dc6b8fafe98a6739d9752a24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/e77fce60d0615d68dc6b8fafe98a6739d9752a24",
+                "reference": "e77fce60d0615d68dc6b8fafe98a6739d9752a24",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/routing": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/validation": "^10.0|^11.0|^12.0|^13.0",
+                "laravel/prompts": "^0.1.24|^0.2|^0.3",
+                "league/mime-type-detection": "^1.9",
+                "php": "^8.1",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/http-kernel": "^6.2|^7.0|^8.0"
+            },
+            "require-dev": {
+                "calebporzio/sushi": "^2.1",
+                "laravel/framework": "^10.15.0|^11.0|^12.0|^13.0",
+                "mockery/mockery": "^1.3.1",
+                "orchestra/testbench": "^8.21.0|^9.0|^10.0|^11.0",
+                "orchestra/testbench-dusk": "^8.24|^9.1|^10.0|^11.0",
+                "phpunit/phpunit": "^10.4|^11.5|^12.5",
+                "psy/psysh": "^0.11.22|^0.12"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Livewire": "Livewire\\Livewire"
+                    },
+                    "providers": [
+                        "Livewire\\LivewireServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Livewire\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Caleb Porzio",
+                    "email": "calebporzio@gmail.com"
+                }
+            ],
+            "description": "A front-end framework for Laravel.",
+            "support": {
+                "issues": "https://github.com/livewire/livewire/issues",
+                "source": "https://github.com/livewire/livewire/tree/v3.8.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/livewire",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-27T03:14:20+00:00"
+        },
+        {
             "name": "mockery/mockery",
             "version": "1.6.12",
             "source": {
@@ -11444,5 +11520,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/config/performance.php
+++ b/config/performance.php
@@ -376,6 +376,7 @@ return [
         'enabled' => true,
         'api_prefix' => 'api/performance',
         'api_middleware' => ['api'],
+        'api_throttle' => env('PERF_API_THROTTLE', '60,1'),
     ],
 
     /*

--- a/database/migrations/2026_01_01_000005_create_performance_raw_metrics_table.php
+++ b/database/migrations/2026_01_01_000005_create_performance_raw_metrics_table.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Create performance_raw_metrics table migration.
+ *
+ * Stores raw Core Web Vitals samples as they arrive from the browser
+ * before the aggregation pipeline rolls them up into the daily
+ * percentiles persisted in `performance_metrics`. Persistence is gated
+ * by `monitoring.store_raw_metrics`; when disabled the metric API
+ * accepts samples but discards them without writing to this table.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Runs the migration.
+     *
+     * @since 1.0.0
+     */
+    public function up(): void
+    {
+        Schema::create( 'performance_raw_metrics', function ( Blueprint $table ): void {
+            $table->id();
+            $table->string( 'name', 32 );
+            $table->float( 'value' );
+            $table->float( 'delta' )->nullable();
+            $table->string( 'rating', 32 )->nullable();
+            $table->string( 'vital_id', 64 )->nullable();
+            $table->text( 'url' )->nullable();
+            $table->string( 'route' )->nullable();
+            $table->string( 'device_type', 32 )->nullable();
+            $table->string( 'connection_type', 32 )->nullable();
+            $table->text( 'user_agent' )->nullable();
+            $table->json( 'extra' )->nullable();
+            $table->timestamp( 'recorded_at' )->index();
+            $table->timestamps();
+
+            $table->index( [ 'name', 'recorded_at' ] );
+            $table->index( [ 'route', 'recorded_at' ] );
+        } );
+    }
+
+    /**
+     * Reverses the migration.
+     *
+     * @since 1.0.0
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists( 'performance_raw_metrics' );
+    }
+};

--- a/resources/js/metrics-chart.js
+++ b/resources/js/metrics-chart.js
@@ -1,0 +1,169 @@
+/**
+ * ArtisanPack UI Performance — metrics chart bootstrap.
+ *
+ * Renders Chart.js charts inside `[data-metrics-chart]` containers
+ * emitted by the `MetricsChart` Livewire component. Each container
+ * carries a `data-chart-payload` JSON blob that drives the chart:
+ * type, labels, datasets (with per-dataset threshold), and colors.
+ *
+ * The bootstrap is intentionally framework-agnostic — it doesn't
+ * depend on Alpine or Livewire — but it re-runs on the standard
+ * Livewire morph events so charts created by a re-render get
+ * initialized just like ones present at first paint.
+ *
+ * Chart.js is expected on `window.Chart` (loaded by the host page
+ * via CDN or a bundler). When it's missing the bootstrap logs a
+ * single warning and the rendered "View data" details table
+ * remains as the textual fallback.
+ *
+ * @since 1.0.0
+ */
+( function () {
+	'use strict';
+
+	const SELECTOR = '[data-metrics-chart]';
+	const INSTANCE_KEY = '__artisanpackPerfChart';
+	const PALETTE = [
+		'#2563eb',
+		'#16a34a',
+		'#ea580c',
+		'#9333ea',
+		'#dc2626',
+		'#0891b2',
+	];
+
+	function readPayload( container ) {
+		const raw = container.getAttribute( 'data-chart-payload' );
+
+		if ( ! raw ) {
+			return null;
+		}
+
+		try {
+			return JSON.parse( raw );
+		} catch ( error ) {
+			console.warn( 'ArtisanPack Performance: invalid chart payload', error );
+			return null;
+		}
+	}
+
+	function buildDatasets( payload ) {
+		const datasets = [];
+		const sourceDatasets = Array.isArray( payload.datasets ) ? payload.datasets : [];
+
+		sourceDatasets.forEach( function ( dataset, index ) {
+			const color = PALETTE[ index % PALETTE.length ];
+			const isArea = 'area' === payload.type;
+			const isBar = 'bar' === payload.type;
+
+			datasets.push( {
+				label: dataset.metric || 'metric',
+				data: Array.isArray( dataset.values ) ? dataset.values : [],
+				borderColor: color,
+				backgroundColor: isBar || isArea ? color + '33' : color,
+				fill: isArea,
+				tension: 0.25,
+				spanGaps: true,
+			} );
+
+			if ( null !== dataset.threshold && undefined !== dataset.threshold ) {
+				const labels = Array.isArray( payload.labels ) ? payload.labels : [];
+				const goodColor = ( payload.colors && payload.colors.good ) || '#22c55e';
+
+				datasets.push( {
+					label: ( dataset.metric || 'metric' ) + ' threshold',
+					data: labels.map( function () { return dataset.threshold; } ),
+					borderColor: goodColor,
+					borderDash: [ 6, 4 ],
+					borderWidth: 1,
+					pointRadius: 0,
+					fill: false,
+					spanGaps: true,
+				} );
+			}
+		} );
+
+		return datasets;
+	}
+
+	function destroy( container ) {
+		const existing = container[ INSTANCE_KEY ];
+
+		if ( existing && 'function' === typeof existing.destroy ) {
+			existing.destroy();
+		}
+
+		container[ INSTANCE_KEY ] = null;
+	}
+
+	function render( container ) {
+		const payload = readPayload( container );
+
+		if ( ! payload ) {
+			return;
+		}
+
+		const canvas = container.querySelector( 'canvas' );
+
+		if ( ! canvas ) {
+			return;
+		}
+
+		if ( ! window.Chart ) {
+			if ( ! window.__artisanpackPerfChartWarned ) {
+				console.warn( 'ArtisanPack Performance: Chart.js is not loaded. Charts will not render.' );
+				window.__artisanpackPerfChartWarned = true;
+			}
+			return;
+		}
+
+		destroy( container );
+
+		const chartType = 'area' === payload.type ? 'line' : ( payload.type || 'line' );
+
+		container[ INSTANCE_KEY ] = new window.Chart( canvas, {
+			type: chartType,
+			data: {
+				labels: Array.isArray( payload.labels ) ? payload.labels : [],
+				datasets: buildDatasets( payload ),
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: false,
+				interaction: { mode: 'index', intersect: false },
+				plugins: {
+					legend: { position: 'bottom' },
+				},
+				scales: {
+					y: { beginAtZero: true },
+				},
+			},
+		} );
+	}
+
+	function renderAll( root ) {
+		const scope = root || document;
+		const containers = scope.querySelectorAll( SELECTOR );
+
+		containers.forEach( render );
+	}
+
+	function init() {
+		renderAll();
+
+		if ( window.Livewire && 'function' === typeof window.Livewire.hook ) {
+			// Re-run after each component morph so charts inside
+			// re-rendered Livewire trees pick up the new payload.
+			window.Livewire.hook( 'morph.updated', function ( payload ) {
+				const element = payload && payload.el ? payload.el : null;
+				renderAll( element );
+			} );
+		}
+	}
+
+	if ( 'loading' === document.readyState ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+} )();

--- a/resources/views/livewire/cache-manager.blade.php
+++ b/resources/views/livewire/cache-manager.blade.php
@@ -1,0 +1,160 @@
+<div class="performance-cache-manager" data-testid="performance-cache-manager">
+    @if($statusMessage !== null)
+        <div @class([
+            'performance-cache-manager__status',
+            'is-error' => $statusIsError,
+            'is-success' => ! $statusIsError,
+        ]) data-testid="status-banner">
+            {{ $statusMessage }}
+        </div>
+    @endif
+
+    <section class="performance-cache-manager__section">
+        <h3 class="performance-cache-manager__heading">{{ __( 'Page Cache' ) }}</h3>
+
+        <dl class="performance-cache-manager__summary">
+            <div>
+                <dt>{{ __( 'Entries' ) }}</dt>
+                <dd>{{ number_format( $pageSummary['entries'] ) }}</dd>
+            </div>
+            <div>
+                <dt>{{ __( 'Size' ) }}</dt>
+                <dd>{{ $pageSummary['size_bytes'] !== null ? number_format( $pageSummary['size_bytes'] ) . ' B' : __( 'N/A' ) }}</dd>
+            </div>
+            <div>
+                <dt>{{ __( 'Hit rate' ) }}</dt>
+                <dd>{{ $pageSummary['hit_rate'] !== null ? number_format( $pageSummary['hit_rate'] * 100, 2 ) . '%' : __( 'N/A' ) }}</dd>
+            </div>
+        </dl>
+
+        <form wire:submit.prevent="requestKeyInvalidation" class="performance-cache-manager__inline-form">
+            <label for="invalidate-key" class="performance-cache-manager__label">{{ __( 'Invalidate by key' ) }}</label>
+            <input
+                type="text"
+                id="invalidate-key"
+                wire:model.live="invalidateKeyInput"
+                class="performance-cache-manager__input"
+                placeholder="{{ __( 'e.g. products/*' ) }}"
+            />
+            <button type="submit" class="performance-cache-manager__button">{{ $resolvedLabels['invalidate'] }}</button>
+        </form>
+
+        @if($pendingAction === 'key:' . $invalidateKeyInput && $invalidateKeyInput !== '')
+            <div class="performance-cache-manager__confirm-bar" data-testid="confirm-key-input">
+                <span>{{ __( 'Invalidate page entries matching ":pattern"?', [ 'pattern' => $invalidateKeyInput ] ) }}</span>
+                <button type="button" wire:click="invalidate('{{ addslashes( $invalidateKeyInput ) }}')" class="performance-cache-manager__button is-danger">
+                    {{ $resolvedLabels['confirm'] }}
+                </button>
+                <button type="button" wire:click="cancelConfirmation" class="performance-cache-manager__button">
+                    {{ $resolvedLabels['cancel'] }}
+                </button>
+            </div>
+        @endif
+
+        @if(! empty($pageEntries))
+            <table class="performance-cache-manager__table" data-testid="page-entries">
+                <thead>
+                    <tr>
+                        <th>{{ __( 'Key' ) }}</th>
+                        <th>{{ __( 'Path' ) }}</th>
+                        <th class="performance-cache-manager__actions-col">{{ __( 'Actions' ) }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($pageEntries as $index => $entry)
+                        <tr wire:key="page-entry-{{ $index }}">
+                            <td><code>{{ $entry['key'] }}</code></td>
+                            <td>{{ $entry['path'] }}</td>
+                            <td>
+                                @if($pendingAction === 'entry:' . $index)
+                                    <button type="button" wire:click="invalidateEntry({{ $index }})" class="performance-cache-manager__button is-danger" data-testid="confirm-entry-{{ $index }}">
+                                        {{ $resolvedLabels['confirm'] }}
+                                    </button>
+                                    <button type="button" wire:click="cancelConfirmation" class="performance-cache-manager__button">
+                                        {{ $resolvedLabels['cancel'] }}
+                                    </button>
+                                @else
+                                    <button type="button" wire:click="requestConfirmation('entry:{{ $index }}')" class="performance-cache-manager__button">
+                                        {{ $resolvedLabels['invalidate'] }}
+                                    </button>
+                                @endif
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        @endif
+    </section>
+
+    <section class="performance-cache-manager__section">
+        <h3 class="performance-cache-manager__heading">{{ __( 'Fragment Cache' ) }}</h3>
+
+        <dl class="performance-cache-manager__summary">
+            <div>
+                <dt>{{ __( 'Entries' ) }}</dt>
+                <dd>{{ number_format( $fragmentSummary['entries'] ) }}</dd>
+            </div>
+            <div>
+                <dt>{{ __( 'Tags' ) }}</dt>
+                <dd>{{ number_format( $fragmentSummary['tags'] ) }}</dd>
+            </div>
+            <div>
+                <dt>{{ __( 'Hit rate' ) }}</dt>
+                <dd>{{ $fragmentSummary['hit_rate'] !== null ? number_format( $fragmentSummary['hit_rate'] * 100, 2 ) . '%' : __( 'N/A' ) }}</dd>
+            </div>
+        </dl>
+
+        @if(! empty($fragmentTags))
+            <table class="performance-cache-manager__table" data-testid="fragment-tags">
+                <thead>
+                    <tr>
+                        <th>{{ __( 'Tag' ) }}</th>
+                        <th>{{ __( 'Entries' ) }}</th>
+                        <th class="performance-cache-manager__actions-col">{{ __( 'Actions' ) }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($fragmentTags as $index => $tagRow)
+                        <tr wire:key="fragment-tag-{{ $index }}">
+                            <td><code>{{ $tagRow['tag'] }}</code></td>
+                            <td>{{ number_format( $tagRow['entry_count'] ) }}</td>
+                            <td>
+                                @if($pendingAction === 'fragment-tag:' . $index)
+                                    <button type="button" wire:click="invalidateFragmentTagByIndex({{ $index }})" class="performance-cache-manager__button is-danger" data-testid="confirm-tag-{{ $index }}">
+                                        {{ $resolvedLabels['confirm'] }}
+                                    </button>
+                                    <button type="button" wire:click="cancelConfirmation" class="performance-cache-manager__button">
+                                        {{ $resolvedLabels['cancel'] }}
+                                    </button>
+                                @else
+                                    <button type="button" wire:click="requestConfirmation('fragment-tag:{{ $index }}')" class="performance-cache-manager__button">
+                                        {{ $resolvedLabels['tag'] }}
+                                    </button>
+                                @endif
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        @endif
+    </section>
+
+    <section class="performance-cache-manager__section performance-cache-manager__actions">
+        <button type="button" wire:click="warmCache" class="performance-cache-manager__button is-primary" data-testid="warm-cache">
+            {{ $resolvedLabels['warm'] }}
+        </button>
+
+        @if($pendingAction === 'flush')
+            <button type="button" wire:click="flushAll" class="performance-cache-manager__button is-danger" data-testid="confirm-flush">
+                {{ $resolvedLabels['confirm'] }}
+            </button>
+            <button type="button" wire:click="cancelConfirmation" class="performance-cache-manager__button">
+                {{ $resolvedLabels['cancel'] }}
+            </button>
+        @else
+            <button type="button" wire:click="requestConfirmation('flush')" class="performance-cache-manager__button is-danger" data-testid="request-flush">
+                {{ $resolvedLabels['purge'] }}
+            </button>
+        @endif
+    </section>
+</div>

--- a/resources/views/livewire/metrics-chart.blade.php
+++ b/resources/views/livewire/metrics-chart.blade.php
@@ -1,0 +1,48 @@
+<div class="performance-metrics-chart" data-testid="performance-metrics-chart">
+    <div class="performance-metrics-chart__range" role="group" aria-label="{{ __( 'Chart date range' ) }}">
+        @foreach(array_keys(\ArtisanPackUI\Performance\Livewire\MetricsChart::RANGE_DAYS) as $rangeKey)
+            <button
+                type="button"
+                wire:click="setDateRange('{{ $rangeKey }}')"
+                @class([
+                    'performance-metrics-chart__range-button',
+                    'is-active' => $dateRange === $rangeKey,
+                ])
+                aria-pressed="{{ $dateRange === $rangeKey ? 'true' : 'false' }}"
+            >{{ $rangeKey }}</button>
+        @endforeach
+    </div>
+
+    <div
+        class="performance-metrics-chart__canvas"
+        data-metrics-chart
+        data-chart-payload="{{ json_encode( $chartPayload, JSON_THROW_ON_ERROR ) }}"
+    >
+        <canvas role="img" aria-label="{{ __( 'Metrics chart' ) }}"></canvas>
+    </div>
+
+    <details class="performance-metrics-chart__data">
+        <summary>{{ __( 'View data' ) }}</summary>
+
+        <table class="performance-metrics-chart__table">
+            <thead>
+                <tr>
+                    <th>{{ __( 'Date' ) }}</th>
+                    @foreach($chartPayload['datasets'] as $dataset)
+                        <th>{{ $dataset['metric'] }}</th>
+                    @endforeach
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($chartPayload['labels'] as $index => $label)
+                    <tr wire:key="metrics-chart-row-{{ $label }}">
+                        <td>{{ $label }}</td>
+                        @foreach($chartPayload['datasets'] as $dataset)
+                            <td>{{ $dataset['values'][ $index ] !== null ? number_format( $dataset['values'][ $index ], 2 ) : '—' }}</td>
+                        @endforeach
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </details>
+</div>

--- a/resources/views/livewire/performance-dashboard.blade.php
+++ b/resources/views/livewire/performance-dashboard.blade.php
@@ -1,0 +1,211 @@
+<div class="performance-dashboard" data-testid="performance-dashboard">
+    @isset($header)
+        <div class="performance-dashboard__header">
+            {{ $header }}
+        </div>
+    @endisset
+
+    @php
+        $rangeLabels = [
+            '24h' => __( 'Last 24 hours' ),
+            '7d'  => __( 'Last 7 days' ),
+            '30d' => __( 'Last 30 days' ),
+            '90d' => __( 'Last 90 days' ),
+        ];
+        $tabLabels = [
+            'overview'        => __( 'Overview' ),
+            'pages'           => __( 'Pages' ),
+            'images'          => __( 'Images' ),
+            'cache'           => __( 'Cache' ),
+            'queries'         => __( 'Queries' ),
+            'recommendations' => __( 'Recommendations' ),
+        ];
+        $statusLabels = [
+            'good'              => __( 'Good' ),
+            'needs-improvement' => __( 'Needs improvement' ),
+            'poor'              => __( 'Poor' ),
+            'unknown'           => __( 'Unknown' ),
+        ];
+    @endphp
+
+    <div class="performance-dashboard__toolbar">
+        <div class="performance-dashboard__range" role="group" aria-label="{{ __( 'Date range' ) }}">
+            @foreach($ranges as $range)
+                <button
+                    type="button"
+                    wire:click="setDateRange('{{ $range }}')"
+                    @class([
+                        'performance-dashboard__range-button',
+                        'is-active' => $dateRange === $range,
+                    ])
+                    aria-pressed="{{ $dateRange === $range ? 'true' : 'false' }}"
+                >
+                    {{ $rangeLabels[$range] ?? $range }}
+                </button>
+            @endforeach
+        </div>
+
+        <button
+            type="button"
+            wire:click="refreshMetrics"
+            class="performance-dashboard__refresh"
+        >
+            {{ __( 'Refresh' ) }}
+        </button>
+    </div>
+
+    <div class="performance-dashboard__tabs" role="tablist">
+        @foreach($tabs as $tab)
+            <button
+                type="button"
+                role="tab"
+                wire:click="setTab('{{ $tab }}')"
+                aria-selected="{{ $activeTab === $tab ? 'true' : 'false' }}"
+                @class([
+                    'performance-dashboard__tab',
+                    'is-active' => $activeTab === $tab,
+                ])
+            >
+                {{ $tabLabels[$tab] ?? $tab }}
+            </button>
+        @endforeach
+    </div>
+
+    <div class="performance-dashboard__panel" role="tabpanel" wire:key="panel-{{ $activeTab }}">
+        @if($activeTab === 'overview')
+            <h2 class="performance-dashboard__heading">{{ __( 'Core Web Vitals' ) }}</h2>
+
+            @if(empty($overview))
+                <p class="performance-dashboard__empty">{{ __( 'No metrics recorded for this range yet.' ) }}</p>
+            @else
+                <table class="performance-dashboard__table" data-testid="overview-table">
+                    <thead>
+                        <tr>
+                            <th>{{ __( 'Metric' ) }}</th>
+                            <th>{{ __( 'p75' ) }}</th>
+                            <th>{{ __( 'Samples' ) }}</th>
+                            <th>{{ __( 'Status' ) }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($overview as $row)
+                            <tr wire:key="overview-{{ $row['metric'] }}">
+                                <td>{{ $row['metric'] }}</td>
+                                <td>{{ $row['p75'] !== null ? number_format( $row['p75'], 2 ) : '—' }}</td>
+                                <td>{{ number_format( $row['sample_count'] ) }}</td>
+                                <td>
+                                    <span @class([
+                                        'performance-dashboard__badge',
+                                        'is-good' => $row['status'] === 'good',
+                                        'is-warning' => $row['status'] === 'needs-improvement',
+                                        'is-danger' => $row['status'] === 'poor',
+                                        'is-muted' => $row['status'] === 'unknown',
+                                    ])>{{ $statusLabels[$row['status']] ?? $row['status'] }}</span>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            @endif
+        @elseif($activeTab === 'pages')
+            <h2 class="performance-dashboard__heading">{{ __( 'Pages' ) }}</h2>
+
+            @if(empty($pages))
+                <p class="performance-dashboard__empty">{{ __( 'No per-route metrics recorded yet.' ) }}</p>
+            @else
+                <table class="performance-dashboard__table" data-testid="pages-table">
+                    <thead>
+                        <tr>
+                            <th>{{ __( 'Route' ) }}</th>
+                            <th>{{ __( 'Metric' ) }}</th>
+                            <th>{{ __( 'p75' ) }}</th>
+                            <th>{{ __( 'Samples' ) }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($pages as $row)
+                            <tr wire:key="pages-{{ $loop->index }}">
+                                <td>{{ $row['route'] }}</td>
+                                <td>{{ $row['metric'] }}</td>
+                                <td>{{ number_format( $row['p75'], 2 ) }}</td>
+                                <td>{{ number_format( $row['sample_count'] ) }}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            @endif
+        @elseif($activeTab === 'images')
+            <h2 class="performance-dashboard__heading">{{ __( 'Images' ) }}</h2>
+            <p class="performance-dashboard__empty">{{ __( 'Image optimization details appear here once the optimization queue has run.' ) }}</p>
+        @elseif($activeTab === 'cache')
+            <h2 class="performance-dashboard__heading">{{ __( 'Cache' ) }}</h2>
+
+            <dl class="performance-dashboard__summary">
+                <div>
+                    <dt>{{ __( 'Page cache entries' ) }}</dt>
+                    <dd>{{ number_format( $cacheSummary['page']['entries'] ) }}</dd>
+                </div>
+                <div>
+                    <dt>{{ __( 'Fragment cache entries' ) }}</dt>
+                    <dd>{{ number_format( $cacheSummary['fragment']['entries'] ) }}</dd>
+                </div>
+                <div>
+                    <dt>{{ __( 'Fragment tags' ) }}</dt>
+                    <dd>{{ number_format( $cacheSummary['fragment']['tags'] ) }}</dd>
+                </div>
+            </dl>
+
+            @livewire('perf-cache-manager')
+        @elseif($activeTab === 'queries')
+            <h2 class="performance-dashboard__heading">{{ __( 'Slow Queries' ) }}</h2>
+
+            @if(empty($queries))
+                <p class="performance-dashboard__empty">{{ __( 'No slow queries logged for this range.' ) }}</p>
+            @else
+                <table class="performance-dashboard__table" data-testid="queries-table">
+                    <thead>
+                        <tr>
+                            <th>{{ __( 'Query' ) }}</th>
+                            <th>{{ __( 'Time (ms)' ) }}</th>
+                            <th>{{ __( 'Route' ) }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($queries as $row)
+                            <tr wire:key="query-{{ $loop->index }}">
+                                <td><code>{{ \Illuminate\Support\Str::limit( $row['query'], 120 ) }}</code></td>
+                                <td>{{ number_format( $row['time_ms'], 2 ) }}</td>
+                                <td>{{ $row['route'] ?? '—' }}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            @endif
+        @elseif($activeTab === 'recommendations')
+            <h2 class="performance-dashboard__heading">{{ __( 'Recommendations' ) }}</h2>
+
+            @if(empty($recommendations))
+                <p class="performance-dashboard__empty">{{ __( 'No recommendations at the moment — all tracked metrics are in the good band.' ) }}</p>
+            @else
+                <ul class="performance-dashboard__recommendations">
+                    @foreach($recommendations as $item)
+                        <li wire:key="rec-{{ $loop->index }}" @class([
+                            'performance-dashboard__recommendation',
+                            'is-high' => $item['severity'] === 'high',
+                            'is-medium' => $item['severity'] === 'medium',
+                        ])>
+                            <strong>{{ $item['title'] }}</strong>
+                            <p>{{ $item['body'] }}</p>
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+        @endif
+    </div>
+
+    @isset($footer)
+        <div class="performance-dashboard__footer">
+            {{ $footer }}
+        </div>
+    @endisset
+</div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Performance package API routes.
+ *
+ * Loaded from `PerformanceServiceProvider::registerRoutes()` when
+ * `artisanpack.performance.routes.enabled` is true. The package's
+ * route prefix, throttle middleware, and any user-supplied middleware
+ * stack are applied by the loader — this file only declares the
+ * endpoints themselves so the surface stays readable.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Http\Controllers\Api\MetricsApiController;
+use Illuminate\Support\Facades\Route;
+
+Route::post( '/metrics', [ MetricsApiController::class, 'store' ] )
+    ->name( 'metrics.store' );

--- a/src/Cache/CacheStatistics.php
+++ b/src/Cache/CacheStatistics.php
@@ -1,0 +1,196 @@
+<?php
+
+/**
+ * Cache statistics service.
+ *
+ * Exposes a read-only summary of the page and fragment caches managed
+ * by the package — entry counts and tag lists drawn from the existing
+ * pattern-invalidation indexes, plus a sample list of entry keys for
+ * dashboard display. Size and hit/miss rates are not tracked by the
+ * underlying managers and are surfaced here as `null` rather than
+ * fabricated.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Cache;
+
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Cache statistics class.
+ *
+ *
+ * @since      1.0.0
+ */
+class CacheStatistics
+{
+    /**
+     * Returns the page cache summary.
+     *
+     * `entries` is the count of cached responses derived from the
+     * pattern-invalidation index. `size_bytes` is null because the
+     * underlying manager does not track byte sizes (most cache stores
+     * do not expose them either). `hit_rate` is null for the same
+     * reason — adding counters would require touching the hot read
+     * path, which is out of scope for the dashboard's read-only view.
+     *
+     * @since 1.0.0
+     *
+     * @return array{entries: int, size_bytes: int|null, hit_rate: float|null}
+     */
+    public function pageSummary(): array
+    {
+        $index = $this->readPageIndex();
+
+        return [
+            'entries'    => count( $index ),
+            'size_bytes' => null,
+            'hit_rate'   => null,
+        ];
+    }
+
+    /**
+     * Returns the fragment cache summary.
+     *
+     * `tags` counts the distinct tags currently registered against
+     * fragment entries; `entries` is the deduplicated count of cache
+     * keys across every tag. Both come from the tag side-index that
+     * `FragmentCache` maintains for invalidation lookups.
+     *
+     * @since 1.0.0
+     *
+     * @return array{entries: int, tags: int, size_bytes: int|null, hit_rate: float|null}
+     */
+    public function fragmentSummary(): array
+    {
+        $index = $this->readFragmentIndex();
+
+        $keys = [];
+
+        foreach ( $index as $tag => $tagKeys ) {
+            if ( ! is_array( $tagKeys ) ) {
+                continue;
+            }
+
+            foreach ( $tagKeys as $key ) {
+                if ( is_string( $key ) ) {
+                    $keys[ $key ] = true;
+                }
+            }
+        }
+
+        return [
+            'entries'    => count( $keys ),
+            'tags'       => count( $index ),
+            'size_bytes' => null,
+            'hit_rate'   => null,
+        ];
+    }
+
+    /**
+     * Returns a sample of cached page entries for display.
+     *
+     * The dashboard renders these as a table; the sample size is
+     * bounded so dashboards on large caches stay responsive. The
+     * returned shape is `[{ key, path }, …]` so the UI can show the
+     * cache key alongside the request path it serves.
+     *
+     * @since 1.0.0
+     *
+     * @param  int  $limit  Maximum number of entries to return.
+     *
+     * @return array<int, array{key: string, path: string}>
+     */
+    public function pageEntries( int $limit = 50 ): array
+    {
+        $index   = $this->readPageIndex();
+        $entries = [];
+        $i       = 0;
+
+        foreach ( $index as $key => $path ) {
+            if ( $i >= $limit ) {
+                break;
+            }
+
+            if ( ! is_string( $key ) ) {
+                continue;
+            }
+
+            $entries[] = [
+                'key'  => $key,
+                'path' => is_string( $path ) ? $path : '',
+            ];
+
+            $i++;
+        }
+
+        return $entries;
+    }
+
+    /**
+     * Returns the distinct tags currently registered against fragments.
+     *
+     * The returned array has the shape `[{ tag, entry_count }, …]` so
+     * the dashboard can show how broad each tag's invalidation reach is.
+     *
+     * @since 1.0.0
+     *
+     * @return array<int, array{tag: string, entry_count: int}>
+     */
+    public function fragmentTags(): array
+    {
+        $index = $this->readFragmentIndex();
+        $tags  = [];
+
+        foreach ( $index as $tag => $keys ) {
+            if ( ! is_string( $tag ) || ! is_array( $keys ) ) {
+                continue;
+            }
+
+            $tags[] = [
+                'tag'         => $tag,
+                'entry_count' => count( array_filter( $keys, 'is_string' ) ),
+            ];
+        }
+
+        return $tags;
+    }
+
+    /**
+     * Reads the page cache pattern-invalidation index.
+     *
+     * @since 1.0.0
+     *
+     * @return array<string, string>
+     */
+    protected function readPageIndex(): array
+    {
+        $store = Cache::store( config( 'artisanpack.performance.page_cache.driver' ) );
+
+        $index = $store->get( PageCacheManager::INDEX_KEY, [] );
+
+        return is_array( $index ) ? $index : [];
+    }
+
+    /**
+     * Reads the fragment cache tag side-index.
+     *
+     * @since 1.0.0
+     *
+     * @return array<string, array<int, string>>
+     */
+    protected function readFragmentIndex(): array
+    {
+        $store = Cache::store( config( 'artisanpack.performance.fragment_cache.driver' ) );
+
+        $index = $store->get( FragmentCache::TAG_INDEX_KEY, [] );
+
+        return is_array( $index ) ? $index : [];
+    }
+}

--- a/src/Console/Commands/AggregateMetricsCommand.php
+++ b/src/Console/Commands/AggregateMetricsCommand.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * `perf:aggregate-metrics` artisan command.
+ *
+ * Folds the raw Core Web Vitals samples for a calendar date into the
+ * `performance_metrics` percentile summaries via `MetricsAggregator`.
+ * Intended to run on a scheduled hourly trigger (re-running per hour
+ * is safe because the aggregator is idempotent for any given date).
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Console\Commands;
+
+use ArtisanPackUI\Performance\Monitoring\MetricsAggregator;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Throwable;
+
+/**
+ * Aggregate metrics command class.
+ *
+ *
+ * @since      1.0.0
+ */
+class AggregateMetricsCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    protected $signature = 'perf:aggregate-metrics
+		{--date= : The calendar date to aggregate (YYYY-MM-DD). Defaults to today.}
+		{--backfill= : Backfill the last N days inclusive of today.}';
+
+    /**
+     * The console command description.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    protected $description = 'Aggregate raw performance metrics into per-day percentile summaries.';
+
+    /**
+     * Executes the command.
+     *
+     * @since 1.0.0
+     *
+     * @param  MetricsAggregator  $aggregator  Resolved aggregator service.
+     */
+    public function handle( MetricsAggregator $aggregator ): int
+    {
+        $dates = $this->resolveDates();
+
+        if ( empty( $dates ) ) {
+            $this->error( __( 'No dates resolved for aggregation.' ) );
+
+            return self::FAILURE;
+        }
+
+        $total = 0;
+
+        foreach ( $dates as $date ) {
+            try {
+                $written = $aggregator->aggregate( $date );
+            } catch ( Throwable $e ) {
+                $this->error( __( 'Failed to aggregate :date: :message', [
+                    'date'    => $date->toDateString(),
+                    'message' => $e->getMessage(),
+                ] ) );
+
+                return self::FAILURE;
+            }
+
+            $total += $written;
+
+            $this->line( __( ':date — :count buckets written.', [
+                'date'  => $date->toDateString(),
+                'count' => $written,
+            ] ) );
+        }
+
+        $this->info( __( 'Aggregation complete. :total bucket(s) written across :days day(s).', [
+            'total' => $total,
+            'days'  => count( $dates ),
+        ] ) );
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Builds the list of dates the command should aggregate.
+     *
+     * @since 1.0.0
+     *
+     * @return array<int, Carbon>
+     */
+    protected function resolveDates(): array
+    {
+        $explicit = (string) ( $this->option( 'date' ) ?? '' );
+        $backfill = (int) ( $this->option( 'backfill' ) ?? 0 );
+
+        if ( '' !== $explicit ) {
+            return [ Carbon::parse( $explicit )->startOfDay() ];
+        }
+
+        if ( $backfill > 0 ) {
+            $dates = [];
+            $today = Carbon::today();
+
+            for ( $offset = 0; $offset < $backfill; $offset++ ) {
+                $dates[] = $today->copy()->subDays( $offset );
+            }
+
+            return $dates;
+        }
+
+        return [ Carbon::today() ];
+    }
+}

--- a/src/Http/Controllers/Api/MetricsApiController.php
+++ b/src/Http/Controllers/Api/MetricsApiController.php
@@ -1,0 +1,233 @@
+<?php
+
+/**
+ * Metrics collection API controller.
+ *
+ * Accepts Core Web Vitals samples posted by the bundled
+ * `web-vitals.js` bootstrap (or any compatible client) and persists
+ * them to the `performance_raw_metrics` table for later aggregation.
+ * Persistence is gated by the `monitoring.store_raw_metrics` flag, so
+ * applications that only consume aggregated percentiles can leave the
+ * endpoint enabled without growing the raw table.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Http\Controllers\Api;
+
+use ArtisanPackUI\Performance\Models\RawMetric;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Carbon;
+use Throwable;
+
+/**
+ * Metrics API controller class.
+ *
+ *
+ * @since      1.0.0
+ */
+class MetricsApiController extends Controller
+{
+    /**
+     * The metric names the endpoint accepts.
+     *
+     * The web-vitals library reports five Core Web Vitals plus a handful
+     * of legacy/companion metrics. Anything outside this allowlist is
+     * rejected so a misconfigured client cannot pollute the table with
+     * unbounded metric names.
+     *
+     * @since 1.0.0
+     *
+     * @var array<int, string>
+     */
+    public const ALLOWED_METRICS = [
+        'LCP',
+        'FID',
+        'INP',
+        'CLS',
+        'TTFB',
+        'FCP',
+    ];
+
+    /**
+     * Persists a single metric sample.
+     *
+     * Validates the payload, applies sampling (so applications can throttle
+     * a busy production endpoint without overhauling instrumentation), and
+     * writes a row to `performance_raw_metrics` when storage is enabled.
+     * Returns a small JSON body the client can use for retry logic.
+     *
+     * @since 1.0.0
+     *
+     * @param  Request  $request  The incoming JSON request.
+     */
+    public function store( Request $request ): JsonResponse
+    {
+        if ( false === (bool) config( 'artisanpack.performance.monitoring.enabled', false ) ) {
+            return response()->json( [
+                'success' => false,
+                'reason'  => 'monitoring-disabled',
+            ], 403 );
+        }
+
+        // Mirror the gate that suppresses `@perfMonitor` script output.
+        // Without this check, HTML pages cached before the operator
+        // disabled RUM keep posting beacons that the endpoint would
+        // happily persist, defeating the opt-out.
+        if ( false === (bool) config( 'artisanpack.performance.monitoring.collect_web_vitals', true ) ) {
+            return response()->json( [
+                'success' => false,
+                'reason'  => 'web-vitals-disabled',
+            ], 403 );
+        }
+
+        $noControlChars = static function ( $attribute, $value, $fail ): void {
+            // The aggregator packs (route, metric, device, connection)
+            // into a single string with the ASCII Unit Separator
+            // (`\x1F`) as a delimiter; allowing control chars here
+            // would let a client smuggle a separator through and
+            // poison the aggregation buckets. Reject anything below
+            // 0x20 except whitespace.
+            if ( is_string( $value ) && preg_match( '/[\x00-\x1F\x7F]/', $value ) ) {
+                $fail( "The {$attribute} field contains disallowed control characters." );
+            }
+        };
+
+        $validated = $request->validate( [
+            'name'       => [ 'required', 'string', 'max:32', $noControlChars ],
+            'value'      => [ 'required', 'numeric' ],
+            'delta'      => [ 'sometimes', 'nullable', 'numeric' ],
+            'id'         => [ 'sometimes', 'nullable', 'string', 'max:64', $noControlChars ],
+            'rating'     => [ 'sometimes', 'nullable', 'string', 'max:32', $noControlChars ],
+            'page'       => [ 'sometimes', 'nullable', 'string', 'max:2048', $noControlChars ],
+            'route'      => [ 'sometimes', 'nullable', 'string', 'max:191', $noControlChars ],
+            'device'     => [ 'sometimes', 'nullable', 'string', 'max:32', $noControlChars ],
+            'deviceType' => [ 'sometimes', 'nullable', 'string', 'max:32', $noControlChars ],
+            'connection' => [ 'sometimes', 'nullable', 'string', 'max:32', $noControlChars ],
+            'extra'      => [ 'sometimes', 'nullable', 'array' ],
+        ] );
+
+        $name = (string) ( $validated['name'] ?? '' );
+
+        if ( ! in_array( $name, self::ALLOWED_METRICS, true ) ) {
+            return response()->json( [
+                'success' => false,
+                'reason'  => 'unknown-metric',
+            ], 422 );
+        }
+
+        if ( ! $this->passesSampleGate() ) {
+            // Sampling is intentionally silent — clients should not retry a
+            // sample dropped on purpose, so the API returns a 200 with a
+            // success=false body the client can ignore.
+            return response()->json( [
+                'success' => false,
+                'reason'  => 'sampled-out',
+            ] );
+        }
+
+        if ( false === (bool) config( 'artisanpack.performance.monitoring.store_raw_metrics', false ) ) {
+            // Raw storage is opt-in; when off the endpoint still validates
+            // the payload so misconfigured clients surface a 422 immediately
+            // instead of silently succeeding everywhere.
+            return response()->json( [ 'success' => true ] );
+        }
+
+        try {
+            RawMetric::create( $this->buildAttributes( $validated, $request ) );
+        } catch ( Throwable $e ) {
+            return response()->json( [
+                'success' => false,
+                'reason'  => 'storage-failed',
+            ], 500 );
+        }
+
+        return response()->json( [ 'success' => true ] );
+    }
+
+    /**
+     * Builds the model attribute payload from the validated request.
+     *
+     * Splits the URL into `url` (full path supplied by the client) and
+     * `route` (the resolved Laravel route name, when the client passes one
+     * — otherwise null) so the aggregator can group by either dimension.
+     *
+     * @since 1.0.0
+     *
+     * @param  array<string, mixed>  $validated  Validated input.
+     * @param  Request  $request  Incoming request used for client metadata.
+     *
+     * @return array<string, mixed>
+     */
+    protected function buildAttributes( array $validated, Request $request ): array
+    {
+        $page      = isset( $validated['page'] ) ? (string) $validated['page'] : null;
+        $userAgent = $request->header( 'User-Agent' );
+
+        // The bundled `web-vitals.js` posts `deviceType`; older
+        // hand-rolled clients tend to use `device`. Accept both so a
+        // package upgrade doesn't break clients that hard-coded the
+        // legacy field name. `deviceType` wins when both arrive.
+        $deviceType = $validated['deviceType']
+            ?? $validated['device']
+            ?? null;
+
+        $extra = $validated['extra'] ?? null;
+
+        return [
+            'name'            => (string) $validated['name'],
+            'value'           => (float) $validated['value'],
+            'delta'           => isset( $validated['delta'] ) ? (float) $validated['delta'] : null,
+            'rating'          => isset( $validated['rating'] ) ? (string) $validated['rating'] : null,
+            'vital_id'        => isset( $validated['id'] ) ? (string) $validated['id'] : null,
+            'url'             => $page,
+            'route'           => isset( $validated['route'] ) ? (string) $validated['route'] : null,
+            'device_type'     => null === $deviceType ? null : (string) $deviceType,
+            'connection_type' => isset( $validated['connection'] ) ? (string) $validated['connection'] : null,
+            'extra'           => is_array( $extra ) && ! empty( $extra ) ? $extra : null,
+            'user_agent'      => is_string( $userAgent ) ? $userAgent : null,
+            'recorded_at'     => Carbon::now(),
+        ];
+    }
+
+    /**
+     * Decides whether to accept the current sample based on the configured rate.
+     *
+     * The configured `sample_rate` is expressed as a 0-100 percentage; a
+     * value of 100 (the default) accepts every sample, 0 rejects every
+     * sample, and intermediate values use `random_int()` to make an
+     * unbiased decision. The implementation prefers `random_int()` over
+     * `mt_rand()` so test seeding tools that mock it intercept the same
+     * function the application would otherwise use.
+     *
+     * @since 1.0.0
+     */
+    protected function passesSampleGate(): bool
+    {
+        $rate = (int) config( 'artisanpack.performance.monitoring.sample_rate', 100 );
+
+        if ( $rate >= 100 ) {
+            return true;
+        }
+
+        if ( $rate <= 0 ) {
+            return false;
+        }
+
+        try {
+            return random_int( 1, 100 ) <= $rate;
+        } catch ( Throwable ) {
+            // Fall back to the deterministic-on-failure path: accept the
+            // sample. Better to over-collect than to silently drop on a
+            // RNG failure that's likely transient.
+            return true;
+        }
+    }
+}

--- a/src/Livewire/CacheManager.php
+++ b/src/Livewire/CacheManager.php
@@ -1,0 +1,393 @@
+<?php
+
+/**
+ * Cache manager Livewire component.
+ *
+ * Exposes the page and fragment cache controls — invalidate by key,
+ * invalidate by tag, flush both stores, and trigger cache warming — as
+ * a single dashboard surface. Destructive actions go through a small
+ * confirmation step the view renders inline so the component does not
+ * depend on a third-party modal library.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Livewire;
+
+use ArtisanPackUI\Performance\Cache\CacheInvalidator;
+use ArtisanPackUI\Performance\Cache\CacheStatistics;
+use ArtisanPackUI\Performance\Cache\PageCacheManager;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Cache manager component class.
+ *
+ *
+ * @since      1.0.0
+ */
+class CacheManager extends Component
+{
+    /**
+     * Label overrides supplied by the host application.
+     *
+     * The view checks each well-known key (`purge`, `warm`, `flush`,
+     * `invalidate`) against this map so host applications can change
+     * the verbiage without re-publishing the template.
+     *
+     * @since 1.0.0
+     *
+     * @var array<string, string>
+     */
+    public array $labels = [];
+
+    /**
+     * The action currently awaiting confirmation, or null when none is pending.
+     *
+     * Stored as a `type:value` string so the view can match on the
+     * exact action being confirmed. Concrete forms:
+     *
+     * - `flush`                — whole-cache flush
+     * - `entry:{index}`        — confirm invalidation of pageEntries[$index]
+     * - `key:{value}`          — confirm invalidation of a user-typed pattern
+     * - `fragment-tag:{index}` — confirm invalidation of fragmentTags[$index]
+     *
+     * @since 1.0.0
+     */
+    public ?string $pendingAction = null;
+
+    /**
+     * The current value of the "Invalidate by key" text input.
+     *
+     * Bound via `wire:model.live` so the user-typed pattern is
+     * available server-side without trying to parse `$event` out of a
+     * Livewire action expression (which is a Livewire-can't-do-it
+     * footgun even though the syntax looks right).
+     *
+     * @since 1.0.0
+     */
+    public string $invalidateKeyInput = '';
+
+    /**
+     * The most recent status message produced by an action.
+     *
+     * @since 1.0.0
+     */
+    public ?string $statusMessage = null;
+
+    /**
+     * Whether the most recent status is an error.
+     *
+     * @since 1.0.0
+     */
+    public bool $statusIsError = false;
+
+    /**
+     * Mounts the component, applying any label overrides.
+     *
+     * @since 1.0.0
+     *
+     * @param  array<string, string>  $labels  Label overrides.
+     */
+    public function mount( array $labels = [] ): void
+    {
+        $this->labels = array_filter( $labels, 'is_string' );
+    }
+
+    /**
+     * Stages a destructive action for confirmation.
+     *
+     * The view re-renders with the matching action highlighted and a
+     * confirm/cancel pair underneath. The action only runs when the
+     * confirm button calls the matching `confirm…` method.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $action  Action descriptor (e.g. `flush`, `tag:foo`, `key:bar`).
+     */
+    public function requestConfirmation( string $action ): void
+    {
+        $this->pendingAction = $action;
+    }
+
+    /**
+     * Cancels a pending confirmation without performing the action.
+     *
+     * @since 1.0.0
+     */
+    public function cancelConfirmation(): void
+    {
+        $this->pendingAction = null;
+    }
+
+    /**
+     * Stages a key-invalidation confirmation for the current input value.
+     *
+     * Backs the `<form wire:submit="requestKeyInvalidation">` in the
+     * view. Pulls the value from the `wire:model`-bound
+     * `$invalidateKeyInput` property — server-side data, no JS
+     * `$event` parsing — and stages the same `key:{value}` confirm
+     * flow the per-row buttons use.
+     *
+     * @since 1.0.0
+     */
+    public function requestKeyInvalidation(): void
+    {
+        $trimmed = trim( $this->invalidateKeyInput );
+
+        if ( '' === $trimmed ) {
+            $this->setStatus( __( 'A cache key is required.' ), true );
+
+            return;
+        }
+
+        $this->pendingAction = 'key:' . $trimmed;
+    }
+
+    /**
+     * Invalidates the page entry at the given index in the current view.
+     *
+     * The view passes a numeric index instead of the raw path so user-
+     * controlled characters (apostrophes, quotes, backslashes) cannot
+     * break the wire:click expression syntax. The path is resolved
+     * server-side from the same `pageEntries()` sample the view
+     * rendered.
+     *
+     * @since 1.0.0
+     *
+     * @param  int  $index  Zero-based index into the rendered page-entry list.
+     */
+    public function invalidateEntry( int $index ): void
+    {
+        $entries = app( CacheStatistics::class )->pageEntries();
+
+        if ( ! isset( $entries[ $index ] ) ) {
+            $this->setStatus( __( 'Cache entry no longer exists.' ), true );
+            $this->pendingAction = null;
+
+            return;
+        }
+
+        $path = (string) ( $entries[ $index ]['path'] ?? '' );
+
+        if ( '' === $path ) {
+            $this->setStatus( __( 'Cache entry has no path to invalidate.' ), true );
+            $this->pendingAction = null;
+
+            return;
+        }
+
+        $this->invalidate( $path );
+    }
+
+    /**
+     * Invalidates the fragment tag at the given index in the current view.
+     *
+     * @since 1.0.0
+     *
+     * @param  int  $index  Zero-based index into the rendered fragment-tag list.
+     */
+    public function invalidateFragmentTagByIndex( int $index ): void
+    {
+        $tags = app( CacheStatistics::class )->fragmentTags();
+
+        if ( ! isset( $tags[ $index ] ) ) {
+            $this->setStatus( __( 'Fragment tag no longer exists.' ), true );
+            $this->pendingAction = null;
+
+            return;
+        }
+
+        $tag = (string) ( $tags[ $index ]['tag'] ?? '' );
+
+        if ( '' === $tag ) {
+            $this->setStatus( __( 'Fragment tag is empty.' ), true );
+            $this->pendingAction = null;
+
+            return;
+        }
+
+        $this->invalidateByTag( $tag );
+    }
+
+    /**
+     * Invalidates a specific page cache entry.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $key  Cache key or path pattern.
+     */
+    public function invalidate( string $key ): void
+    {
+        if ( '' === trim( $key ) ) {
+            $this->setStatus( __( 'A cache key is required.' ), true );
+
+            return;
+        }
+
+        try {
+            $count = app( CacheInvalidator::class )->invalidatePagePattern( $key );
+        } catch ( Throwable $e ) {
+            $this->setStatus( __( 'Failed to invalidate cache: :message', [ 'message' => $e->getMessage() ] ), true );
+
+            return;
+        }
+
+        $this->pendingAction      = null;
+        $this->invalidateKeyInput = '';
+        $this->setStatus( __( ':count entries invalidated for :key.', [
+            'count' => $count,
+            'key'   => $key,
+        ] ) );
+    }
+
+    /**
+     * Invalidates every fragment cache entry registered under the given tag.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $tag  Tag name.
+     */
+    public function invalidateByTag( string $tag ): void
+    {
+        if ( '' === trim( $tag ) ) {
+            $this->setStatus( __( 'A tag name is required.' ), true );
+
+            return;
+        }
+
+        try {
+            $count = app( CacheInvalidator::class )->invalidateFragmentTag( $tag );
+        } catch ( Throwable $e ) {
+            $this->setStatus( __( 'Failed to invalidate tag: :message', [ 'message' => $e->getMessage() ] ), true );
+
+            return;
+        }
+
+        $this->pendingAction = null;
+        $this->setStatus( __( ':count fragments invalidated for tag ":tag".', [
+            'count' => $count,
+            'tag'   => $tag,
+        ] ) );
+    }
+
+    /**
+     * Flushes both the page and fragment caches the package manages.
+     *
+     * @since 1.0.0
+     */
+    public function flushAll(): void
+    {
+        try {
+            $summary = app( CacheInvalidator::class )->purgeAll();
+        } catch ( Throwable $e ) {
+            $this->setStatus( __( 'Failed to flush caches: :message', [ 'message' => $e->getMessage() ] ), true );
+
+            return;
+        }
+
+        $this->pendingAction = null;
+        $this->setStatus( __( ':page page and :fragments fragment entries flushed.', [
+            'page'      => $summary['page'] ?? 0,
+            'fragments' => $summary['fragments'] ?? 0,
+        ] ) );
+    }
+
+    /**
+     * Triggers cache warming for the URLs configured in `cache_warming.urls`.
+     *
+     * @since 1.0.0
+     */
+    public function warmCache(): void
+    {
+        $urls = (array) config( 'artisanpack.performance.cache_warming.urls', [] );
+        $urls = array_values( array_filter( $urls, 'is_string' ) );
+
+        if ( empty( $urls ) ) {
+            $this->setStatus( __( 'No cache_warming.urls configured.' ), true );
+
+            return;
+        }
+
+        try {
+            $results = app( PageCacheManager::class )->warmPageCache( $urls );
+        } catch ( Throwable $e ) {
+            $this->setStatus( __( 'Failed to warm cache: :message', [ 'message' => $e->getMessage() ] ), true );
+
+            return;
+        }
+
+        $succeeded = 0;
+
+        foreach ( $results as $entry ) {
+            if ( is_array( $entry ) && true === ( $entry['ok'] ?? false ) ) {
+                $succeeded++;
+            }
+        }
+
+        $this->setStatus( __( 'Warmed :count of :total URLs.', [
+            'count' => $succeeded,
+            'total' => count( $results ),
+        ] ) );
+    }
+
+    /**
+     * Renders the cache manager template.
+     *
+     * @since 1.0.0
+     */
+    public function render(): View
+    {
+        $statistics = app( CacheStatistics::class );
+
+        return view( 'performance::livewire.cache-manager', [
+            'pageSummary'     => $statistics->pageSummary(),
+            'fragmentSummary' => $statistics->fragmentSummary(),
+            'pageEntries'     => $statistics->pageEntries(),
+            'fragmentTags'    => $statistics->fragmentTags(),
+            'resolvedLabels'  => $this->resolveLabels(),
+        ] );
+    }
+
+    /**
+     * Resolves the action labels — merging host overrides over defaults.
+     *
+     * @since 1.0.0
+     *
+     * @return array<string, string>
+     */
+    protected function resolveLabels(): array
+    {
+        $defaults = [
+            'purge'      => (string) __( 'Flush All Caches' ),
+            'warm'       => (string) __( 'Warm Cache' ),
+            'flush'      => (string) __( 'Flush' ),
+            'invalidate' => (string) __( 'Invalidate' ),
+            'tag'        => (string) __( 'Invalidate by Tag' ),
+            'confirm'    => (string) __( 'Confirm' ),
+            'cancel'     => (string) __( 'Cancel' ),
+        ];
+
+        return array_merge( $defaults, $this->labels );
+    }
+
+    /**
+     * Sets the status banner for the next render.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $message  Status message.
+     * @param  bool  $isError  Whether the message represents a failure.
+     */
+    protected function setStatus( string $message, bool $isError = false ): void
+    {
+        $this->statusMessage = $message;
+        $this->statusIsError = $isError;
+    }
+}

--- a/src/Livewire/MetricsChart.php
+++ b/src/Livewire/MetricsChart.php
@@ -1,0 +1,320 @@
+<?php
+
+/**
+ * Metrics chart Livewire component.
+ *
+ * Renders a daily time series of one or more Web Vitals as a line chart.
+ * The component reads from the aggregated `performance_metrics` table
+ * (p75 column) and emits a small `<canvas>` plus a data island the
+ * client-side Chart.js bootstrap consumes. The component itself owns
+ * the data shaping; the JavaScript layer is a thin renderer.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Livewire;
+
+use ArtisanPackUI\Performance\Models\PerformanceMetric;
+use ArtisanPackUI\Performance\Monitoring\WebVitals;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Carbon;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+
+/**
+ * Metrics chart component class.
+ *
+ *
+ * @since      1.0.0
+ */
+class MetricsChart extends Component
+{
+    /**
+     * Date range options in days.
+     *
+     * @since 1.0.0
+     *
+     * @var array<string, int>
+     */
+    public const RANGE_DAYS = [
+        '7d'  => 7,
+        '30d' => 30,
+        '90d' => 90,
+    ];
+
+    /**
+     * Default per-metric threshold colors keyed by status.
+     *
+     * @since 1.0.0
+     *
+     * @var array<string, string>
+     */
+    public const DEFAULT_COLORS = [
+        'good'              => '#22c55e',
+        'needs_improvement' => '#f59e0b',
+        'poor'              => '#ef4444',
+    ];
+
+    /**
+     * The metrics to include in the chart.
+     *
+     * Accepts either a single metric (mounted via the `metric` prop) or
+     * a list (mounted via the `metrics` prop). Internally the property
+     * is always normalized to a list so the renderer doesn't branch on
+     * the shape.
+     *
+     * @since 1.0.0
+     *
+     * @var array<int, string>
+     */
+    public array $metrics = [ 'LCP' ];
+
+    /**
+     * Selected date range key.
+     *
+     * Bound to the URL so a user-selected range survives a reload and
+     * can be bookmarked. Different `as:` than the dashboard so the two
+     * components can coexist on a page without their range pickers
+     * sharing one query parameter.
+     *
+     * @since 1.0.0
+     */
+    #[Url( as: 'chart_range', history: true )]
+    public string $dateRange = '7d';
+
+    /**
+     * Whether to render the "good" threshold reference line.
+     *
+     * @since 1.0.0
+     */
+    public bool $showThreshold = true;
+
+    /**
+     * Chart type — `line`, `bar`, or `area`.
+     *
+     * @since 1.0.0
+     */
+    public string $chartType = 'line';
+
+    /**
+     * Mounts the component, normalizing the metric props.
+     *
+     * Accepts both `metric="LCP"` and `metrics={['LCP','FID']}` because
+     * the issue's example markup shows both forms. Either is coerced
+     * to the `$metrics` list.
+     *
+     * @since 1.0.0
+     *
+     * @param  string|null  $metric  Single metric name.
+     * @param  array<int, string>|null  $metrics  List of metrics.
+     * @param  string|null  $dateRange  Range key.
+     * @param  bool|null  $showThreshold  Whether to draw threshold reference lines.
+     * @param  string|null  $chartType  Chart type override.
+     */
+    public function mount(
+        ?string $metric = null,
+        ?array $metrics = null,
+        ?string $dateRange = null,
+        ?bool $showThreshold = null,
+        ?string $chartType = null,
+    ): void {
+        if ( is_array( $metrics ) ) {
+            $this->metrics = array_values( array_filter( $metrics, static fn ( $value ): bool => is_string( $value ) && '' !== $value ) );
+        } elseif ( null !== $metric && '' !== $metric ) {
+            $this->metrics = [ $metric ];
+        } else {
+            // Re-filter the property too, since Livewire syncs raw
+            // mount-args onto the public property BEFORE mount() runs
+            // — a host passing `:metrics="[null, '']"` arrives with
+            // junk in `$this->metrics` even when `$metrics` itself is
+            // never re-touched here.
+            $this->metrics = array_values( array_filter( $this->metrics, static fn ( $value ): bool => is_string( $value ) && '' !== $value ) );
+        }
+
+        // An empty or filter-stripped metrics list would later produce
+        // `WHERE metric IN ()` — a SQL syntax error on MySQL — so the
+        // class-level default (`['LCP']`) is reasserted whenever the
+        // resolved list is empty. The host gets a sensible fallback
+        // instead of a 500 page.
+        if ( empty( $this->metrics ) ) {
+            $this->metrics = [ 'LCP' ];
+        }
+
+        if ( null !== $dateRange && '' !== $dateRange ) {
+            $this->dateRange = $dateRange;
+        }
+
+        if ( null !== $showThreshold ) {
+            $this->showThreshold = $showThreshold;
+        }
+
+        if ( null !== $chartType && '' !== $chartType ) {
+            $this->chartType = $chartType;
+        }
+
+        $this->dateRange = $this->resolveRange( $this->dateRange );
+        $this->chartType = $this->resolveChartType( $this->chartType );
+    }
+
+    /**
+     * Switches the active date range.
+     *
+     * Exposed as a Livewire action so the bundled view can render a
+     * range-picker (`<button wire:click="setDateRange('30d')">`)
+     * without the host having to wire one up. Coerces unknown keys
+     * to the default rather than throwing so a stale URL never
+     * crashes the page.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $range  Range key.
+     */
+    public function setDateRange( string $range ): void
+    {
+        $this->dateRange = $this->resolveRange( $range );
+    }
+
+    /**
+     * Renders the chart container and data payload.
+     *
+     * @since 1.0.0
+     */
+    public function render(): View
+    {
+        return view( 'performance::livewire.metrics-chart', [
+            'chartPayload' => $this->buildChartPayload(),
+        ] );
+    }
+
+    /**
+     * Builds the data payload the client-side renderer consumes.
+     *
+     * The payload is a single JSON-encodable structure containing the
+     * chart type, the labels (daily date strings), every metric's
+     * dataset (date → p75), the configured colors, and the threshold
+     * lines so the client can render a complete chart without further
+     * AJAX round-trips.
+     *
+     * @since 1.0.0
+     *
+     * @return array<string, mixed>
+     */
+    public function buildChartPayload(): array
+    {
+        $startDate = $this->startDate();
+        $endDate   = $this->endDate();
+        $labels    = $this->dateRangeLabels( $startDate, $endDate );
+
+        // The metrics list is guaranteed non-empty by mount() — the
+        // class-level default is reasserted whenever the resolved list
+        // becomes empty so this query never produces `WHERE metric IN ()`.
+        $rows = PerformanceMetric::query()
+            ->whereBetween( 'date', [ $startDate, $endDate ] )
+            ->whereIn( 'metric', $this->metrics )
+            ->selectRaw( 'metric, date, SUM(p75 * sample_count) / NULLIF(SUM(sample_count), 0) as p75' )
+            ->groupBy( 'metric', 'date' )
+            ->orderBy( 'date' )
+            ->get();
+
+        $byMetric = [];
+
+        foreach ( $rows as $row ) {
+            $metric = (string) $row->metric;
+            $date   = Carbon::parse( $row->date )->toDateString();
+
+            $byMetric[ $metric ][ $date ] = null === $row->p75 ? null : (float) $row->p75;
+        }
+
+        $datasets = [];
+
+        foreach ( $this->metrics as $metric ) {
+            $values = array_map( static fn ( string $label ) => $byMetric[ $metric ][ $label ] ?? null, $labels );
+
+            $datasets[] = [
+                'metric'    => $metric,
+                'values'    => $values,
+                'threshold' => $this->showThreshold ? ( WebVitals::GOOD_THRESHOLDS[ $metric ] ?? null ) : null,
+            ];
+        }
+
+        return [
+            'type'     => $this->chartType,
+            'labels'   => $labels,
+            'datasets' => $datasets,
+            'colors'   => self::DEFAULT_COLORS,
+        ];
+    }
+
+    /**
+     * Returns the inclusive start date for the current range.
+     *
+     * @since 1.0.0
+     */
+    protected function startDate(): Carbon
+    {
+        $days = self::RANGE_DAYS[ $this->dateRange ] ?? self::RANGE_DAYS['7d'];
+
+        return Carbon::today()->subDays( $days - 1 );
+    }
+
+    /**
+     * Returns the inclusive end date for the current range.
+     *
+     * @since 1.0.0
+     */
+    protected function endDate(): Carbon
+    {
+        return Carbon::today();
+    }
+
+    /**
+     * Returns the ordered list of date labels covering the range.
+     *
+     * @since 1.0.0
+     *
+     * @return array<int, string>
+     */
+    protected function dateRangeLabels( Carbon $startDate, Carbon $endDate ): array
+    {
+        $labels = [];
+        $cursor = $startDate->copy();
+
+        while ( $cursor->lessThanOrEqualTo( $endDate ) ) {
+            $labels[] = $cursor->toDateString();
+            $cursor->addDay();
+        }
+
+        return $labels;
+    }
+
+    /**
+     * Normalizes the supplied range key.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $range  Range key.
+     */
+    protected function resolveRange( string $range ): string
+    {
+        return isset( self::RANGE_DAYS[ $range ] ) ? $range : '7d';
+    }
+
+    /**
+     * Normalizes the supplied chart type.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $type  Chart type.
+     */
+    protected function resolveChartType( string $type ): string
+    {
+        $allowed = [ 'line', 'bar', 'area' ];
+
+        return in_array( $type, $allowed, true ) ? $type : 'line';
+    }
+}

--- a/src/Livewire/PerformanceDashboard.php
+++ b/src/Livewire/PerformanceDashboard.php
@@ -1,0 +1,446 @@
+<?php
+
+/**
+ * Performance dashboard Livewire component.
+ *
+ * Top-level surface for the package's admin UI. Composes a date-range
+ * picker, a tab strip, and the per-tab summary data sourced from the
+ * aggregated `performance_metrics` table and the cache statistics
+ * helpers. The component is read-only; mutating cache actions live on
+ * the bundled `CacheManager` component the Cache tab mounts.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Livewire;
+
+use ArtisanPackUI\Performance\Cache\CacheStatistics;
+use ArtisanPackUI\Performance\Models\PerformanceMetric;
+use ArtisanPackUI\Performance\Models\SlowQuery;
+use ArtisanPackUI\Performance\Monitoring\WebVitals;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+
+/**
+ * Performance dashboard component class.
+ *
+ *
+ * @since      1.0.0
+ */
+class PerformanceDashboard extends Component
+{
+    /**
+     * Date ranges the picker offers.
+     *
+     * Expressed as `key => days` so the query side can convert a range
+     * into an `>= today - days` clause without re-parsing the labels.
+     *
+     * @since 1.0.0
+     *
+     * @var array<string, int>
+     */
+    public const RANGE_DAYS = [
+        '24h' => 1,
+        '7d'  => 7,
+        '30d' => 30,
+        '90d' => 90,
+    ];
+
+    /**
+     * Tab keys the dashboard exposes.
+     *
+     * @since 1.0.0
+     *
+     * @var array<int, string>
+     */
+    public const TABS = [
+        'overview',
+        'pages',
+        'images',
+        'cache',
+        'queries',
+        'recommendations',
+    ];
+
+    /**
+     * The currently selected date range key.
+     *
+     * @since 1.0.0
+     */
+    #[Url( as: 'range', history: true )]
+    public string $dateRange = '7d';
+
+    /**
+     * The currently active tab key.
+     *
+     * @since 1.0.0
+     */
+    #[Url( as: 'tab', history: true )]
+    public string $activeTab = 'overview';
+
+    /**
+     * Memoized overview rollup for the current render cycle.
+     *
+     * Lets `buildRecommendations()` reuse the rows `buildOverview()`
+     * already computed without re-issuing the aggregate query — Livewire
+     * components are short-lived (one per server request), so the cache
+     * lives exactly as long as a single render and cannot serve stale
+     * data across user actions.
+     *
+     * @since 1.0.0
+     *
+     * @var array<int, array{metric: string, p75: float|null, sample_count: int, status: string}>|null
+     */
+    protected ?array $overviewCache = null;
+
+    /**
+     * Mounts the component, applying the default range when none is supplied.
+     *
+     * Validation is intentionally loose: an unknown range or tab is
+     * coerced to the default so deep-linked URLs from older builds never
+     * 500. The same coercion happens on every render so an external
+     * URL-manipulation bug cannot park the component in a bad state.
+     *
+     * The `$defaultDateRange` host prop is honored only when the URL
+     * did not already carry a `range` query string — otherwise the
+     * `#[Url]` restoration would be silently overwritten on every
+     * reload, defeating the history binding.
+     *
+     * @since 1.0.0
+     *
+     * @param  Request|null  $request  Bound by Livewire to inspect the URL query.
+     * @param  string|null  $defaultDateRange  Optional override for the initial range.
+     */
+    public function mount( ?Request $request = null, ?string $defaultDateRange = null ): void
+    {
+        $rangeFromUrl = null === $request ? null : $request->query( 'range' );
+        $hasUrlRange  = is_string( $rangeFromUrl ) && '' !== $rangeFromUrl;
+
+        if ( ! $hasUrlRange && null !== $defaultDateRange && '' !== $defaultDateRange ) {
+            $this->dateRange = $defaultDateRange;
+        }
+
+        $this->dateRange = $this->resolveRange( $this->dateRange );
+        $this->activeTab = $this->resolveTab( $this->activeTab );
+    }
+
+    /**
+     * Switches the active tab.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $tab  Tab key.
+     */
+    public function setTab( string $tab ): void
+    {
+        $this->activeTab = $this->resolveTab( $tab );
+    }
+
+    /**
+     * Switches the active date range.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $range  Range key (`24h`, `7d`, `30d`, `90d`).
+     */
+    public function setDateRange( string $range ): void
+    {
+        $this->dateRange = $this->resolveRange( $range );
+    }
+
+    /**
+     * Forces a re-render so subordinate components reload data.
+     *
+     * @since 1.0.0
+     */
+    public function refreshMetrics(): void
+    {
+        $this->dispatch( 'performance-dashboard:refreshed' );
+    }
+
+    /**
+     * Renders the dashboard template.
+     *
+     * Only the active tab's payload is computed — the other tabs
+     * resolve to empty defaults until the user switches to them. On
+     * a real dataset this is roughly a 5x query reduction per render
+     * compared to eager-building every tab. The `overview` payload
+     * is always built when the Recommendations tab is active because
+     * it derives its list from the overview rollup.
+     *
+     * @since 1.0.0
+     */
+    public function render(): View
+    {
+        $overview        = [];
+        $pages           = [];
+        $queries         = [];
+        $cacheSummary    = [ 'page' => [ 'entries' => 0 ], 'fragment' => [ 'entries' => 0, 'tags' => 0 ] ];
+        $recommendations = [];
+
+        if ( 'overview' === $this->activeTab ) {
+            $overview = $this->overview();
+        } elseif ( 'pages' === $this->activeTab ) {
+            $pages = $this->buildPagesBreakdown();
+        } elseif ( 'queries' === $this->activeTab ) {
+            $queries = $this->buildQuerySummary();
+        } elseif ( 'cache' === $this->activeTab ) {
+            $cacheSummary = $this->buildCacheSummary();
+        } elseif ( 'recommendations' === $this->activeTab ) {
+            $recommendations = $this->buildRecommendations();
+        }
+
+        return view( 'performance::livewire.performance-dashboard', [
+            'overview'        => $overview,
+            'pages'           => $pages,
+            'queries'         => $queries,
+            'cacheSummary'    => $cacheSummary,
+            'recommendations' => $recommendations,
+            'ranges'          => array_keys( self::RANGE_DAYS ),
+            'tabs'            => self::TABS,
+        ] );
+    }
+
+    /**
+     * Returns the memoized overview payload, computing it on first call.
+     *
+     * Both the Overview tab and the Recommendations tab need the same
+     * rollup; memoization avoids a second copy of the aggregate query
+     * within a single render cycle.
+     *
+     * @since 1.0.0
+     *
+     * @return array<int, array{metric: string, p75: float|null, sample_count: int, status: string}>
+     */
+    protected function overview(): array
+    {
+        return $this->overviewCache ??= $this->buildOverview();
+    }
+
+    /**
+     * Builds the Overview tab payload — one row per Core Web Vital.
+     *
+     * Each metric's headline number is the sample-weighted mean of its
+     * bucket p75s (`SUM(p75 * sample_count) / SUM(sample_count)`), not a
+     * straight `AVG(p75)`. A straight average over device/connection
+     * buckets weights every bucket equally — a 50-sample desktop p75
+     * pulls the headline as hard as a 50,000-sample mobile p75 — and
+     * the result is a value no actual population experienced. The
+     * weighted form is still a mean of percentiles (re-percentiling
+     * raw samples would be the only fully-correct rollup), but it at
+     * least approximates the population-wide central tendency.
+     *
+     * @since 1.0.0
+     *
+     * @return array<int, array{metric: string, p75: float|null, sample_count: int, status: string}>
+     */
+    protected function buildOverview(): array
+    {
+        $rows = PerformanceMetric::query()
+            ->whereBetween( 'date', [ $this->startDate(), $this->endDate() ] )
+            ->selectRaw( 'metric, SUM(p75 * sample_count) as weighted_p75_sum, SUM(sample_count) as sample_count' )
+            ->groupBy( 'metric' )
+            ->get();
+
+        $out = [];
+
+        foreach ( $rows as $row ) {
+            $metric = (string) $row->metric;
+            $count  = (int) $row->sample_count;
+            $p75    = $count > 0 ? (float) $row->weighted_p75_sum / $count : null;
+
+            $out[] = [
+                'metric'       => $metric,
+                'p75'          => $p75,
+                'sample_count' => $count,
+                'status'       => WebVitals::classify( $metric, $p75 ),
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Builds the Pages tab payload — per-route p75 rollup.
+     *
+     * Mirrors the weighting strategy in `buildOverview()` — each row's
+     * p75 is the sample-weighted mean of the per-bucket p75s for that
+     * (route, metric) pair, so a route with a tiny mobile/4g cohort
+     * doesn't pull a route-level rollup out of alignment with the
+     * dominant cohort. Ordering by the weighted mean keeps the
+     * "worst pages" list ranked by what the typical user actually
+     * sees, not by an unweighted outlier.
+     *
+     * @since 1.0.0
+     *
+     * @return array<int, array{route: string|null, metric: string, p75: float, sample_count: int}>
+     */
+    protected function buildPagesBreakdown(): array
+    {
+        return PerformanceMetric::query()
+            ->whereBetween( 'date', [ $this->startDate(), $this->endDate() ] )
+            ->whereNotNull( 'route' )
+            ->selectRaw( 'route, metric, SUM(p75 * sample_count) / NULLIF(SUM(sample_count), 0) as p75, SUM(sample_count) as sample_count' )
+            ->groupBy( 'route', 'metric' )
+            ->orderByDesc( 'p75' )
+            ->limit( 25 )
+            ->get()
+            ->map( static fn ( $row ): array => [
+                'route'        => $row->route,
+                'metric'       => (string) $row->metric,
+                'p75'          => (float) $row->p75,
+                'sample_count' => (int) $row->sample_count,
+            ] )
+            ->all();
+    }
+
+    /**
+     * Builds the Queries tab payload.
+     *
+     * @since 1.0.0
+     *
+     * @return array<int, array{query: string, time_ms: float, route: string|null}>
+     */
+    protected function buildQuerySummary(): array
+    {
+        if ( ! class_exists( SlowQuery::class ) ) {
+            return [];
+        }
+
+        return SlowQuery::query()
+            ->where( 'created_at', '>=', $this->startDate()->startOfDay() )
+            ->orderByDesc( 'time_ms' )
+            ->limit( 25 )
+            ->get( [ 'query_normalized', 'time_ms', 'route' ] )
+            ->map( static fn ( SlowQuery $row ): array => [
+                'query'   => $row->query_normalized,
+                'time_ms' => (float) $row->time_ms,
+                'route'   => $row->route,
+            ] )
+            ->all();
+    }
+
+    /**
+     * Builds the Cache tab summary (counts only — actions live on CacheManager).
+     *
+     * @since 1.0.0
+     *
+     * @return array{page: array<string, mixed>, fragment: array<string, mixed>}
+     */
+    protected function buildCacheSummary(): array
+    {
+        $statistics = app( CacheStatistics::class );
+
+        return [
+            'page'     => $statistics->pageSummary(),
+            'fragment' => $statistics->fragmentSummary(),
+        ];
+    }
+
+    /**
+     * Builds the Recommendations tab payload.
+     *
+     * The list is derived from the same data shown in the Overview tab —
+     * any metric whose rolling p75 lands outside the "good" band becomes
+     * an actionable item with a brief remediation hint. This keeps the
+     * recommendations grounded in real data instead of a static list.
+     *
+     * @since 1.0.0
+     *
+     * @return array<int, array{title: string, severity: string, body: string}>
+     */
+    protected function buildRecommendations(): array
+    {
+        $items = [];
+
+        foreach ( $this->overview() as $row ) {
+            if ( 'poor' !== $row['status'] && 'needs-improvement' !== $row['status'] ) {
+                continue;
+            }
+
+            $items[] = [
+                'title'    => 'poor' === $row['status']
+                    ? (string) __( ':metric is poor', [ 'metric' => $row['metric'] ] )
+                    : (string) __( ':metric needs improvement', [ 'metric' => $row['metric'] ] ),
+                'severity' => 'poor' === $row['status'] ? 'high' : 'medium',
+                'body'     => $this->remediationFor( $row['metric'] ),
+            ];
+        }
+
+        return $items;
+    }
+
+    /**
+     * Returns a short remediation hint for the given metric.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $metric  Metric name.
+     */
+    protected function remediationFor( string $metric ): string
+    {
+        return match ( $metric ) {
+            'LCP'   => (string) __( 'Optimize the largest element above the fold: preload its image, prioritize its CSS, and serve modern formats.' ),
+            'INP'   => (string) __( 'Reduce long tasks on the main thread and split heavy JavaScript into deferred or async chunks.' ),
+            'CLS'   => (string) __( 'Reserve space for images, ads, and embeds; avoid inserting content above existing content after load.' ),
+            'FID'   => (string) __( 'Defer non-critical JavaScript and split long tasks so the main thread stays responsive to early input.' ),
+            'TTFB'  => (string) __( 'Enable page caching, tune database queries, and ensure the origin responds quickly to first byte requests.' ),
+            'FCP'   => (string) __( 'Inline critical CSS, preconnect to required origins, and reduce blocking resources in the document head.' ),
+            default => (string) __( 'Review the metric definition and audit relevant page resources.' ),
+        };
+    }
+
+    /**
+     * Returns the inclusive start date for the current range.
+     *
+     * @since 1.0.0
+     */
+    protected function startDate(): Carbon
+    {
+        $days = self::RANGE_DAYS[ $this->dateRange ] ?? self::RANGE_DAYS['7d'];
+
+        return Carbon::today()->subDays( $days - 1 );
+    }
+
+    /**
+     * Returns the inclusive end date for the current range.
+     *
+     * @since 1.0.0
+     */
+    protected function endDate(): Carbon
+    {
+        return Carbon::today();
+    }
+
+    /**
+     * Normalizes the supplied range key.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $range  Candidate range key.
+     */
+    protected function resolveRange( string $range ): string
+    {
+        return isset( self::RANGE_DAYS[ $range ] ) ? $range : '7d';
+    }
+
+    /**
+     * Normalizes the supplied tab key.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $tab  Candidate tab key.
+     */
+    protected function resolveTab( string $tab ): string
+    {
+        return in_array( $tab, self::TABS, true ) ? $tab : 'overview';
+    }
+}

--- a/src/Models/PerformanceMetric.php
+++ b/src/Models/PerformanceMetric.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Aggregated performance metric Eloquent model.
+ *
+ * Wraps the `performance_metrics` table that holds per-day, per-route,
+ * per-device, per-connection percentile aggregates produced by the
+ * `MetricsAggregator`. Each row represents a single metric (LCP, FID,
+ * CLS, INP, TTFB) summarized across the matching raw samples.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Performance metric model class.
+ *
+ *
+ * @since      1.0.0
+ *
+ * @property int $id
+ * @property \Illuminate\Support\Carbon $date
+ * @property string|null $route
+ * @property string|null $url
+ * @property string $metric
+ * @property float $p50
+ * @property float $p75
+ * @property float $p90
+ * @property float $p99
+ * @property int $sample_count
+ * @property string|null $device_type
+ * @property string|null $connection_type
+ * @property \Illuminate\Support\Carbon $created_at
+ * @property \Illuminate\Support\Carbon $updated_at
+ */
+class PerformanceMetric extends Model
+{
+    /**
+     * The database table backing the model.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    protected $table = 'performance_metrics';
+
+    /**
+     * The attributes that are mass-assignable.
+     *
+     * The aggregator and the API both need to write every column; gating
+     * the columns individually would force callers into `forceFill()` and
+     * obscure the intent of straightforward upserts.
+     *
+     * @since 1.0.0
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'date',
+        'route',
+        'url',
+        'metric',
+        'p50',
+        'p75',
+        'p90',
+        'p99',
+        'sample_count',
+        'device_type',
+        'connection_type',
+    ];
+
+    /**
+     * Returns the attribute casts.
+     *
+     * @since 1.0.0
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'date'         => 'date',
+            'p50'          => 'float',
+            'p75'          => 'float',
+            'p90'          => 'float',
+            'p99'          => 'float',
+            'sample_count' => 'integer',
+        ];
+    }
+}

--- a/src/Models/RawMetric.php
+++ b/src/Models/RawMetric.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Raw performance metric Eloquent model.
+ *
+ * Wraps the `performance_raw_metrics` table that captures Core Web
+ * Vitals samples as they arrive from the browser. Each row is a single
+ * measurement (`name`, `value`, `delta`) tagged with enough context for
+ * the aggregator to bucket samples by route, device, and connection.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Raw metric model class.
+ *
+ *
+ * @since      1.0.0
+ *
+ * @property int $id
+ * @property string $name
+ * @property float $value
+ * @property float|null $delta
+ * @property string|null $rating
+ * @property string|null $vital_id
+ * @property string|null $url
+ * @property string|null $route
+ * @property string|null $device_type
+ * @property string|null $connection_type
+ * @property string|null $user_agent
+ * @property array<string, mixed>|null $extra
+ * @property \Illuminate\Support\Carbon $recorded_at
+ * @property \Illuminate\Support\Carbon $created_at
+ * @property \Illuminate\Support\Carbon $updated_at
+ */
+class RawMetric extends Model
+{
+    /**
+     * The database table backing the model.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    protected $table = 'performance_raw_metrics';
+
+    /**
+     * The attributes that are mass-assignable.
+     *
+     * @since 1.0.0
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+        'value',
+        'delta',
+        'rating',
+        'vital_id',
+        'url',
+        'route',
+        'device_type',
+        'connection_type',
+        'user_agent',
+        'extra',
+        'recorded_at',
+    ];
+
+    /**
+     * Returns the attribute casts.
+     *
+     * @since 1.0.0
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'value'       => 'float',
+            'delta'       => 'float',
+            'extra'       => 'array',
+            'recorded_at' => 'datetime',
+        ];
+    }
+}

--- a/src/Monitoring/MetricsAggregator.php
+++ b/src/Monitoring/MetricsAggregator.php
@@ -1,0 +1,319 @@
+<?php
+
+/**
+ * Metrics aggregator.
+ *
+ * Folds raw `performance_raw_metrics` rows into the per-day percentile
+ * summaries that back the dashboard. Aggregation groups by date, route,
+ * metric name, device type, and connection type so callers can slice
+ * the dashboard by every dimension they receive from the browser.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Monitoring;
+
+use ArtisanPackUI\Performance\Models\PerformanceMetric;
+use ArtisanPackUI\Performance\Models\RawMetric;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Metrics aggregator class.
+ *
+ *
+ * @since      1.0.0
+ */
+class MetricsAggregator
+{
+    /**
+     * Percentiles the aggregator computes for each bucket.
+     *
+     * @since 1.0.0
+     *
+     * @var array<int, int>
+     */
+    public const PERCENTILES = [ 50, 75, 90, 99 ];
+
+    /**
+     * Number of raw samples loaded per chunk during aggregation.
+     *
+     * Sized to keep the bucketing pass under ~5MB of resident memory
+     * for typical samples (~1KB hydrated rows) while still amortizing
+     * query round-trip cost across a meaningful batch.
+     *
+     * @since 1.0.0
+     *
+     * @var int
+     */
+    public const CHUNK_SIZE = 5000;
+
+    /**
+     * Aggregates the raw samples for the given calendar date.
+     *
+     * Returns the number of `performance_metrics` rows written or
+     * updated. The implementation reads every raw sample for the date,
+     * buckets them by `(route, metric, device, connection)`, computes
+     * the configured percentiles, and upserts a single row per bucket.
+     * Existing rows for the same bucket are overwritten so the
+     * aggregator is idempotent — re-running for the same date produces
+     * the same totals regardless of how many times it has run before.
+     *
+     * @since 1.0.0
+     *
+     * @param  Carbon|string|null  $date  Calendar date (defaults to today).
+     */
+    public function aggregate( Carbon|string|null $date = null ): int
+    {
+        $target = $this->resolveDate( $date );
+
+        // Iterate the raw samples in chunks (via the primary key, which
+        // is the most reliable cursor under concurrent inserts) so the
+        // aggregator's memory footprint stays flat regardless of daily
+        // sample volume. A naive `->get()` would hydrate every model
+        // for the day at once and OOM at production RUM scale.
+        $buckets = [];
+        $hasAny  = false;
+
+        RawMetric::query()
+            ->whereBetween( 'recorded_at', [
+                $target->copy()->startOfDay(),
+                $target->copy()->endOfDay(),
+            ] )
+            ->select( [ 'id', 'name', 'value', 'route', 'device_type', 'connection_type' ] )
+            ->orderBy( 'id' )
+            ->chunkById( self::CHUNK_SIZE, function ( $chunk ) use ( &$buckets, &$hasAny ): void {
+                foreach ( $chunk as $sample ) {
+                    $hasAny = true;
+                    $key    = $this->packBucket(
+                        $sample->route,
+                        $sample->name,
+                        $sample->device_type,
+                        $sample->connection_type,
+                    );
+
+                    $buckets[ $key ][] = (float) $sample->value;
+                }
+            } );
+
+        if ( ! $hasAny ) {
+            return 0;
+        }
+
+        $written = 0;
+
+        foreach ( $buckets as $bucket => $values ) {
+            [ $route, $metric, $device, $connection ] = $this->unpackBucket( $bucket );
+
+            $percentiles = $this->computePercentiles( $values );
+
+            $values_payload = [
+                'p50'          => $percentiles[50],
+                'p75'          => $percentiles[75],
+                'p90'          => $percentiles[90],
+                'p99'          => $percentiles[99],
+                'sample_count' => count( $values ),
+            ];
+
+            $this->upsertBucket( $target->toDateString(), $route, $metric, $device, $connection, $values_payload );
+
+            $written++;
+        }
+
+        return $written;
+    }
+
+    /**
+     * Computes the configured percentiles for the given sample list.
+     *
+     * Uses the "nearest-rank" method (NIST handbook §6.16.2): given a
+     * sorted list of `N` samples and a percentile `p` in `[0, 100]`, the
+     * value at zero-indexed position `ceil(p * N / 100) - 1` (clamped
+     * to `[0, N-1]`) is returned. The method is exact for the percentile
+     * boundary samples and stable under ties — the chief alternative
+     * (linear interpolation) would invent values that did not actually
+     * occur, which is undesirable for a metric like LCP that's already
+     * coarse-grained.
+     *
+     * @since 1.0.0
+     *
+     * @param  array<int, float>  $values  Sample values for a single bucket.
+     *
+     * @return array<int, float>
+     */
+    public function computePercentiles( array $values ): array
+    {
+        $sorted = $values;
+        sort( $sorted, SORT_NUMERIC );
+        $count = count( $sorted );
+
+        if ( 0 === $count ) {
+            return array_fill_keys( self::PERCENTILES, 0.0 );
+        }
+
+        $out = [];
+
+        foreach ( self::PERCENTILES as $percentile ) {
+            $rank = (int) ceil( ( $percentile / 100 ) * $count ) - 1;
+
+            if ( $rank < 0 ) {
+                $rank = 0;
+            }
+
+            if ( $rank >= $count ) {
+                $rank = $count - 1;
+            }
+
+            $out[ $percentile ] = (float) $sorted[ $rank ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Upserts a single bucket, handling NULL key columns explicitly.
+     *
+     * Eloquent's `updateOrCreate` passes the key columns through
+     * `where($key, '=', $value)`, which produces `WHERE column = NULL`
+     * for nullable key values — never matching. That bug would cause
+     * the aggregator to insert a fresh row on every re-run (breaking
+     * idempotency), so the lookup is performed manually here with the
+     * `whereNull()` branch where required.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $date  Calendar date string.
+     * @param  string|null  $route  Route name.
+     * @param  string  $metric  Metric name.
+     * @param  string|null  $device  Device type.
+     * @param  string|null  $connection  Connection type.
+     * @param  array<string, mixed>  $values  Values to write.
+     */
+    protected function upsertBucket(
+        string $date,
+        ?string $route,
+        string $metric,
+        ?string $device,
+        ?string $connection,
+        array $values,
+    ): void {
+        // The SELECT-then-INSERT/UPDATE path needs to be atomic per
+        // logical bucket: two aggregator runs hitting the same bucket
+        // would both see no row, both insert, and produce duplicates
+        // that poison the dashboard's AVG/SUM rollups. Wrapping in a
+        // transaction with `lockForUpdate()` serializes concurrent
+        // upserts on the row's index range under MySQL/Postgres; on
+        // stores without row locks (SQLite) the transaction at least
+        // makes the pair atomic from each writer's perspective.
+        //
+        // The `date` column is cast as a Carbon date by the model, so
+        // the value stored by SQLite includes the `00:00:00` time
+        // component. `whereDate()` normalizes both sides of the
+        // comparison to the date portion so the lookup matches the
+        // row this aggregator wrote on a prior pass — keeping the
+        // operation idempotent.
+        DB::transaction( function () use ( $date, $route, $metric, $device, $connection, $values ): void {
+            $query = PerformanceMetric::query()
+                ->whereDate( 'date', $date )
+                ->where( 'metric', $metric );
+
+            $query = null === $route ? $query->whereNull( 'route' ) : $query->where( 'route', $route );
+            $query = null === $device ? $query->whereNull( 'device_type' ) : $query->where( 'device_type', $device );
+            $query = null === $connection ? $query->whereNull( 'connection_type' ) : $query->where( 'connection_type', $connection );
+
+            $existing = $query->lockForUpdate()->first();
+
+            if ( null !== $existing ) {
+                $existing->fill( $values )->save();
+
+                return;
+            }
+
+            PerformanceMetric::create( array_merge( $values, [
+                'date'            => $date,
+                'route'           => $route,
+                'metric'          => $metric,
+                'device_type'     => $device,
+                'connection_type' => $connection,
+            ] ) );
+        } );
+    }
+
+    /**
+     * Packs the bucket dimensions into a separator-delimited string.
+     *
+     * The chosen separator (`"\x1F"`, the ASCII Unit Separator) is
+     * rejected at the API ingest boundary by
+     * `MetricsApiController::store()`'s `$noControlChars` validation
+     * rule, so the four-component round trip stays unambiguous
+     * without escaping. The rejection — not the choice of separator
+     * alone — is what guarantees correctness here; relaxing the
+     * controller's validation would re-open the bucket-poisoning
+     * vector.
+     *
+     * @since 1.0.0
+     *
+     * @param  string|null  $route  Route name (nullable when the client did not resolve one).
+     * @param  string  $metric  Metric name.
+     * @param  string|null  $device  Device type.
+     * @param  string|null  $connection  Connection type.
+     */
+    protected function packBucket( ?string $route, string $metric, ?string $device, ?string $connection ): string
+    {
+        return implode( "\x1F", [
+            $route ?? '',
+            $metric,
+            $device ?? '',
+            $connection ?? '',
+        ] );
+    }
+
+    /**
+     * Reverses `packBucket()` into a 4-tuple of dimensions.
+     *
+     * Empty components are restored to `null` so the upsert key matches
+     * the original column types (which are nullable).
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $bucket  Packed bucket string.
+     *
+     * @return array{0: string|null, 1: string, 2: string|null, 3: string|null}
+     */
+    protected function unpackBucket( string $bucket ): array
+    {
+        $parts = explode( "\x1F", $bucket, 4 );
+
+        return [
+            '' === $parts[0] ? null : $parts[0],
+            $parts[1] ?? '',
+            '' === ( $parts[2] ?? '' ) ? null : $parts[2],
+            '' === ( $parts[3] ?? '' ) ? null : $parts[3],
+        ];
+    }
+
+    /**
+     * Normalizes the date argument to a Carbon instance at the day boundary.
+     *
+     * @since 1.0.0
+     *
+     * @param  Carbon|string|null  $date  The date argument.
+     */
+    protected function resolveDate( Carbon|string|null $date ): Carbon
+    {
+        if ( $date instanceof Carbon ) {
+            return $date->copy()->startOfDay();
+        }
+
+        if ( is_string( $date ) && '' !== $date ) {
+            return Carbon::parse( $date )->startOfDay();
+        }
+
+        return Carbon::today();
+    }
+}

--- a/src/Monitoring/WebVitals.php
+++ b/src/Monitoring/WebVitals.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Web Vitals threshold constants.
+ *
+ * Single source of truth for the "good" / "poor" boundary values used
+ * by the dashboard's pass/fail badges, the chart's reference lines,
+ * and any future recommendation engine. Aligned with web.dev's Core
+ * Web Vitals guidance — each metric has metric-specific good and
+ * poor thresholds (the ratios are not uniform, e.g. LCP is 1.6x
+ * while CLS is 2.5x and FID is 3x).
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Monitoring;
+
+/**
+ * Web Vitals threshold helper.
+ *
+ *
+ * @since      1.0.0
+ */
+final class WebVitals
+{
+    /**
+     * "Good" thresholds per Core Web Vital.
+     *
+     * Values from web.dev/vitals (LCP ≤2500ms, INP ≤200ms, CLS ≤0.10,
+     * FID ≤100ms, TTFB ≤800ms, FCP ≤1800ms). Any sample at or under
+     * the threshold qualifies as "good".
+     *
+     * @since 1.0.0
+     *
+     * @var array<string, float>
+     */
+    public const GOOD_THRESHOLDS = [
+        'LCP'  => 2500.0,
+        'INP'  => 200.0,
+        'CLS'  => 0.10,
+        'FID'  => 100.0,
+        'TTFB' => 800.0,
+        'FCP'  => 1800.0,
+    ];
+
+    /**
+     * "Poor" thresholds per Core Web Vital.
+     *
+     * Values from web.dev/vitals (LCP >4000ms, INP >500ms, CLS >0.25,
+     * FID >300ms, TTFB >1800ms, FCP >3000ms). Anything strictly above
+     * the threshold is "poor"; between the good and poor values is
+     * "needs improvement".
+     *
+     * The ratios are NOT uniform — LCP is 1.6x, FCP is 1.67x, TTFB is
+     * 2.25x, CLS is 2.5x, INP is 2.5x, FID is 3x — so a single
+     * multiplier (e.g. 2x) misclassifies several metrics near the
+     * boundary.
+     *
+     * @since 1.0.0
+     *
+     * @var array<string, float>
+     */
+    public const POOR_THRESHOLDS = [
+        'LCP'  => 4000.0,
+        'INP'  => 500.0,
+        'CLS'  => 0.25,
+        'FID'  => 300.0,
+        'TTFB' => 1800.0,
+        'FCP'  => 3000.0,
+    ];
+
+    /**
+     * Disallow instantiation; the class is a pure constant container.
+     *
+     * @since 1.0.0
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Classifies a metric value against the good/poor thresholds.
+     *
+     * Returns "good" when the value is at or below the good threshold,
+     * "poor" when strictly above the poor threshold, and
+     * "needs-improvement" in between. Returns "unknown" when the
+     * value is null or the metric is not in the thresholds table.
+     *
+     * @since 1.0.0
+     *
+     * @param  string  $metric  Metric name (e.g. `LCP`).
+     * @param  float|null  $value  Metric value (typically a p75 rollup).
+     */
+    public static function classify( string $metric, ?float $value ): string
+    {
+        if ( null === $value ) {
+            return 'unknown';
+        }
+
+        if ( ! isset( self::GOOD_THRESHOLDS[ $metric ], self::POOR_THRESHOLDS[ $metric ] ) ) {
+            return 'unknown';
+        }
+
+        if ( $value <= self::GOOD_THRESHOLDS[ $metric ] ) {
+            return 'good';
+        }
+
+        if ( $value > self::POOR_THRESHOLDS[ $metric ] ) {
+            return 'poor';
+        }
+
+        return 'needs-improvement';
+    }
+}

--- a/src/PerformanceServiceProvider.php
+++ b/src/PerformanceServiceProvider.php
@@ -19,9 +19,11 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\Performance;
 
 use ArtisanPackUI\Performance\Cache\CacheInvalidator;
+use ArtisanPackUI\Performance\Cache\CacheStatistics;
 use ArtisanPackUI\Performance\Cache\CacheStrategyManager;
 use ArtisanPackUI\Performance\Cache\FragmentCache;
 use ArtisanPackUI\Performance\Cache\PageCacheManager;
+use ArtisanPackUI\Performance\Console\Commands\AggregateMetricsCommand;
 use ArtisanPackUI\Performance\Console\Commands\GenerateCriticalCssCommand;
 use ArtisanPackUI\Performance\Console\Commands\GenerateWebPCommand;
 use ArtisanPackUI\Performance\Console\Commands\PurgeCacheCommand;
@@ -37,6 +39,10 @@ use ArtisanPackUI\Performance\Http\Middleware\MinifyHtml;
 use ArtisanPackUI\Performance\Images\DominantColorExtractor;
 use ArtisanPackUI\Performance\Images\ResponsiveImageGenerator;
 use ArtisanPackUI\Performance\JavaScript\ScriptManager;
+use ArtisanPackUI\Performance\Livewire\CacheManager as CacheManagerComponent;
+use ArtisanPackUI\Performance\Livewire\MetricsChart as MetricsChartComponent;
+use ArtisanPackUI\Performance\Livewire\PerformanceDashboard as PerformanceDashboardComponent;
+use ArtisanPackUI\Performance\Monitoring\MetricsAggregator;
 use ArtisanPackUI\Performance\Output\HtmlMinifier;
 use ArtisanPackUI\Performance\Output\OutputBuffer;
 use ArtisanPackUI\Performance\Output\ResourceHintInjector;
@@ -47,6 +53,7 @@ use ArtisanPackUI\Performance\Services\PerformanceService;
 use ArtisanPackUI\Performance\Speculative\PrefetchManager;
 use ArtisanPackUI\Performance\Speculative\PrerenderManager;
 use ArtisanPackUI\Performance\Speculative\SpeculativeRulesGenerator;
+use ArtisanPackUI\Performance\Support\MetricsChartDirectives;
 use ArtisanPackUI\Performance\Support\MonitorDirectives;
 use ArtisanPackUI\Performance\Support\ResourceHintDirectives;
 use ArtisanPackUI\Performance\Support\ScriptDirectives;
@@ -61,6 +68,7 @@ use ArtisanPackUI\Performance\View\Components\ResourceHints;
 use ArtisanPackUI\Performance\View\Components\ResponsiveImage;
 use ArtisanPackUI\Performance\View\Components\SpeculativeRules;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -153,6 +161,14 @@ class PerformanceServiceProvider extends ServiceProvider
             return new CacheStrategyManager;
         } );
 
+        $this->app->singleton( CacheStatistics::class, function () {
+            return new CacheStatistics;
+        } );
+
+        $this->app->singleton( MetricsAggregator::class, function () {
+            return new MetricsAggregator;
+        } );
+
         $this->app->singleton( QueryAnalyzer::class, function () {
             return new QueryAnalyzer;
         } );
@@ -219,11 +235,13 @@ class PerformanceServiceProvider extends ServiceProvider
         $this->loadViewsFrom( __DIR__ . '/../resources/views', 'performance' );
         $this->loadBladeComponents();
         $this->registerBladeDirectives();
+        $this->registerLivewireComponents();
         $this->registerMiddlewareAliases();
         $this->registerCriticalCssSources();
         $this->registerEventListeners();
         $this->registerOctaneResetHooks();
         $this->registerCommands();
+        $this->registerRoutes();
         $this->publishConfiguration();
     }
 
@@ -321,8 +339,60 @@ class PerformanceServiceProvider extends ServiceProvider
                 WarmCacheCommand::class,
                 PurgeCacheCommand::class,
                 SuggestIndexesCommand::class,
+                AggregateMetricsCommand::class,
             ] );
         }
+    }
+
+    /**
+     * Registers the package's Livewire components.
+     *
+     * The components are registered under the `perf-` prefix so they don't
+     * clash with application Livewire components named `dashboard` or
+     * `cache-manager`. Registration is a no-op when Livewire is not
+     * installed — applications using the package without the dashboard
+     * still load the rest of the surface normally.
+     *
+     * @since 1.0.0
+     */
+    protected function registerLivewireComponents(): void
+    {
+        if ( ! class_exists( '\Livewire\Livewire' ) ) {
+            return;
+        }
+
+        \Livewire\Livewire::component( 'perf-performance-dashboard', PerformanceDashboardComponent::class );
+        \Livewire\Livewire::component( 'perf-metrics-chart', MetricsChartComponent::class );
+        \Livewire\Livewire::component( 'perf-cache-manager', CacheManagerComponent::class );
+    }
+
+    /**
+     * Registers the package's HTTP routes.
+     *
+     * The API surface is gated by `routes.enabled` so applications that
+     * only consume the optimization helpers can disable the dashboard
+     * endpoints entirely. The configured `api_prefix` is normalized to a
+     * single leading segment so callers can supply either `api/perf` or
+     * `/api/perf` without producing a double-slashed URI.
+     *
+     * @since 1.0.0
+     */
+    protected function registerRoutes(): void
+    {
+        if ( false === (bool) config( 'artisanpack.performance.routes.enabled', true ) ) {
+            return;
+        }
+
+        $prefix     = trim( (string) config( 'artisanpack.performance.routes.api_prefix', 'api/performance' ), '/' );
+        $middleware = (array) config( 'artisanpack.performance.routes.api_middleware', [ 'api' ] );
+        $throttle   = (string) config( 'artisanpack.performance.routes.api_throttle', '60,1' );
+
+        $middleware[] = 'throttle:' . $throttle;
+
+        Route::middleware( $middleware )
+            ->prefix( $prefix )
+            ->name( 'artisanpack.performance.api.' )
+            ->group( __DIR__ . '/../routes/api.php' );
     }
 
     /**
@@ -504,6 +574,28 @@ class PerformanceServiceProvider extends ServiceProvider
             return sprintf(
                 '<?php echo \\%s::perfMonitor(%s); ?>',
                 $monitorHelper,
+                $argument,
+            );
+        } );
+
+        // Metrics chart assets directive. Emits the Chart.js loader plus
+        // the package's small bootstrap module that binds Chart.js to the
+        // `[data-metrics-chart]` containers rendered by the MetricsChart
+        // Livewire component. Optional argument forwards overrides
+        // (e.g. `@perfMetricsChartAssets(['libraryUrl' => ''])` when the
+        // host page already loads Chart.js).
+        $metricsChartHelper = MetricsChartDirectives::class;
+
+        Blade::directive( 'perfMetricsChartAssets', static function ( string $expression ) use ( $metricsChartHelper ): string {
+            $argument = trim( $expression );
+
+            if ( '' === $argument ) {
+                return sprintf( '<?php echo \\%s::perfMetricsChartAssets(); ?>', $metricsChartHelper );
+            }
+
+            return sprintf(
+                '<?php echo \\%s::perfMetricsChartAssets(%s); ?>',
+                $metricsChartHelper,
                 $argument,
             );
         } );

--- a/src/Support/MetricsChartDirectives.php
+++ b/src/Support/MetricsChartDirectives.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * Metrics chart directive rendering helpers.
+ *
+ * Backs the `@perfMetricsChartAssets` Blade directive that emits the
+ * Chart.js loader plus the package's small bootstrap module which
+ * binds Chart.js to the `[data-metrics-chart]` containers rendered
+ * by the `MetricsChart` Livewire component.
+ *
+ * Chart.js itself is loaded from a CDN by default so applications
+ * that don't bundle it locally still get working charts; the URL is
+ * overridable through `monitoring.chart_library_url` for sites that
+ * self-host the library (CSP, air-gapped builds, etc.) or set it to
+ * an empty string to skip the loader entirely when Chart.js is
+ * already on the page.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Support;
+
+/**
+ * Metrics chart directive helper.
+ *
+ *
+ * @since      1.0.0
+ */
+final class MetricsChartDirectives
+{
+    /**
+     * Default published asset path for the chart bootstrap module.
+     *
+     * Mirrors the `resources/js` publish target in
+     * `PerformanceServiceProvider::publishConfiguration()` so the
+     * directive's default script `src` resolves out of the box
+     * for any app that ran the `artisanpack-performance-js` publish.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    public const DEFAULT_SCRIPT_PATH = '/vendor/artisanpack-performance/metrics-chart.js';
+
+    /**
+     * Default CDN URL for the Chart.js library.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    public const DEFAULT_CHART_LIBRARY_URL = 'https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js';
+
+    /**
+     * Disallow instantiation; the class is a pure static helper.
+     *
+     * @since 1.0.0
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Renders the `@perfMetricsChartAssets` directive output.
+     *
+     * Emits the Chart.js loader tag followed by the package's
+     * bootstrap module. Callers can suppress either piece via
+     * overrides — pass `libraryUrl: ''` when the host page already
+     * loads Chart.js, or `src: ''` to skip the bootstrap when
+     * embedding it through Vite/webpack instead.
+     *
+     * @since 1.0.0
+     *
+     * @param  array<string, mixed>  $overrides  Per-call configuration overrides.
+     */
+    public static function perfMetricsChartAssets( array $overrides = [] ): string
+    {
+        $output = '';
+
+        $libraryUrl = $overrides['libraryUrl']
+            ?? config( 'artisanpack.performance.monitoring.chart_library_url', self::DEFAULT_CHART_LIBRARY_URL );
+
+        if ( is_string( $libraryUrl ) && '' !== $libraryUrl ) {
+            $output .= sprintf(
+                '<script src="%s"></script>',
+                htmlspecialchars( $libraryUrl, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' ),
+            );
+        }
+
+        $src = $overrides['src'] ?? self::DEFAULT_SCRIPT_PATH;
+
+        if ( is_string( $src ) && '' !== $src ) {
+            $output .= sprintf(
+                '<script src="%s"></script>',
+                htmlspecialchars( $src, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' ),
+            );
+        }
+
+        return $output;
+    }
+}

--- a/tests/Feature/Cache/CacheStatisticsTest.php
+++ b/tests/Feature/Cache/CacheStatisticsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Cache\CacheStatistics;
+use ArtisanPackUI\Performance\Cache\FragmentCache;
+use ArtisanPackUI\Performance\Cache\PageCacheManager;
+use Illuminate\Support\Facades\Cache;
+
+beforeEach( function (): void {
+    config( [ 'cache.default' => 'array' ] );
+    config( [
+        'artisanpack.performance.page_cache' => [
+            'enabled'         => true,
+            'driver'          => 'array',
+            'ttl'             => 3600,
+            'exclude_routes'  => [],
+            'exclude_when'    => [],
+            'vary_by'         => [],
+        ],
+        'artisanpack.performance.fragment_cache' => [
+            'enabled'     => true,
+            'driver'      => 'array',
+            'default_ttl' => 3600,
+        ],
+    ] );
+
+    Cache::store( 'array' )->flush();
+} );
+
+it( 'returns zero counts when nothing has been cached yet', function (): void {
+    $stats = app( CacheStatistics::class );
+
+    expect( $stats->pageSummary() )->toMatchArray( [
+        'entries'    => 0,
+        'size_bytes' => null,
+        'hit_rate'   => null,
+    ] );
+
+    expect( $stats->fragmentSummary() )->toMatchArray( [
+        'entries'    => 0,
+        'tags'       => 0,
+        'size_bytes' => null,
+        'hit_rate'   => null,
+    ] );
+} );
+
+it( 'counts entries from the page cache pattern index', function (): void {
+    Cache::store( 'array' )->put( PageCacheManager::INDEX_KEY, [
+        'perf:page:home'  => 'home',
+        'perf:page:about' => 'about',
+    ], 600 );
+
+    $stats = app( CacheStatistics::class );
+
+    expect( $stats->pageSummary()['entries'] )->toBe( 2 );
+
+    $entries = $stats->pageEntries();
+
+    expect( $entries )->toHaveCount( 2 )
+        ->and( $entries[0] )->toMatchArray( [
+            'key'  => 'perf:page:home',
+            'path' => 'home',
+        ] );
+} );
+
+it( 'counts distinct fragment keys across tags', function (): void {
+    $fragments = app( FragmentCache::class );
+
+    $fragments->put( 'sidebar', 'rendered-sidebar', 60, [ 'home', 'shared' ] );
+    $fragments->put( 'footer', 'rendered-footer', 60, [ 'shared' ] );
+
+    $stats = app( CacheStatistics::class );
+
+    expect( $stats->fragmentSummary()['entries'] )->toBe( 2 )
+        ->and( $stats->fragmentSummary()['tags'] )->toBe( 2 );
+
+    $tags = collect( $stats->fragmentTags() )->keyBy( 'tag' );
+
+    expect( $tags->get( 'home' )['entry_count'] )->toBe( 1 )
+        ->and( $tags->get( 'shared' )['entry_count'] )->toBe( 2 );
+} );
+
+it( 'limits the number of page entries returned', function (): void {
+    $index = [];
+
+    for ( $i = 0; $i < 75; $i++ ) {
+        $index[ "perf:page:item-{$i}" ] = "items/{$i}";
+    }
+
+    Cache::store( 'array' )->put( PageCacheManager::INDEX_KEY, $index, 600 );
+
+    $stats = app( CacheStatistics::class );
+
+    expect( $stats->pageEntries( 10 ) )->toHaveCount( 10 );
+} );

--- a/tests/Feature/Http/MetricsApiControllerTest.php
+++ b/tests/Feature/Http/MetricsApiControllerTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Models\RawMetric;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    config( [
+        'artisanpack.performance.monitoring.enabled'           => true,
+        'artisanpack.performance.monitoring.store_raw_metrics' => true,
+        'artisanpack.performance.monitoring.sample_rate'       => 100,
+        'artisanpack.performance.routes.enabled'               => true,
+        'artisanpack.performance.routes.api_prefix'            => 'api/performance',
+        'artisanpack.performance.routes.api_middleware'        => [],
+        'artisanpack.performance.routes.api_throttle'          => '1000,1',
+    ] );
+} );
+
+it( 'accepts a valid Web Vitals payload and stores it', function (): void {
+    $response = $this->postJson( '/api/performance/metrics', [
+        'name'       => 'LCP',
+        'value'      => 2100,
+        'delta'      => 2100,
+        'id'         => 'v3-1234567890',
+        'page'       => '/products',
+        'connection' => '4g',
+    ] );
+
+    $response->assertSuccessful()
+        ->assertJson( [ 'success' => true ] );
+
+    expect( RawMetric::query()->count() )->toBe( 1 );
+
+    $metric = RawMetric::query()->first();
+
+    expect( $metric->name )->toBe( 'LCP' )
+        ->and( $metric->value )->toBe( 2100.0 )
+        ->and( $metric->vital_id )->toBe( 'v3-1234567890' )
+        ->and( $metric->url )->toBe( '/products' )
+        ->and( $metric->connection_type )->toBe( '4g' );
+} );
+
+it( 'rejects unknown metric names with 422', function (): void {
+    $response = $this->postJson( '/api/performance/metrics', [
+        'name'  => 'BogusMetric',
+        'value' => 100,
+    ] );
+
+    $response->assertStatus( 422 )
+        ->assertJson( [
+            'success' => false,
+            'reason'  => 'unknown-metric',
+        ] );
+
+    expect( RawMetric::query()->count() )->toBe( 0 );
+} );
+
+it( 'returns 422 when validation fails', function (): void {
+    $response = $this->postJson( '/api/performance/metrics', [
+        'value' => 100,
+    ] );
+
+    $response->assertStatus( 422 );
+    expect( RawMetric::query()->count() )->toBe( 0 );
+} );
+
+it( 'returns 403 when monitoring is disabled', function (): void {
+    config( [ 'artisanpack.performance.monitoring.enabled' => false ] );
+
+    $response = $this->postJson( '/api/performance/metrics', [
+        'name'  => 'LCP',
+        'value' => 1000,
+    ] );
+
+    $response->assertStatus( 403 )
+        ->assertJson( [ 'success' => false ] );
+} );
+
+it( 'does not persist a sample when store_raw_metrics is off', function (): void {
+    config( [ 'artisanpack.performance.monitoring.store_raw_metrics' => false ] );
+
+    $response = $this->postJson( '/api/performance/metrics', [
+        'name'  => 'CLS',
+        'value' => 0.05,
+    ] );
+
+    $response->assertSuccessful()
+        ->assertJson( [ 'success' => true ] );
+
+    expect( RawMetric::query()->count() )->toBe( 0 );
+} );
+
+it( 'drops every sample when sample_rate is zero', function (): void {
+    config( [ 'artisanpack.performance.monitoring.sample_rate' => 0 ] );
+
+    $response = $this->postJson( '/api/performance/metrics', [
+        'name'  => 'FCP',
+        'value' => 1200,
+    ] );
+
+    $response->assertSuccessful()
+        ->assertJson( [
+            'success' => false,
+            'reason'  => 'sampled-out',
+        ] );
+
+    expect( RawMetric::query()->count() )->toBe( 0 );
+} );
+
+it( 'rejects oversized vital_id and rating values with 422', function (): void {
+    $this->postJson( '/api/performance/metrics', [
+        'name'   => 'INP',
+        'value'  => 180,
+        'id'     => str_repeat( 'a', 100 ),
+        'rating' => str_repeat( 'g', 100 ),
+    ] )->assertStatus( 422 )
+        ->assertJsonValidationErrors( [ 'id', 'rating' ] );
+
+    expect( RawMetric::query()->count() )->toBe( 0 );
+} );
+
+it( 'accepts the deviceType field web-vitals.js sends', function (): void {
+    $this->postJson( '/api/performance/metrics', [
+        'name'       => 'LCP',
+        'value'      => 2100,
+        'deviceType' => 'mobile',
+        'connection' => '4g',
+    ] )->assertSuccessful();
+
+    expect( RawMetric::query()->first()->device_type )->toBe( 'mobile' );
+} );
+
+it( 'still accepts the legacy device field for backward compatibility', function (): void {
+    $this->postJson( '/api/performance/metrics', [
+        'name'   => 'LCP',
+        'value'  => 2100,
+        'device' => 'desktop',
+    ] )->assertSuccessful();
+
+    expect( RawMetric::query()->first()->device_type )->toBe( 'desktop' );
+} );
+
+it( 'prefers deviceType over device when both are sent', function (): void {
+    $this->postJson( '/api/performance/metrics', [
+        'name'       => 'LCP',
+        'value'      => 2100,
+        'device'     => 'desktop',
+        'deviceType' => 'mobile',
+    ] )->assertSuccessful();
+
+    expect( RawMetric::query()->first()->device_type )->toBe( 'mobile' );
+} );
+
+it( 'persists the extra payload when supplied', function (): void {
+    $this->postJson( '/api/performance/metrics', [
+        'name'  => 'LCP',
+        'value' => 2100,
+        'extra' => [ 'tenant' => 42, 'feature' => 'beta' ],
+    ] )->assertSuccessful();
+
+    expect( RawMetric::query()->first()->extra )->toBe( [
+        'tenant'  => 42,
+        'feature' => 'beta',
+    ] );
+} );
+
+it( 'returns 403 when collect_web_vitals is disabled', function (): void {
+    config( [ 'artisanpack.performance.monitoring.collect_web_vitals' => false ] );
+
+    $this->postJson( '/api/performance/metrics', [
+        'name'  => 'LCP',
+        'value' => 2100,
+    ] )->assertStatus( 403 )
+        ->assertJson( [
+            'success' => false,
+            'reason'  => 'web-vitals-disabled',
+        ] );
+
+    expect( RawMetric::query()->count() )->toBe( 0 );
+} );
+
+it( 'rejects control characters in string fields (separator-poisoning guard)', function (): void {
+    $this->postJson( '/api/performance/metrics', [
+        'name'   => 'LCP',
+        'value'  => 2100,
+        'device' => "mobile\x1Fpoison",
+    ] )->assertStatus( 422 )
+        ->assertJsonValidationErrors( [ 'device' ] );
+
+    expect( RawMetric::query()->count() )->toBe( 0 );
+} );

--- a/tests/Feature/Livewire/CacheManagerTest.php
+++ b/tests/Feature/Livewire/CacheManagerTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Cache\FragmentCache;
+use ArtisanPackUI\Performance\Cache\PageCacheManager;
+use ArtisanPackUI\Performance\Livewire\CacheManager;
+use Illuminate\Support\Facades\Cache;
+use Livewire\Livewire;
+
+beforeEach( function (): void {
+    config( [ 'cache.default' => 'array' ] );
+    config( [
+        'artisanpack.performance.page_cache' => [
+            'enabled'        => true,
+            'driver'         => 'array',
+            'ttl'            => 3600,
+            'exclude_routes' => [],
+            'exclude_when'   => [],
+            'vary_by'        => [],
+        ],
+        'artisanpack.performance.fragment_cache' => [
+            'enabled'     => true,
+            'driver'      => 'array',
+            'default_ttl' => 3600,
+        ],
+        'artisanpack.performance.cache_warming' => [
+            'enabled' => true,
+            'urls'    => [],
+        ],
+    ] );
+
+    Cache::store( 'array' )->flush();
+} );
+
+it( 'renders without errors', function (): void {
+    Livewire::test( CacheManager::class )
+        ->assertOk()
+        ->assertSee( 'Page Cache' )
+        ->assertSee( 'Fragment Cache' );
+} );
+
+it( 'stages a flush confirmation before executing it', function (): void {
+    Livewire::test( CacheManager::class )
+        ->call( 'requestConfirmation', 'flush' )
+        ->assertSet( 'pendingAction', 'flush' );
+} );
+
+it( 'cancels a pending confirmation', function (): void {
+    Livewire::test( CacheManager::class )
+        ->call( 'requestConfirmation', 'flush' )
+        ->call( 'cancelConfirmation' )
+        ->assertSet( 'pendingAction', null );
+} );
+
+it( 'invalidates a fragment cache tag and reports the count', function (): void {
+    $fragments = app( FragmentCache::class );
+    $fragments->put( 'sidebar', 'rendered', 60, [ 'home' ] );
+
+    Livewire::test( CacheManager::class )
+        ->call( 'invalidateByTag', 'home' )
+        ->assertSet( 'pendingAction', null )
+        ->assertSet( 'statusIsError', false )
+        ->assertSee( '1 fragments invalidated for tag "home"' );
+} );
+
+it( 'rejects an empty tag name', function (): void {
+    Livewire::test( CacheManager::class )
+        ->call( 'invalidateByTag', '' )
+        ->assertSet( 'statusIsError', true );
+} );
+
+it( 'rejects an empty cache key', function (): void {
+    Livewire::test( CacheManager::class )
+        ->call( 'invalidate', '   ' )
+        ->assertSet( 'statusIsError', true );
+} );
+
+it( 'flushes both caches and clears the pending action', function (): void {
+    Cache::store( 'array' )->put( PageCacheManager::INDEX_KEY, [
+        'perf:page:home' => 'home',
+    ], 600 );
+
+    Livewire::test( CacheManager::class )
+        ->call( 'flushAll' )
+        ->assertSet( 'pendingAction', null )
+        ->assertSet( 'statusIsError', false );
+} );
+
+it( 'reports an error when warmCache has no configured URLs', function (): void {
+    Livewire::test( CacheManager::class )
+        ->call( 'warmCache' )
+        ->assertSet( 'statusIsError', true )
+        ->assertSee( 'No cache_warming.urls configured.' );
+} );
+
+it( 'merges host-supplied labels over defaults', function (): void {
+    $component = Livewire::test( CacheManager::class, [
+        'labels' => [
+            'purge' => 'Clear Cache',
+            'warm'  => 'Pre-load Cache',
+        ],
+    ] );
+
+    $component->assertSee( 'Clear Cache' )
+        ->assertSee( 'Pre-load Cache' );
+} );
+
+it( 'stages a key invalidation confirmation from the bound input value', function (): void {
+    Livewire::test( CacheManager::class )
+        ->set( 'invalidateKeyInput', 'products/*' )
+        ->call( 'requestKeyInvalidation' )
+        ->assertSet( 'pendingAction', 'key:products/*' );
+} );
+
+it( 'rejects a blank invalidate-by-key input with an error status', function (): void {
+    Livewire::test( CacheManager::class )
+        ->set( 'invalidateKeyInput', '   ' )
+        ->call( 'requestKeyInvalidation' )
+        ->assertSet( 'statusIsError', true )
+        ->assertSet( 'pendingAction', null );
+} );
+
+it( 'invalidates a page entry by its index, not its raw path', function (): void {
+    Cache::store( 'array' )->put( PageCacheManager::INDEX_KEY, [
+        "perf:page:o'brien" => "o'brien",
+        'perf:page:about'   => 'about',
+    ], 600 );
+
+    Livewire::test( CacheManager::class )
+        ->call( 'invalidateEntry', 0 )
+        ->assertSet( 'statusIsError', false )
+        ->assertSee( '1 entries invalidated' );
+} );
+
+it( 'invalidates a fragment tag by its index, not its raw value', function (): void {
+    $fragments = app( FragmentCache::class );
+    $fragments->put( 'sidebar', 'rendered', 60, [ "user's-feed" ] );
+
+    Livewire::test( CacheManager::class )
+        ->call( 'invalidateFragmentTagByIndex', 0 )
+        ->assertSet( 'statusIsError', false );
+} );
+
+it( 'returns an error when invalidating a non-existent entry index', function (): void {
+    Livewire::test( CacheManager::class )
+        ->call( 'invalidateEntry', 99 )
+        ->assertSet( 'statusIsError', true );
+} );
+
+it( 'no longer exposes the FragmentCache service through a public method', function (): void {
+    expect( method_exists( CacheManager::class, 'fragmentCache' ) )->toBeFalse();
+} );

--- a/tests/Feature/Livewire/MetricsChartTest.php
+++ b/tests/Feature/Livewire/MetricsChartTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Livewire\MetricsChart;
+use ArtisanPackUI\Performance\Models\PerformanceMetric;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Livewire\Livewire;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    Carbon::setTestNow( Carbon::create( 2026, 6, 30, 12, 0, 0 ) );
+} );
+
+afterEach( function (): void {
+    Carbon::setTestNow();
+} );
+
+it( 'mounts with a single metric prop', function (): void {
+    Livewire::test( MetricsChart::class, [ 'metric' => 'LCP' ] )
+        ->assertSet( 'metrics', [ 'LCP' ] );
+} );
+
+it( 'mounts with a list of metrics', function (): void {
+    Livewire::test( MetricsChart::class, [ 'metrics' => [ 'LCP', 'CLS' ] ] )
+        ->assertSet( 'metrics', [ 'LCP', 'CLS' ] );
+} );
+
+it( 'falls back to the default range when an invalid one is supplied', function (): void {
+    Livewire::test( MetricsChart::class, [ 'dateRange' => 'nonsense' ] )
+        ->assertSet( 'dateRange', '7d' );
+} );
+
+it( 'rejects an unknown chart type', function (): void {
+    Livewire::test( MetricsChart::class, [ 'chartType' => 'pie' ] )
+        ->assertSet( 'chartType', 'line' );
+} );
+
+it( 'builds a chart payload aligned to one label per day', function (): void {
+    PerformanceMetric::create( [
+        'date'         => '2026-06-29',
+        'metric'       => 'LCP',
+        'p50'          => 1500,
+        'p75'          => 2000,
+        'p90'          => 2400,
+        'p99'          => 2400,
+        'sample_count' => 50,
+    ] );
+
+    PerformanceMetric::create( [
+        'date'         => '2026-06-30',
+        'metric'       => 'LCP',
+        'p50'          => 1800,
+        'p75'          => 2200,
+        'p90'          => 2600,
+        'p99'          => 2700,
+        'sample_count' => 50,
+    ] );
+
+    $component = Livewire::test( MetricsChart::class, [ 'metric' => 'LCP', 'dateRange' => '7d' ] );
+
+    $payload = $component->instance()->buildChartPayload();
+
+    expect( $payload['labels'] )->toHaveCount( 7 )
+        ->and( end( $payload['labels'] ) )->toBe( '2026-06-30' )
+        ->and( $payload['datasets'][0]['metric'] )->toBe( 'LCP' )
+        ->and( $payload['datasets'][0]['threshold'] )->toBe( 2500.0 );
+
+    $values = $payload['datasets'][0]['values'];
+
+    expect( $values[ array_search( '2026-06-30', $payload['labels'], true ) ] )->toBe( 2200.0 )
+        ->and( $values[ array_search( '2026-06-29', $payload['labels'], true ) ] )->toBe( 2000.0 );
+} );
+
+it( 'omits the threshold when the option is disabled', function (): void {
+    $component = Livewire::test( MetricsChart::class, [ 'metric' => 'LCP', 'showThreshold' => false ] );
+    $payload   = $component->instance()->buildChartPayload();
+
+    expect( $payload['datasets'][0]['threshold'] )->toBeNull();
+} );
+
+it( 'falls back to the default metric when the metrics list resolves to empty', function (): void {
+    // Empty array + non-string entries would have produced
+    // `WHERE metric IN ()` (MySQL syntax error). The component must
+    // assert a sensible default so the query stays well-formed.
+    Livewire::test( MetricsChart::class, [ 'metrics' => [] ] )
+        ->assertSet( 'metrics', [ 'LCP' ] );
+
+    Livewire::test( MetricsChart::class, [ 'metrics' => [ null, '', 123 ] ] )
+        ->assertSet( 'metrics', [ 'LCP' ] );
+} );
+
+it( 'lets the user change the date range via setDateRange', function (): void {
+    Livewire::test( MetricsChart::class )
+        ->call( 'setDateRange', '30d' )
+        ->assertSet( 'dateRange', '30d' );
+} );
+
+it( 'ignores unknown ranges passed to setDateRange', function (): void {
+    Livewire::test( MetricsChart::class )
+        ->call( 'setDateRange', 'nonsense' )
+        ->assertSet( 'dateRange', '7d' );
+} );

--- a/tests/Feature/Livewire/PerformanceDashboardTest.php
+++ b/tests/Feature/Livewire/PerformanceDashboardTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Livewire\PerformanceDashboard;
+use ArtisanPackUI\Performance\Models\PerformanceMetric;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Livewire\Livewire;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    Carbon::setTestNow( Carbon::create( 2026, 6, 30, 12, 0, 0 ) );
+} );
+
+afterEach( function (): void {
+    Carbon::setTestNow();
+} );
+
+it( 'mounts with the default range and tab', function (): void {
+    Livewire::test( PerformanceDashboard::class )
+        ->assertSet( 'dateRange', '7d' )
+        ->assertSet( 'activeTab', 'overview' );
+} );
+
+it( 'falls back to the default range when an invalid override is supplied', function (): void {
+    Livewire::test( PerformanceDashboard::class, [ 'defaultDateRange' => 'nonsense' ] )
+        ->assertSet( 'dateRange', '7d' );
+} );
+
+it( 'accepts a supported range override on mount', function (): void {
+    Livewire::test( PerformanceDashboard::class, [ 'defaultDateRange' => '30d' ] )
+        ->assertSet( 'dateRange', '30d' );
+} );
+
+it( 'switches tabs via setTab', function (): void {
+    Livewire::test( PerformanceDashboard::class )
+        ->call( 'setTab', 'cache' )
+        ->assertSet( 'activeTab', 'cache' );
+} );
+
+it( 'ignores unknown tabs', function (): void {
+    Livewire::test( PerformanceDashboard::class )
+        ->call( 'setTab', 'bogus' )
+        ->assertSet( 'activeTab', 'overview' );
+} );
+
+it( 'switches the date range via setDateRange', function (): void {
+    Livewire::test( PerformanceDashboard::class )
+        ->call( 'setDateRange', '30d' )
+        ->assertSet( 'dateRange', '30d' );
+} );
+
+it( 'classifies LCP statuses against web vitals thresholds', function (): void {
+    PerformanceMetric::create( [
+        'date'         => '2026-06-30',
+        'route'        => 'home',
+        'metric'       => 'LCP',
+        'p50'          => 1500,
+        'p75'          => 2000,
+        'p90'          => 2400,
+        'p99'          => 2400,
+        'sample_count' => 100,
+    ] );
+
+    Livewire::test( PerformanceDashboard::class )
+        ->assertSee( 'LCP' )
+        ->assertSee( 'good' );
+} );
+
+it( 'renders a recommendation when a metric is in the poor band', function (): void {
+    PerformanceMetric::create( [
+        'date'         => '2026-06-30',
+        'route'        => 'home',
+        'metric'       => 'LCP',
+        'p50'          => 4000,
+        'p75'          => 6000,
+        'p90'          => 8000,
+        'p99'          => 9000,
+        'sample_count' => 100,
+    ] );
+
+    Livewire::test( PerformanceDashboard::class )
+        ->call( 'setTab', 'recommendations' )
+        ->assertSee( 'LCP is poor' );
+} );
+
+it( 'dispatches a refresh event when refreshMetrics is called', function (): void {
+    Livewire::test( PerformanceDashboard::class )
+        ->call( 'refreshMetrics' )
+        ->assertDispatched( 'performance-dashboard:refreshed' );
+} );
+
+it( 'classifies metrics with metric-specific poor thresholds (not a flat 2x)', function (): void {
+    // INP good=200, poor=500 (per web.dev). A p75 of 450 is needs-improvement.
+    // The old flat-2x rule would have marked it poor.
+    PerformanceMetric::create( [
+        'date'         => '2026-06-30',
+        'route'        => 'home',
+        'metric'       => 'INP',
+        'p50'          => 300,
+        'p75'          => 450,
+        'p90'          => 480,
+        'p99'          => 490,
+        'sample_count' => 100,
+    ] );
+
+    Livewire::test( PerformanceDashboard::class )
+        ->assertSee( 'INP' )
+        ->assertSee( 'Needs improvement' );
+} );
+
+it( 'respects a URL-restored range over the host defaultDateRange prop', function (): void {
+    // Simulate a reload where the browser sent `?range=24h`. The
+    // host page passes :default-date-range="'30d'", but the URL
+    // value should win so the user's bookmark survives. We assert
+    // the inverse of the buggy behavior — if mount() unconditionally
+    // overwrites the property, the URL value cannot stick when the
+    // host supplies a default.
+    $request = new Illuminate\Http\Request( [ 'range' => '24h' ] );
+
+    $component            = new PerformanceDashboard;
+    $component->dateRange = '24h';
+    $component->mount( $request, '30d' );
+
+    expect( $component->dateRange )->toBe( '24h' );
+} );
+
+it( 'applies the defaultDateRange when no URL parameter is present', function (): void {
+    $request = new Illuminate\Http\Request;
+
+    $component = new PerformanceDashboard;
+    $component->mount( $request, '30d' );
+
+    expect( $component->dateRange )->toBe( '30d' );
+} );
+
+it( 'only builds the active tab payload to avoid eager-rendering every tab', function (): void {
+    PerformanceMetric::create( [
+        'date'         => '2026-06-30',
+        'route'        => 'home',
+        'metric'       => 'LCP',
+        'p50'          => 1500,
+        'p75'          => 2000,
+        'p90'          => 2400,
+        'p99'          => 2400,
+        'sample_count' => 100,
+    ] );
+
+    // Pages tab data should not render content from the Overview build
+    Livewire::test( PerformanceDashboard::class )
+        ->call( 'setTab', 'pages' )
+        ->assertSee( 'Pages' )
+        ->assertDontSee( 'Core Web Vitals' );
+} );

--- a/tests/Feature/Monitoring/MetricsAggregatorTest.php
+++ b/tests/Feature/Monitoring/MetricsAggregatorTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Models\PerformanceMetric;
+use ArtisanPackUI\Performance\Models\RawMetric;
+use ArtisanPackUI\Performance\Monitoring\MetricsAggregator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    Carbon::setTestNow( Carbon::create( 2026, 6, 30, 12, 0, 0 ) );
+} );
+
+afterEach( function (): void {
+    Carbon::setTestNow();
+} );
+
+function seedRawMetrics( array $samples, ?Carbon $recordedAt = null ): void
+{
+    $recordedAt ??= Carbon::create( 2026, 6, 30, 10, 0, 0 );
+
+    foreach ( $samples as $sample ) {
+        RawMetric::create( array_merge( [
+            'name'        => 'LCP',
+            'value'       => 0,
+            'route'       => 'products.index',
+            'recorded_at' => $recordedAt,
+        ], $sample ) );
+    }
+}
+
+it( 'computes nearest-rank percentiles for an unsorted sample list', function (): void {
+    $aggregator = new MetricsAggregator;
+
+    // Sorted: [25, 50, 75, 90, 100, 150, 200, 300, 400, 600] (n=10).
+    // Nearest-rank: ceil(p * n / 100) - 1.
+    //   p50 -> rank 4 = 100, p75 -> rank 7 = 300, p90 -> rank 8 = 400, p99 -> rank 9 = 600.
+    $result = $aggregator->computePercentiles( [ 100, 50, 200, 75, 300, 25, 400, 150, 90, 600 ] );
+
+    expect( $result )->toHaveKeys( [ 50, 75, 90, 99 ] )
+        ->and( $result[50] )->toBe( 100.0 )
+        ->and( $result[75] )->toBe( 300.0 )
+        ->and( $result[90] )->toBe( 400.0 )
+        ->and( $result[99] )->toBe( 600.0 );
+} );
+
+it( 'returns zero percentiles for an empty sample list', function (): void {
+    $aggregator = new MetricsAggregator;
+
+    expect( $aggregator->computePercentiles( [] ) )->toBe( [
+        50 => 0.0,
+        75 => 0.0,
+        90 => 0.0,
+        99 => 0.0,
+    ] );
+} );
+
+it( 'aggregates raw samples into a single bucket row', function (): void {
+    seedRawMetrics( [
+        [ 'value' => 1000 ],
+        [ 'value' => 1500 ],
+        [ 'value' => 2000 ],
+        [ 'value' => 2500 ],
+        [ 'value' => 3000 ],
+    ] );
+
+    $written = ( new MetricsAggregator )->aggregate( '2026-06-30' );
+
+    expect( $written )->toBe( 1 );
+
+    $row = PerformanceMetric::query()->first();
+
+    // Sorted: [1000, 1500, 2000, 2500, 3000] (n=5).
+    // Nearest-rank: p50 -> rank 2 = 2000, p75 -> rank 3 = 2500, p90 -> rank 4 = 3000, p99 -> rank 4 = 3000.
+    expect( $row->metric )->toBe( 'LCP' )
+        ->and( $row->route )->toBe( 'products.index' )
+        ->and( $row->sample_count )->toBe( 5 )
+        ->and( $row->p50 )->toBe( 2000.0 )
+        ->and( $row->p75 )->toBe( 2500.0 )
+        ->and( $row->p90 )->toBe( 3000.0 )
+        ->and( $row->p99 )->toBe( 3000.0 );
+} );
+
+it( 'buckets by route, metric, device, and connection', function (): void {
+    seedRawMetrics( [
+        [ 'name' => 'LCP', 'value' => 1000, 'device_type' => 'mobile', 'connection_type' => '4g' ],
+        [ 'name' => 'LCP', 'value' => 2000, 'device_type' => 'mobile', 'connection_type' => '4g' ],
+        [ 'name' => 'LCP', 'value' => 1500, 'device_type' => 'desktop', 'connection_type' => '4g' ],
+        [ 'name' => 'CLS', 'value' => 0.1,  'device_type' => 'mobile', 'connection_type' => '4g' ],
+    ] );
+
+    $written = ( new MetricsAggregator )->aggregate( '2026-06-30' );
+
+    expect( $written )->toBe( 3 );
+    expect( PerformanceMetric::query()->count() )->toBe( 3 );
+
+    $mobileLcp = PerformanceMetric::query()
+        ->where( 'metric', 'LCP' )
+        ->where( 'device_type', 'mobile' )
+        ->first();
+
+    expect( $mobileLcp->sample_count )->toBe( 2 );
+} );
+
+it( 'is idempotent — re-running produces the same row counts', function (): void {
+    seedRawMetrics( [
+        [ 'value' => 1000 ],
+        [ 'value' => 2000 ],
+        [ 'value' => 3000 ],
+    ] );
+
+    $aggregator = new MetricsAggregator;
+
+    $aggregator->aggregate( '2026-06-30' );
+    $aggregator->aggregate( '2026-06-30' );
+
+    expect( PerformanceMetric::query()->count() )->toBe( 1 );
+
+    $row = PerformanceMetric::query()->first();
+
+    expect( $row->sample_count )->toBe( 3 );
+} );
+
+it( 'returns zero when there are no raw samples for the date', function (): void {
+    expect( ( new MetricsAggregator )->aggregate( '2026-06-29' ) )->toBe( 0 );
+    expect( PerformanceMetric::query()->count() )->toBe( 0 );
+} );
+
+it( 'aggregates only samples within the requested calendar date', function (): void {
+    seedRawMetrics( [
+        [ 'value' => 1000 ],
+        [ 'value' => 2000 ],
+    ], Carbon::create( 2026, 6, 29, 10, 0, 0 ) );
+
+    seedRawMetrics( [
+        [ 'value' => 5000 ],
+    ], Carbon::create( 2026, 6, 30, 10, 0, 0 ) );
+
+    ( new MetricsAggregator )->aggregate( '2026-06-30' );
+
+    expect( PerformanceMetric::query()->count() )->toBe( 1 );
+
+    $row = PerformanceMetric::query()->first();
+
+    expect( $row->sample_count )->toBe( 1 )
+        ->and( $row->p75 )->toBe( 5000.0 );
+} );

--- a/tests/Feature/Monitoring/WebVitalsTest.php
+++ b/tests/Feature/Monitoring/WebVitalsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Monitoring\WebVitals;
+
+it( 'classifies a value at or under the good threshold as good', function (): void {
+    expect( WebVitals::classify( 'LCP', 2500.0 ) )->toBe( 'good' )
+        ->and( WebVitals::classify( 'LCP', 1800.0 ) )->toBe( 'good' )
+        ->and( WebVitals::classify( 'CLS', 0.10 ) )->toBe( 'good' )
+        ->and( WebVitals::classify( 'CLS', 0.05 ) )->toBe( 'good' );
+} );
+
+it( 'classifies a value between the good and poor thresholds as needs-improvement', function (): void {
+    expect( WebVitals::classify( 'LCP', 3500.0 ) )->toBe( 'needs-improvement' )
+        ->and( WebVitals::classify( 'INP', 450.0 ) )->toBe( 'needs-improvement' )
+        ->and( WebVitals::classify( 'CLS', 0.20 ) )->toBe( 'needs-improvement' );
+} );
+
+it( 'classifies a value strictly above the poor threshold as poor', function (): void {
+    expect( WebVitals::classify( 'LCP', 4500.0 ) )->toBe( 'poor' )
+        ->and( WebVitals::classify( 'INP', 600.0 ) )->toBe( 'poor' )
+        ->and( WebVitals::classify( 'CLS', 0.30 ) )->toBe( 'poor' );
+} );
+
+it( 'applies metric-specific (not flat-2x) poor thresholds', function (): void {
+    // The previous implementation used good * 2 for the poor boundary;
+    // these cases would have misclassified under that rule.
+
+    // LCP poor threshold is 4000ms (1.6x of good=2500), not 5000ms.
+    expect( WebVitals::classify( 'LCP', 4500.0 ) )->toBe( 'poor' );
+
+    // INP poor threshold is 500ms (2.5x of good=200), not 400ms.
+    expect( WebVitals::classify( 'INP', 450.0 ) )->toBe( 'needs-improvement' );
+
+    // FID poor threshold is 300ms (3x of good=100), not 200ms.
+    expect( WebVitals::classify( 'FID', 250.0 ) )->toBe( 'needs-improvement' );
+} );
+
+it( 'returns unknown for null values or unrecognized metrics', function (): void {
+    expect( WebVitals::classify( 'LCP', null ) )->toBe( 'unknown' )
+        ->and( WebVitals::classify( 'NOT_A_METRIC', 100.0 ) )->toBe( 'unknown' );
+} );
+
+it( 'classifies the boundary points exactly per web.dev guidance', function (): void {
+    expect( WebVitals::classify( 'LCP', 4000.0 ) )->toBe( 'needs-improvement' )
+        ->and( WebVitals::classify( 'LCP', 4000.001 ) )->toBe( 'poor' )
+        ->and( WebVitals::classify( 'INP', 200.0 ) )->toBe( 'good' )
+        ->and( WebVitals::classify( 'INP', 200.001 ) )->toBe( 'needs-improvement' );
+} );

--- a/tests/Feature/Support/MetricsChartDirectivesTest.php
+++ b/tests/Feature/Support/MetricsChartDirectivesTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Support\MetricsChartDirectives;
+use Illuminate\Support\Facades\Blade;
+
+it( 'emits both the chart library and bootstrap script tags by default', function (): void {
+    $html = MetricsChartDirectives::perfMetricsChartAssets();
+
+    expect( $html )->toContain( MetricsChartDirectives::DEFAULT_CHART_LIBRARY_URL )
+        ->toContain( MetricsChartDirectives::DEFAULT_SCRIPT_PATH );
+} );
+
+it( 'omits the chart library tag when libraryUrl is blanked', function (): void {
+    $html = MetricsChartDirectives::perfMetricsChartAssets( [ 'libraryUrl' => '' ] );
+
+    expect( $html )->not->toContain( MetricsChartDirectives::DEFAULT_CHART_LIBRARY_URL )
+        ->toContain( MetricsChartDirectives::DEFAULT_SCRIPT_PATH );
+} );
+
+it( 'omits the bootstrap tag when src is blanked', function (): void {
+    $html = MetricsChartDirectives::perfMetricsChartAssets( [ 'src' => '' ] );
+
+    expect( $html )->toContain( MetricsChartDirectives::DEFAULT_CHART_LIBRARY_URL )
+        ->not->toContain( MetricsChartDirectives::DEFAULT_SCRIPT_PATH );
+} );
+
+it( 'honors the chart_library_url config override', function (): void {
+    config( [ 'artisanpack.performance.monitoring.chart_library_url' => 'https://example.test/chart.js' ] );
+
+    expect( MetricsChartDirectives::perfMetricsChartAssets() )
+        ->toContain( 'https://example.test/chart.js' );
+} );
+
+it( 'escapes attribute special characters in the supplied URLs', function (): void {
+    $html = MetricsChartDirectives::perfMetricsChartAssets( [
+        'libraryUrl' => 'https://evil.test/" onerror="alert(1)',
+        'src'        => 'https://evil.test/bootstrap"<script>',
+    ] );
+
+    expect( $html )->not->toContain( '" onerror="' )
+        ->not->toContain( '"<script>' )
+        ->toContain( '&quot;' );
+} );
+
+it( 'renders the @perfMetricsChartAssets Blade directive', function (): void {
+    $compiled = Blade::compileString( '@perfMetricsChartAssets' );
+
+    expect( $compiled )->toContain( 'perfMetricsChartAssets()' );
+
+    $compiledWithArgs = Blade::compileString( "@perfMetricsChartAssets(['libraryUrl' => 'https://cdn.example/chart.js'])" );
+
+    expect( $compiledWithArgs )->toContain( "perfMetricsChartAssets(['libraryUrl' => 'https://cdn.example/chart.js'])" );
+} );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ namespace Tests;
 
 use ArtisanPackUI\Performance\PerformanceServiceProvider;
 use Illuminate\Foundation\Application;
+use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
 /**
@@ -37,6 +38,7 @@ abstract class TestCase extends BaseTestCase
     protected function getPackageProviders( $app ): array
     {
         return [
+            LivewireServiceProvider::class,
             PerformanceServiceProvider::class,
         ];
     }
@@ -60,6 +62,6 @@ abstract class TestCase extends BaseTestCase
             'database'                => ':memory:',
             'prefix'                  => '',
             'foreign_key_constraints' => true,
-        ]);
+        ] );
     }
 }


### PR DESCRIPTION
## Description

Bundles five closely-related issues into one PR because the surfaces ship together: the API (#52) feeds the aggregator (#53), the dashboard (#54) mounts the chart (#55) and cache manager (#56). Implementing them piecemeal would leave each issue's surface untestable until the next one landed.

**Closes:** #52, #53, #54, #55, #56

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #52, #53, #54, #55, #56

## Motivation and Context

The Performance package's monitoring story stops at the JS collector (#51) — it has nowhere to send beacons and no UI to surface them. This PR completes that loop: an ingestion endpoint with rate-limiting and sampling, an aggregator that rolls raw samples into the per-day percentile table, and the three Livewire components that turn those rollups into a working admin dashboard.

## Changes Made

- ` MetricsApiController` — POST endpoint with throttle middleware, sample-rate gating, control-character rejection, and dual-shape (`deviceType` from web-vitals.js, legacy `device`) field handling
- ` performance_raw_metrics` migration + `RawMetric` Eloquent model
- ` PerformanceMetric` Eloquent model wrapping the existing aggregated table
- ` MetricsAggregator` + `perf:aggregate-metrics` console command — chunked iteration, `lockForUpdate` transaction, nearest-rank percentiles
- ` Monitoring\WebVitals` — single source of truth for the good/poor thresholds (per-metric, not a flat 2x)
- ` PerformanceDashboard` Livewire component — 6 tabs (Overview, Pages, Images, Cache, Queries, Recommendations), URL-bound range + tab state, weighted-mean p75 rollups
- ` MetricsChart` Livewire component — daily time-series with threshold reference lines, `setDateRange` action, URL-bound range
- ` CacheManager` Livewire component — invalidate by key, by tag, flush all, warm; confirmation gates on every destructive action
- ` CacheStatistics` helper — entry/tag counts for the cache UI
- ` @perfMetricsChartAssets` Blade directive — loads Chart.js + the package bootstrap
- ` resources/js/metrics-chart.js` — vanilla JS Chart.js binder that re-runs on Livewire morph events

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.5.0
- Browser: Chrome (manual verification against the dev app)
- PHP Version: 8.4.22
- Project Version: 1.0.0

**Tests Performed:**

1. ` ./vendor/bin/pest` — 619 passing, 1 skipped (122 new tests added across MetricsApiController, MetricsAggregator, WebVitals, CacheStatistics, MetricsChartDirectives, PerformanceDashboard, MetricsChart, CacheManager)
2. ` ./vendor/bin/php-cs-fixer fix` — clean
3. ` ./vendor/bin/phpcs` — clean
4. Manual browser test of the dashboard, chart, and cache manager against a 14k-sample seed; verified curl POST + aggregation + dashboard rendering end-to-end
5. Local `/code-review` pass — 15 findings surfaced, all 15 fixed (including the deviceType/device mismatch, AVG(p75) statistical bug, upsertBucket race, and the chart's JS dependency)

## Accessibility Tests Run

- [x] Keyboard navigation tested (tab buttons, range buttons, confirmation buttons all reachable)
- [ ] Screen reader tested (not run — flagging for follow-up)
- [x] Color contrast verified (default palette tested in light + dark backgrounds)
- [x] ARIA labels checked (` role=tab`, `role=tablist`, `role=tabpanel`, `aria-selected`, `aria-pressed`, `aria-label` on the range groups)

**Details:** The Livewire views ship with semantic markup but the default CSS is minimal; consumers are expected to provide a real stylesheet via the published views.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** 122 new tests covering the API ingestion path (sample gating, control-char rejection, deviceType/device routing, extra payload persistence, collect_web_vitals gate), the aggregator (nearest-rank percentiles, idempotent upsert, bucketing), the Livewire components (mount param resolution, tab gating, URL restoration, confirmation flows, label overrides), the WebVitals classifier (boundary cases, per-metric thresholds), the cache statistics helper, and the chart directive output.

## Documentation

- [x] Inline code documentation added
- [ ] README updated (not in scope for this PR)
- [ ] Wiki updated (deferred — surface is still pre-release)

**Documentation details:** Every new class carries PHPDoc with ` @since` tags; the metrics-chart.js module has a header explaining the Livewire morph hook; the ` @perfMetricsChartAssets` directive's `MetricsChartDirectives` helper documents the `libraryUrl` / `src` override conventions.

## Screenshots

(Captured during manual verification — not committed to the repo. The dashboard renders 14k-sample data across the Overview, Pages, Cache, and Recommendations tabs; the chart's threshold line shows the LCP 2500ms boundary as a dashed reference; the cache manager surfaces 3 page entries and 3 fragment tags with confirmation buttons.)

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed (partial — see notes above)
- [x] Code follows project style guide
- [x] Self-review completed (via local /code-review with 15 findings all fixed)
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a performance dashboard with charts, date-range filters, tabbed views, and cache/slow-query insights.
  * Added a cache manager for viewing cache stats, warming cache, and confirming invalidation actions.
  * Added performance metrics ingestion and daily aggregation support, plus a new API endpoint for submitting metrics.
  * Added a chart bootstrap directive to render metrics charts on supported pages.

* **Bug Fixes**
  * Improved chart and dashboard updates so they refresh correctly after page changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->