### PR TITLE
feat(media-library): auto-optimize uploads + docs (#62-#66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,9 +364,11 @@ Performance::recordMetric( 'checkout.duration', 4200.0, ['step' => 'shipping'] )
 ## Media Library Integration
 
 When [`artisanpack-ui/media-library`](https://github.com/ArtisanPack-UI/media-library)
-is installed, the Performance package automatically optimizes every uploaded
-image. The integration is detected at boot (via `MediaLibraryDetector`) and
-can be forced on or off explicitly:
+is installed, the Performance package automatically optimizes uploaded images
+whose file resolves to a local filesystem path. Non-image uploads are skipped,
+and rows on remote disks (S3, GCS) that don't expose a local `path()` are a
+current caveat — see the FAQ. The integration is detected at boot (via
+`MediaLibraryDetector`) and can be forced on or off explicitly:
 
 ```php
 'media_library_integration' => [
@@ -377,26 +379,33 @@ can be forced on or off explicitly:
 ```
 
 Uploaded rows are enriched with optimization metadata via the
-`HasOptimizedMedia` trait:
+`HasOptimizedMedia` trait. Extend media-library's `Media` model in your app
+and mix in the trait:
 
 ```php
-use ArtisanPackUI\MediaLibrary\Models\Media;
+namespace App\Models;
+
+use ArtisanPackUI\MediaLibrary\Models\Media as BaseMedia;
 use ArtisanPackUI\Performance\Traits\HasOptimizedMedia;
 
-class Media extends Model
+class OptimizedMedia extends BaseMedia
 {
     use HasOptimizedMedia;
 }
 
-$media = Media::find( 1 );
+$media = OptimizedMedia::find( 1 );
 
 $media->isOptimized();                         // bool
 $media->getOptimizationStatus();               // 'pending' | 'processing' | 'completed' | 'failed'
 $media->getDominantColor();                    // '#3b82f6' or null
-$media->getOptimizedUrl( 'webp' );             // format-only lookup
+$media->getOptimizedUrl( 'webp' );             // format-only lookup — returns the largest-width URL
 $media->getOptimizedUrl( 'webp', 640 );        // format + width lookup
 $media->getSrcset( 'webp' );                   // '<url> 320w, <url> 640w, ...'
 ```
+
+The trait auto-registers the `optimized_formats`/`optimized_sizes`/`optimized_at`
+casts via `initializeHasOptimizedMedia()`, so you don't have to declare them
+on the model yourself.
 
 Optimization runs asynchronously in `OptimizeMediaJob`, which writes back
 `dominant_color`, `optimization_status`, `optimized_at`, `optimized_formats`,

--- a/README.md
+++ b/README.md
@@ -1,16 +1,56 @@
 # ArtisanPack UI Performance
 
-Comprehensive performance optimization toolkit for Laravel applications: image
-optimization (WebP/AVIF), JavaScript and CSS strategies, resource hints and
-speculative loading, page and fragment caching, query analysis, and real-user
-performance monitoring.
+Comprehensive performance optimization toolkit for Laravel applications. Ship
+faster pages, better Core Web Vitals, and a real-user performance dashboard
+without leaving Laravel.
 
-All features are opt-in. Enable only what you need.
+- **Image optimization** — WebP/AVIF conversion, responsive sizes, dominant color extraction, lazy loading.
+- **JavaScript & CSS strategies** — deferred, conditional, and priority scripts; critical CSS extraction; async loading.
+- **Speculative loading** — Speculation Rules API integration for prefetch and prerender.
+- **Resource hints & early hints** — preconnect, dns-prefetch, preload, and HTTP 103 Early Hints.
+- **HTML minification** — request-time or middleware-based.
+- **Caching** — page cache, fragment cache, cache warming, tag-based invalidation.
+- **Database optimization** — N+1 detection, slow query logging, query cache, index suggestions.
+- **Performance monitoring** — RUM (Real User Monitoring) with Web Vitals collection, aggregation, and a Livewire dashboard.
+- **Media library integration** — automatic optimization for uploads made through `artisanpack-ui/media-library`.
+
+All features are **opt-in**. Nothing runs unless you turn it on.
+
+---
+
+## Table of Contents
+
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Image Optimization](#image-optimization)
+- [JavaScript & CSS Optimization](#javascript--css-optimization)
+- [Speculative Loading & Resource Hints](#speculative-loading--resource-hints)
+- [Caching](#caching)
+- [Database Optimization](#database-optimization)
+- [Performance Monitoring & Dashboard](#performance-monitoring--dashboard)
+- [Media Library Integration](#media-library-integration)
+- [Blade Components](#blade-components)
+- [Blade Directives](#blade-directives)
+- [Livewire Components](#livewire-components)
+- [Artisan Commands](#artisan-commands)
+- [Middleware](#middleware)
+- [Events](#events)
+- [Helper Functions](#helper-functions)
+- [Troubleshooting](#troubleshooting)
+- [FAQ](#faq)
+- [Contributing](#contributing)
+
+---
 
 ## Requirements
 
 - PHP 8.2+ for Laravel 10, 11, or 12
 - PHP 8.3+ for Laravel 13
+- `ext-gd` or `ext-imagick` for image optimization
+- Livewire 3 (optional — required only for the bundled dashboard components)
+
+---
 
 ## Installation
 
@@ -18,46 +58,612 @@ All features are opt-in. Enable only what you need.
 composer require artisanpack-ui/performance
 ```
 
-Publish the configuration and run the migrations (migrations ship inside the
-package and are picked up automatically — you do not need to publish them):
+Publish the configuration file and run migrations. The package migrations ship
+inside the package and are loaded automatically — you don't need to publish
+them:
 
 ```bash
 php artisan vendor:publish --tag=artisanpack-performance-config
 php artisan migrate
 ```
 
+Optionally publish the front-end bundle (used by the RUM collector) and view
+templates if you want to customize markup or styling:
+
+```bash
+php artisan vendor:publish --tag=artisanpack-performance-js
+php artisan vendor:publish --tag=performance-views
+php artisan vendor:publish --tag=performance-css
+```
+
+---
+
 ## Configuration
 
-Configuration lives in `config/artisanpack/performance.php` after publishing.
-Every feature is disabled by default — flip the corresponding `features.*`
-toggle (or its `PERF_*` environment variable) to opt in.
+Configuration lives at `config/artisanpack/performance.php` after publishing.
+Every feature toggle has a matching `PERF_*` environment variable so you can
+flip features per-environment without code changes.
 
-## Usage
+```php
+'features' => [
+    'image_optimization'  => env( 'PERF_IMAGE_OPTIMIZATION', false ),
+    'lazy_loading'        => env( 'PERF_LAZY_LOADING', false ),
+    'script_optimization' => env( 'PERF_SCRIPT_OPTIMIZATION', false ),
+    'critical_css'        => env( 'PERF_CRITICAL_CSS', false ),
+    'resource_hints'      => env( 'PERF_RESOURCE_HINTS', false ),
+    'speculative_loading' => env( 'PERF_SPECULATIVE_LOADING', false ),
+    'html_minification'   => env( 'PERF_HTML_MINIFICATION', false ),
+    'early_hints'         => env( 'PERF_EARLY_HINTS', false ),
+    'page_cache'          => env( 'PERF_PAGE_CACHE', false ),
+    'fragment_cache'      => env( 'PERF_FRAGMENT_CACHE', false ),
+    'cache_warming'       => env( 'PERF_CACHE_WARMING', false ),
+    'query_optimization'  => env( 'PERF_QUERY_OPTIMIZATION', false ),
+    'monitoring'          => env( 'PERF_MONITORING', false ),
+    'alerts'              => env( 'PERF_ALERTS', false ),
+    'dashboard'           => env( 'PERF_DASHBOARD', false ),
+],
+```
+
+The configuration file is heavily commented — every section documents what it
+does and the trade-offs of each option.
+
+---
+
+## Image Optimization
+
+Convert JPEG/PNG uploads to WebP or AVIF, generate responsive sizes, and
+extract a dominant color for use as an LQIP placeholder.
 
 ```php
 use ArtisanPackUI\Performance\Facades\Performance;
 
-if ( Performance::isFeatureEnabled( 'image_optimization' ) ) {
-    Performance::optimizeImage( $path );
-}
+$result = Performance::optimizeImage( $path, [
+    'sizes'   => [320, 640, 1024],
+    'formats' => ['webp', 'avif'],
+    'quality' => 80,
+] );
 
-$value = Performance::remember( 'expensive-key', 3600, fn () => compute() );
+// Convert directly.
+$webp = Performance::convertToWebP( $path, 80 );
+$avif = Performance::convertToAvif( $path, 70 );
 
-Performance::recordMetric( 'LCP', 2100.0 );
+// LQIP dominant color.
+$color = Performance::getDominantColor( $path );
+
+// Responsive srcset.
+$srcset = Performance::getResponsiveSrcset( $path, [320, 640, 1024] );
 ```
 
-The same API is available via the `performance()` global helper.
+Optimization can also run in the background via `OptimizeImageJob`:
+
+```php
+use ArtisanPackUI\Performance\Jobs\OptimizeImageJob;
+
+OptimizeImageJob::dispatch( $path, [
+    'sizes'   => [320, 640, 1024],
+    'formats' => ['webp', 'avif'],
+] );
+```
+
+### Model integration
+
+Attach the `HasOptimizedImages` trait to any Eloquent model that owns image
+attributes:
+
+```php
+use ArtisanPackUI\Performance\Traits\HasOptimizedImages;
+
+class Product extends Model
+{
+    use HasOptimizedImages;
+
+    protected function optimizableImages(): array
+    {
+        return [
+            'hero_image' => [
+                'sizes'                  => [320, 640, 1024],
+                'formats'                => ['webp', 'avif'],
+                'quality'                => 80,
+                'extract_dominant_color' => true,
+                'auto_optimize'          => true,
+            ],
+        ];
+    }
+}
+
+$product->getOptimizedImageUrl( 'hero_image', 'webp', 640 );
+$product->getImageSrcset( 'hero_image', 'webp' );
+$product->getImageDominantColor( 'hero_image' );
+```
+
+Setting `auto_optimize` to `true` dispatches `OptimizeImageJob` whenever the
+attribute changes on save.
+
+---
+
+## JavaScript & CSS Optimization
+
+Register scripts with a load strategy — the default is `defer`:
+
+```php
+use ArtisanPackUI\Performance\Facades\Performance;
+
+Performance::script( '/js/analytics.js' )->defer();
+Performance::script( '/js/chat.js' )->onInteraction();
+Performance::script( '/js/lazy-carousel.js' )->onVisible();
+Performance::script( '/js/telemetry.js' )->onIdle();
+
+echo Performance::renderScripts();
+```
+
+Extract and inline critical CSS to eliminate render-blocking stylesheet requests
+for above-the-fold content:
+
+```bash
+php artisan perf:critical-css --url=https://example.com/
+```
+
+Or invoke the extractor at runtime:
+
+```php
+$critical = Performance::criticalCss()->extract( $html );
+```
+
+---
+
+## Speculative Loading & Resource Hints
+
+Register URLs to prefetch or prerender on the current request:
+
+```php
+Performance::prefetch( ['/products', '/about'], 'moderate' );
+Performance::prerender( '/checkout', 'conservative' );
+```
+
+Emit the resulting `<script type="speculationrules">` block and resource hints
+in your layout:
+
+```blade
+@speculativeRules
+@resourceHints
+```
+
+---
+
+## Caching
+
+Full-page and fragment caching with tag-based invalidation.
+
+```php
+$html = Performance::remember( 'homepage', 3600, fn () => renderHomepage() );
+
+$fragment = Performance::fragmentRemember(
+    'sidebar-featured',
+    900,
+    fn () => renderSidebar(),
+    tags: ['sidebar', 'featured'],
+);
+
+Performance::invalidateFragmentsByTag( 'featured' );
+Performance::invalidatePageCache( '/products/*' );
+Performance::flushPageCache();
+```
+
+Warm the cache in the background:
+
+```bash
+php artisan perf:warm-cache
+```
+
+Or via the API:
+
+```php
+Performance::warmPageCache( ['/', '/pricing', '/docs'] );
+```
+
+Purge caches on demand:
+
+```bash
+php artisan perf:purge-cache --pattern="/products/*"
+```
+
+---
+
+## Database Optimization
+
+### N+1 detection
+
+Enable the detector to log or notify when queries repeat above a threshold:
+
+```php
+// config/artisanpack/performance.php
+'database' => [
+    'n1_detection' => [
+        'enabled'     => true,
+        'threshold'   => 5,
+        'log_channel' => 'performance',
+        'notify'      => false,
+    ],
+],
+```
+
+### Slow query logging
+
+Log queries above a millisecond threshold to the log channel or a database
+table:
+
+```php
+'slow_query_logging' => [
+    'enabled'           => true,
+    'threshold_ms'      => 100,
+    'store_in_database' => true,
+    'retention_days'    => 30,
+],
+```
+
+### Query cache trait
+
+```php
+use ArtisanPackUI\Performance\Traits\CachesQueries;
+
+class Report extends Model
+{
+    use CachesQueries;
+
+    // Model queries are cached automatically according to the trait's rules.
+}
+```
+
+### Index suggestions
+
+Analyze recent queries and get suggested indexes:
+
+```bash
+php artisan perf:suggest-indexes
+```
+
+---
+
+## Performance Monitoring & Dashboard
+
+The RUM collector emits Web Vitals from the browser to a configurable endpoint,
+aggregates them on a schedule, and surfaces the results in a Livewire dashboard.
+
+```php
+'monitoring' => [
+    'enabled'              => true,
+    'collect_web_vitals'   => true,
+    'endpoint'             => '/api/performance/metrics',
+    'sample_rate'          => 100,
+    'aggregation_interval' => 'hourly',
+    'retention_days'       => 90,
+],
+```
+
+Enable the dashboard and mount the Livewire component in a route your
+application authorizes:
+
+```blade
+<livewire:perf-performance-dashboard />
+```
+
+Aggregate metrics on a schedule:
+
+```bash
+php artisan perf:aggregate-metrics --interval=hourly
+```
+
+Record a custom metric from application code:
+
+```php
+Performance::recordMetric( 'checkout.duration', 4200.0, ['step' => 'shipping'] );
+```
+
+---
+
+## Media Library Integration
+
+When [`artisanpack-ui/media-library`](https://github.com/ArtisanPack-UI/media-library)
+is installed, the Performance package automatically optimizes every uploaded
+image. The integration is detected at boot (via `MediaLibraryDetector`) and
+can be forced on or off explicitly:
+
+```php
+'media_library_integration' => [
+    'enabled'                    => true,   // null = auto-detect
+    'optimize_on_upload'         => true,
+    'generate_formats_on_upload' => true,
+],
+```
+
+Uploaded rows are enriched with optimization metadata via the
+`HasOptimizedMedia` trait:
+
+```php
+use ArtisanPackUI\MediaLibrary\Models\Media;
+use ArtisanPackUI\Performance\Traits\HasOptimizedMedia;
+
+class Media extends Model
+{
+    use HasOptimizedMedia;
+}
+
+$media = Media::find( 1 );
+
+$media->isOptimized();                         // bool
+$media->getOptimizationStatus();               // 'pending' | 'processing' | 'completed' | 'failed'
+$media->getDominantColor();                    // '#3b82f6' or null
+$media->getOptimizedUrl( 'webp' );             // format-only lookup
+$media->getOptimizedUrl( 'webp', 640 );        // format + width lookup
+$media->getSrcset( 'webp' );                   // '<url> 320w, <url> 640w, ...'
+```
+
+Optimization runs asynchronously in `OptimizeMediaJob`, which writes back
+`dominant_color`, `optimization_status`, `optimized_at`, `optimized_formats`,
+and `optimized_sizes` to the row on completion. The migration that adds
+these columns is a no-op when the `media` table is absent, so applications
+without media-library never fail their migrate step.
+
+---
+
+## Blade Components
+
+All components are registered under the `perf` prefix.
+
+| Component | Purpose |
+|-----------|---------|
+| `<x-perf-lazy-image>` | Lazy-loaded image with dominant-color placeholder. |
+| `<x-perf-responsive-image>` | Responsive image with automatic `srcset`. |
+| `<x-perf-critical-css>` | Inline critical CSS block. |
+| `<x-perf-resource-hints>` | Emit preconnect/dns-prefetch/preload tags. |
+| `<x-perf-script>` | Script tag with a load strategy (`defer`, `async`, `priority`). |
+| `<x-perf-conditional-script>` | Script that loads on interaction, visibility, or idle. |
+| `<x-perf-speculative-rules>` | Emit the Speculation Rules `<script>` block. |
+| `<x-perf-prefetch>` | Register a URL for prefetching. |
+| `<x-perf-embed>` | Optimized `<iframe>` embed (YouTube/Vimeo lite). |
+
+Example:
+
+```blade
+<x-perf-responsive-image
+    src="/images/hero.jpg"
+    :sizes="[320, 640, 1024]"
+    formats="webp,avif"
+    alt="Hero"
+/>
+
+<x-perf-lazy-image
+    src="/images/product.jpg"
+    dominant-color="#3b82f6"
+    alt="Product"
+/>
+```
+
+---
+
+## Blade Directives
+
+| Directive | Purpose |
+|-----------|---------|
+| `@speculativeRules` | Emit the Speculation Rules `<script>` block. |
+| `@resourceHints` | Emit registered resource hints. |
+| `@perfScript($src, $strategy)` | Register and emit a strategy-loaded script. |
+| `@perfMonitor` | Inject the RUM monitor bootstrap script. |
+| `@perfMetricsChart($metric)` | Emit a metrics chart for a Web Vitals metric. |
+
+---
+
+## Livewire Components
+
+| Component | Description |
+|-----------|-------------|
+| `perf-performance-dashboard` | Top-level dashboard with tabs. |
+| `perf-metrics-chart` | Time-series chart for a single metric. |
+| `perf-cache-manager` | Browse and invalidate cached pages/fragments. |
+| `perf-query-analyzer` | Inspect slow queries and N+1 offenders. |
+| `perf-recommendations-panel` | Human-readable recommendations from collected metrics. |
+
+Livewire itself is a suggested (not required) dependency — the components only
+register when Livewire is present.
+
+---
+
+## Artisan Commands
+
+| Command | Description |
+|---------|-------------|
+| `perf:generate-webp` | Bulk-convert existing images to WebP. |
+| `perf:critical-css` | Extract critical CSS for a URL. |
+| `perf:warm-cache` | Warm the page cache. |
+| `perf:purge-cache` | Purge caches by pattern. |
+| `perf:suggest-indexes` | Analyze recent queries and suggest indexes. |
+| `perf:aggregate-metrics` | Aggregate raw metrics into hourly/daily buckets. |
+
+Every command supports `--help` for full option details.
+
+---
+
+## Middleware
+
+Two named middleware aliases ship with the package:
+
+| Alias | Class | Purpose |
+|-------|-------|---------|
+| `perf.minify` | `MinifyHtml` | Minify the response body. |
+| `perf.early-hints` | `EarlyHints` | Emit HTTP 103 Early Hints before the response body. |
+
+Apply them to route groups:
+
+```php
+Route::middleware( [ 'web', 'perf.minify', 'perf.early-hints' ] )->group( function () {
+    // ...
+} );
+```
+
+Additional middleware — `DetectSlowQueries`, `InjectResourceHints`,
+`PageCache` — can be applied via the full FQCN.
+
+---
 
 ## Events
 
-The package dispatches the following events that applications can listen for:
+The package dispatches these events for applications to listen for:
 
-- `ImageOptimized`
-- `CacheWarmed`
-- `CachePurged`
-- `SlowQueryDetected`
-- `N1QueryDetected`
-- `PerformanceThresholdExceeded`
+| Event | Payload |
+|-------|---------|
+| `ImageOptimized` | `path`, `formats`, `sizes` |
+| `CacheWarmed` | `url`, `duration_ms` |
+| `CachePurged` | `pattern`, `count` |
+| `SlowQueryDetected` | `query`, `time_ms`, `bindings` |
+| `N1QueryDetected` | `query_normalized`, `count`, `route` |
+| `PerformanceThresholdExceeded` | `metric`, `value`, `threshold` |
+
+Registered internally:
+
+| Listener | Trigger |
+|----------|---------|
+| `OptimizeUploadedMedia` | Media-library Media model `created` event; also `MediaUploaded` if the future event class exists. |
+
+---
+
+## Helper Functions
+
+Global helpers that mirror the facade. Use them in templates and lightweight
+application code where dependency injection is impractical.
+
+| Function | Description |
+|----------|-------------|
+| `performance()` | Resolve the PerformanceService. |
+| `perfFeatureEnabled(string $feature)` | Check whether a feature toggle is on. |
+| `perfOptimizeImage(string $path, array $options = [])` | Run the optimization pipeline. |
+| `perfConvertToWebP(string $path, int $quality = 80)` | Convert to WebP. |
+| `perfConvertToAvif(string $path, int $quality = 70)` | Convert to AVIF. |
+| `perfGetDominantColor(string $path)` | Extract dominant color hex. |
+| `perfGetResponsiveSrcset(string $path, array $sizes)` | Build a `srcset` string. |
+| `perfRemember(string $key, int $ttl, Closure $callback)` | Cache remember. |
+| `perfRememberForever(string $key, Closure $callback)` | Cache remember forever. |
+| `perfInvalidateCache(string $key)` | Invalidate a cache key. |
+| `perfFlushCache()` | Flush the whole cache store. |
+| `perfFragmentRemember(string $key, int $ttl, Closure $callback, array $tags = [])` | Fragment cache. |
+| `perfInvalidatePageCache(string $pattern)` | Invalidate page cache entries by pattern. |
+| `perfFlushPageCache()` | Flush all page cache entries. |
+| `perfInvalidateFragmentsByTag(string $tag)` | Invalidate fragments by tag. |
+| `perfWarmPageCache(array $urls)` | Warm the page cache. |
+| `perfRecordMetric(string $name, float $value, array $context = [])` | Record a custom RUM metric. |
+| `perfGetRecommendations()` | Get performance recommendations. |
+
+---
+
+## Troubleshooting
+
+### GD/Imagick not installed
+
+Image optimization requires either `ext-gd` (default) or `ext-imagick`. Choose
+the driver in config:
+
+```php
+'images' => [ 'driver' => 'imagick' ],
+```
+
+Check the driver's format support at runtime:
+
+```php
+Performance::images()->supportsFormat( 'avif' );
+```
+
+### Media library integration seems dormant
+
+Check the detector's status:
+
+```php
+app( \ArtisanPackUI\Performance\Services\MediaLibraryDetector::class )->status();
+// [
+//     'installed' => true,
+//     'enabled'   => true,
+//     'source'    => 'auto',
+// ]
+```
+
+If `installed` is false, the media-library package isn't autoloadable. If
+`enabled` is false, the `media_library_integration.enabled` config value is
+`false` — set it to `null` for auto-detect or `true` to force on.
+
+### Optimized images not appearing on the Media model
+
+Check that the migration ran (`php artisan migrate`) and that the target
+`Media` model uses the `HasOptimizedMedia` trait. Rows uploaded before the
+migration ran will keep their `optimization_status = pending` until they
+are re-uploaded or manually re-queued via `OptimizeMediaJob::dispatch($media)`.
+
+### Dashboard shows no data
+
+The RUM collector fires from the client-side bundle. Publish it and include
+it in your layout:
+
+```bash
+php artisan vendor:publish --tag=artisanpack-performance-js
+```
+
+```blade
+@perfMonitor
+```
+
+Metrics are aggregated by `perf:aggregate-metrics` — schedule it every hour
+(or match `aggregation_interval`) via Laravel's task scheduler.
+
+### Page cache serving stale content
+
+Reduce the TTL, exclude the route under `page_cache.exclude_routes`, or
+invalidate the pattern:
+
+```php
+Performance::invalidatePageCache( '/products/*' );
+```
+
+### Slow queries not being logged
+
+The logger is opt-in. Confirm:
+
+```php
+config( 'artisanpack.performance.database.slow_query_logging.enabled' );      // true
+config( 'artisanpack.performance.database.slow_query_logging.threshold_ms' ); // 100
+```
+
+And make sure the `performance` log channel is defined in `config/logging.php`
+if you configured `log_channel` to `performance`.
+
+---
+
+## FAQ
+
+**Do I have to use every feature?**  
+No — every feature is opt-in and toggled independently. Enable only what you need.
+
+**Does the package replace a CDN?**  
+No. It complements a CDN. Serve WebP/AVIF variants from your CDN and let the
+package handle generation.
+
+**Can I use the RUM collector without the dashboard?**  
+Yes. Set `monitoring.enabled = true` and `dashboard.enabled = false`. Query
+`performance_metrics` directly, or read from the `MetricsAggregator` service.
+
+**Does the media-library integration work with S3?**  
+The current implementation reads the source file from a disk exposing a local
+`path()`. Remote disks (S3, GCS) are supported for storage but the
+optimization job needs a local copy — download to a temp file and dispatch
+`OptimizeImageJob` against that path in the interim. Native remote-disk
+support is planned.
+
+**Will enabling all features slow down my app?**  
+Only if you enable expensive features (monitoring, N+1 detection) with an
+aggressive `sample_rate` or `threshold`. Start conservative and increase as
+you validate impact.
+
+**How do I disable the package temporarily?**  
+Set every `PERF_*` env var to `false` and clear config cache. The service
+provider still boots but no listeners, middleware, or observers activate.
+
+---
 
 ## Contributing
 

--- a/database/migrations/2026_01_01_000006_add_performance_columns_to_media_table.php
+++ b/database/migrations/2026_01_01_000006_add_performance_columns_to_media_table.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Add performance columns to the media library `media` table.
+ *
+ * Adds the optimization metadata the Performance package writes back to each
+ * media row after processing an upload: dominant color for LQIP placeholders,
+ * a lifecycle status (`pending` → `processing` → `completed`/`failed`), a
+ * completion timestamp, and JSON maps for the produced formats and sizes.
+ *
+ * The migration is a no-op when the media-library package's `media` table
+ * is absent, so applications that pull the Performance package without
+ * media-library never fail their migrate step.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Runs the migration.
+     *
+     * @since 1.0.0
+     */
+    public function up(): void
+    {
+        if ( ! Schema::hasTable( 'media' ) ) {
+            return;
+        }
+
+        Schema::table( 'media', function ( Blueprint $table ): void {
+            if ( ! Schema::hasColumn( 'media', 'dominant_color' ) ) {
+                $table->string( 'dominant_color', 7 )->nullable();
+            }
+
+            if ( ! Schema::hasColumn( 'media', 'optimization_status' ) ) {
+                $table->string( 'optimization_status' )->default( 'pending' );
+            }
+
+            if ( ! Schema::hasColumn( 'media', 'optimized_at' ) ) {
+                $table->timestamp( 'optimized_at' )->nullable();
+            }
+
+            if ( ! Schema::hasColumn( 'media', 'optimized_formats' ) ) {
+                $table->json( 'optimized_formats' )->nullable();
+            }
+
+            if ( ! Schema::hasColumn( 'media', 'optimized_sizes' ) ) {
+                $table->json( 'optimized_sizes' )->nullable();
+            }
+        } );
+    }
+
+    /**
+     * Reverses the migration.
+     *
+     * @since 1.0.0
+     */
+    public function down(): void
+    {
+        if ( ! Schema::hasTable( 'media' ) ) {
+            return;
+        }
+
+        Schema::table( 'media', function ( Blueprint $table ): void {
+            $columns = [
+                'dominant_color',
+                'optimization_status',
+                'optimized_at',
+                'optimized_formats',
+                'optimized_sizes',
+            ];
+
+            foreach ( $columns as $column ) {
+                if ( Schema::hasColumn( 'media', $column ) ) {
+                    $table->dropColumn( $column );
+                }
+            }
+        } );
+    }
+};

--- a/src/Jobs/OptimizeMediaJob.php
+++ b/src/Jobs/OptimizeMediaJob.php
@@ -31,6 +31,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Throwable;
 
@@ -180,6 +181,11 @@ class OptimizeMediaJob implements ShouldQueue
     /**
      * Persists the given lifecycle status back onto the media row.
      *
+     * `optimized_at` is only touched when the run just completed; a
+     * `processing` or `failed` write preserves the previous timestamp so
+     * a retry that fails after a successful earlier run doesn't erase
+     * the last-known-good freshness signal.
+     *
      * Silently no-ops when the target column is not present — applications
      * that pull the Performance package without running the additive media
      * migration should not throw at runtime.
@@ -188,10 +194,13 @@ class OptimizeMediaJob implements ShouldQueue
      */
     protected function writeStatus( string $status ): void
     {
-        $this->safelyUpdateAttributes( [
-            'optimization_status' => $status,
-            'optimized_at'        => MediaOptimizationStatus::COMPLETED === $status ? Carbon::now() : null,
-        ] );
+        $attributes = [ 'optimization_status' => $status ];
+
+        if ( MediaOptimizationStatus::COMPLETED === $status ) {
+            $attributes['optimized_at'] = Carbon::now();
+        }
+
+        $this->safelyUpdateAttributes( $attributes );
     }
 
     /**
@@ -358,11 +367,18 @@ class OptimizeMediaJob implements ShouldQueue
     /**
      * Writes attributes back to the media row, ignoring absent columns.
      *
-     * We can't `Schema::hasColumn()` here without knowing the table name, so
-     * catch the resulting `QueryException` when the migration hasn't been
-     * run and swallow it — the failure signal is "job succeeded but
-     * couldn't persist metadata", which the caller can also see via the
-     * absence of the timestamp.
+     * The most common cause of a `save()` failure here is the additive
+     * `media` migration not having been run — column doesn't exist,
+     * SQLSTATE fires, and the job should still report success on its
+     * primary work (deriving files). Any failure is logged at warning
+     * level so operators aren't blind to migration gaps, connection
+     * issues, or unrelated write errors.
+     *
+     * Also merges casts for the trait-managed columns on the fly so the
+     * write works even when the consuming model class doesn't `use
+     * HasOptimizedMedia` (e.g., the vanilla vendor `Media` model). Without
+     * casts, an array bound to a JSON column relies on undocumented MySQL
+     * grammar behavior and fails outright on SQLite/PostgreSQL.
      *
      * @since 1.0.0
      *
@@ -374,15 +390,26 @@ class OptimizeMediaJob implements ShouldQueue
             return;
         }
 
+        $this->media->mergeCasts( [
+            'optimized_formats' => 'array',
+            'optimized_sizes'   => 'array',
+            'optimized_at'      => 'datetime',
+        ] );
+
         foreach ( $attributes as $key => $value ) {
             $this->media->setAttribute( $key, $value );
         }
 
         try {
             $this->media->save();
-        } catch ( Throwable ) {
-            // Metadata columns absent (migration not run) — swallow to avoid
-            // failing the whole job when only the write-back is broken.
+        } catch ( Throwable $e ) {
+            Log::warning(
+                'artisanpack-ui/performance: media optimization write-back failed',
+                [
+                    'media_id' => $this->media->getKey(),
+                    'error'    => $e->getMessage(),
+                ],
+            );
         }
     }
 }

--- a/src/Jobs/OptimizeMediaJob.php
+++ b/src/Jobs/OptimizeMediaJob.php
@@ -308,8 +308,16 @@ class OptimizeMediaJob implements ShouldQueue
 
         if ( method_exists( $storage, 'path' ) && '' !== $filePath ) {
             $sourceAbsolute = $storage->path( $filePath );
-            $storageRoot    = str_replace( $filePath, '', $sourceAbsolute );
-            $storageRoot    = rtrim( $storageRoot, DIRECTORY_SEPARATOR );
+
+            // Trim only the KNOWN trailing suffix — a naive
+            // `str_replace( $filePath, '', $sourceAbsolute )` would strip
+            // every occurrence of `$filePath` text (breaking on disks whose
+            // root contains a repeated segment) and would silently miss
+            // Windows-style separators.
+            $storageRoot = str_ends_with( $sourceAbsolute, $filePath )
+                ? substr( $sourceAbsolute, 0, -strlen( $filePath ) )
+                : $sourceAbsolute;
+            $storageRoot = rtrim( $storageRoot, DIRECTORY_SEPARATOR );
 
             if ( '' !== $storageRoot && str_starts_with( $absolutePath, $storageRoot . DIRECTORY_SEPARATOR ) ) {
                 $relative = substr( $absolutePath, strlen( $storageRoot ) + 1 );

--- a/src/Jobs/OptimizeMediaJob.php
+++ b/src/Jobs/OptimizeMediaJob.php
@@ -1,0 +1,388 @@
+<?php
+
+/**
+ * Optimize media queued job.
+ *
+ * Media-library-aware counterpart to `OptimizeImageJob`: runs the full image
+ * optimization pipeline against an uploaded `Media` row and writes the
+ * derivative paths, dominant color, and lifecycle status back onto the row
+ * so downstream views can consume them through `HasOptimizedMedia`.
+ *
+ * The job is only useful when the artisanpack-ui/media-library package is
+ * installed — dispatch is guarded from the `OptimizeUploadedMedia` listener
+ * so the job never lands on the queue in isolation.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Jobs;
+
+use ArtisanPackUI\Performance\Services\ImageService;
+use ArtisanPackUI\Performance\Support\MediaOptimizationStatus;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
+use Throwable;
+
+/**
+ * Optimize media job class.
+ *
+ *
+ * @since      1.0.0
+ */
+class OptimizeMediaJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * Number of times the job may be attempted.
+     *
+     * @since 1.0.0
+     */
+    public int $tries;
+
+    /**
+     * Seconds between retry attempts.
+     *
+     * @since 1.0.0
+     */
+    public int $backoff;
+
+    /**
+     * Creates a new job instance.
+     *
+     * @since 1.0.0
+     *
+     * @param  Model  $media  The media-library `Media` row to optimize.
+     * @param  array<string, mixed>  $options  Optional overrides forwarded to `ImageService::optimize()`:
+     *                                          - `sizes` array<int> Widths to generate.
+     *                                          - `formats` array<string> Formats to generate.
+     *                                          - `quality` int Quality override.
+     *                                          - `extract_dominant_color` bool Whether to extract a dominant color hex.
+     */
+    public function __construct(
+        public Model $media,
+        public array $options = [],
+    ) {
+        $this->onQueue( (string) config( 'artisanpack.performance.images.queue', 'default' ) );
+        $this->tries   = (int) config( 'artisanpack.performance.images.jobs.tries', 3 );
+        $this->backoff = (int) config( 'artisanpack.performance.images.jobs.backoff', 30 );
+    }
+
+    /**
+     * Executes the job.
+     *
+     * @since 1.0.0
+     *
+     * @param  ImageService  $images  Image service resolved from the container.
+     */
+    public function handle( ImageService $images ): void
+    {
+        $path = $this->resolveSourcePath();
+
+        if ( null === $path ) {
+            $this->writeStatus( MediaOptimizationStatus::FAILED );
+
+            return;
+        }
+
+        $this->writeStatus( MediaOptimizationStatus::PROCESSING );
+
+        try {
+            $result = $images->optimize( $path, $this->optimizeOptions() );
+        } catch ( Throwable $e ) {
+            $this->writeStatus( MediaOptimizationStatus::FAILED );
+
+            throw $e;
+        }
+
+        $dominant = $this->extractDominantColor( $images, $path );
+
+        $this->applyResults( $result, $dominant );
+    }
+
+    /**
+     * Marks the job as failed on the media row when Laravel gives up retrying.
+     *
+     * @since 1.0.0
+     */
+    public function failed( ?Throwable $exception = null ): void
+    {
+        $this->writeStatus( MediaOptimizationStatus::FAILED );
+    }
+
+    /**
+     * Resolves the media row's storage location to an absolute filesystem path.
+     *
+     * Returns `null` when the file cannot be located — either the media row
+     * lacks the columns needed to address the file, or the disk driver
+     * doesn't expose a local path (e.g. a remote S3 disk). Remote-disk
+     * support would require downloading a temp copy, which is deferred to a
+     * future phase.
+     *
+     * @since 1.0.0
+     */
+    protected function resolveSourcePath(): ?string
+    {
+        $filePath = $this->media->getAttribute( 'file_path' );
+
+        if ( ! is_string( $filePath ) || '' === $filePath ) {
+            return null;
+        }
+
+        $disk = (string) ( $this->media->getAttribute( 'disk' ) ?? 'public' );
+
+        try {
+            $storage = Storage::disk( $disk );
+        } catch ( Throwable ) {
+            return null;
+        }
+
+        if ( ! method_exists( $storage, 'path' ) ) {
+            return null;
+        }
+
+        $absolute = $storage->path( $filePath );
+
+        return is_file( $absolute ) && is_readable( $absolute ) ? $absolute : null;
+    }
+
+    /**
+     * Builds the option set forwarded to `ImageService::optimize()`.
+     *
+     * @since 1.0.0
+     *
+     * @return array<string, mixed>
+     */
+    protected function optimizeOptions(): array
+    {
+        $options = $this->options;
+
+        // Trait-only key — never forward it to the ImageService contract.
+        unset( $options['extract_dominant_color'] );
+
+        return $options;
+    }
+
+    /**
+     * Persists the given lifecycle status back onto the media row.
+     *
+     * Silently no-ops when the target column is not present — applications
+     * that pull the Performance package without running the additive media
+     * migration should not throw at runtime.
+     *
+     * @since 1.0.0
+     */
+    protected function writeStatus( string $status ): void
+    {
+        $this->safelyUpdateAttributes( [
+            'optimization_status' => $status,
+            'optimized_at'        => MediaOptimizationStatus::COMPLETED === $status ? Carbon::now() : null,
+        ] );
+    }
+
+    /**
+     * Writes the optimization payload back onto the media row.
+     *
+     * @since 1.0.0
+     *
+     * @param  array<string, mixed>  $result  Payload returned by `ImageService::optimize()`.
+     * @param  string|null  $dominant  Extracted dominant color (or null when extraction was disabled/failed).
+     */
+    protected function applyResults( array $result, ?string $dominant ): void
+    {
+        $formatsMap = $this->buildFormatsMap( $result['variants'] ?? [] );
+        $sizesMap   = $this->buildSizesMap( $result['variants'] ?? [] );
+
+        $updates = [
+            'optimization_status' => MediaOptimizationStatus::COMPLETED,
+            'optimized_at'        => Carbon::now(),
+            'optimized_formats'   => $formatsMap,
+            'optimized_sizes'     => $sizesMap,
+        ];
+
+        if ( null !== $dominant ) {
+            $updates['dominant_color'] = $dominant;
+        }
+
+        $this->safelyUpdateAttributes( $updates );
+    }
+
+    /**
+     * Groups the produced variants by format into a `{format => {width => url}}` map.
+     *
+     * @since 1.0.0
+     *
+     * @param  array<int, array{path: string, format: string, width: int}>  $variants
+     *
+     * @return array<string, array<string, string>>
+     */
+    protected function buildFormatsMap( array $variants ): array
+    {
+        $map = [];
+
+        foreach ( $variants as $variant ) {
+            if ( ! isset( $variant['path'], $variant['format'], $variant['width'] ) ) {
+                continue;
+            }
+
+            $url = $this->urlForVariant( (string) $variant['path'] );
+
+            if ( null === $url ) {
+                continue;
+            }
+
+            $map[ (string) $variant['format'] ][ (string) $variant['width'] ] = $url;
+        }
+
+        return $map;
+    }
+
+    /**
+     * Groups the produced variants into a `{width => url}` map keyed by the smallest width.
+     *
+     * The source-format resize (the first pass in the optimize pipeline) is
+     * the natural candidate here — the responsive `srcset` is the same
+     * regardless of which modern format the browser picks. We take the
+     * first format's map so the shape is deterministic; a future phase may
+     * store a dedicated source-format list.
+     *
+     * @since 1.0.0
+     *
+     * @param  array<int, array{path: string, format: string, width: int}>  $variants
+     *
+     * @return array<string, string>
+     */
+    protected function buildSizesMap( array $variants ): array
+    {
+        $byFormat = $this->buildFormatsMap( $variants );
+
+        if ( empty( $byFormat ) ) {
+            return [];
+        }
+
+        return reset( $byFormat );
+    }
+
+    /**
+     * Converts a filesystem path into a publicly-servable URL when possible.
+     *
+     * Returns the storage disk URL when the variant lives under the media
+     * row's disk root; falls back to a relative public URL when the
+     * variant lives under `public_path()`; otherwise returns null.
+     *
+     * @since 1.0.0
+     */
+    protected function urlForVariant( string $absolutePath ): ?string
+    {
+        $disk     = (string) ( $this->media->getAttribute( 'disk' ) ?? 'public' );
+        $filePath = (string) $this->media->getAttribute( 'file_path' );
+
+        try {
+            $storage = Storage::disk( $disk );
+        } catch ( Throwable ) {
+            return null;
+        }
+
+        if ( method_exists( $storage, 'path' ) && '' !== $filePath ) {
+            $sourceAbsolute = $storage->path( $filePath );
+            $storageRoot    = str_replace( $filePath, '', $sourceAbsolute );
+            $storageRoot    = rtrim( $storageRoot, DIRECTORY_SEPARATOR );
+
+            if ( '' !== $storageRoot && str_starts_with( $absolutePath, $storageRoot . DIRECTORY_SEPARATOR ) ) {
+                $relative = substr( $absolutePath, strlen( $storageRoot ) + 1 );
+                $relative = str_replace( DIRECTORY_SEPARATOR, '/', $relative );
+
+                if ( method_exists( $storage, 'url' ) ) {
+                    try {
+                        return $storage->url( $relative );
+                    } catch ( Throwable ) {
+                        // Fall through to public-path handling.
+                    }
+                }
+            }
+        }
+
+        if ( function_exists( 'public_path' ) ) {
+            $publicRoot = rtrim( public_path(), DIRECTORY_SEPARATOR );
+
+            if ( '' !== $publicRoot && str_starts_with( $absolutePath, $publicRoot . DIRECTORY_SEPARATOR ) ) {
+                $relative = substr( $absolutePath, strlen( $publicRoot ) );
+
+                return '/' . ltrim( str_replace( DIRECTORY_SEPARATOR, '/', $relative ), '/' );
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Extracts the dominant color when the option is enabled and encoding permits.
+     *
+     * Returns `null` on failure so a broken extractor doesn't mark the whole
+     * optimization job as failed — the derivatives are still valuable
+     * without the LQIP color.
+     *
+     * @since 1.0.0
+     */
+    protected function extractDominantColor( ImageService $images, string $path ): ?string
+    {
+        $shouldExtract = array_key_exists( 'extract_dominant_color', $this->options )
+            ? (bool) $this->options['extract_dominant_color']
+            : (bool) config( 'artisanpack.performance.images.dominant_color.enabled', true );
+
+        if ( ! $shouldExtract ) {
+            return null;
+        }
+
+        try {
+            return $images->extractDominantColor( $path );
+        } catch ( Throwable ) {
+            return null;
+        }
+    }
+
+    /**
+     * Writes attributes back to the media row, ignoring absent columns.
+     *
+     * We can't `Schema::hasColumn()` here without knowing the table name, so
+     * catch the resulting `QueryException` when the migration hasn't been
+     * run and swallow it — the failure signal is "job succeeded but
+     * couldn't persist metadata", which the caller can also see via the
+     * absence of the timestamp.
+     *
+     * @since 1.0.0
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    protected function safelyUpdateAttributes( array $attributes ): void
+    {
+        if ( ! $this->media->exists ) {
+            return;
+        }
+
+        foreach ( $attributes as $key => $value ) {
+            $this->media->setAttribute( $key, $value );
+        }
+
+        try {
+            $this->media->save();
+        } catch ( Throwable ) {
+            // Metadata columns absent (migration not run) — swallow to avoid
+            // failing the whole job when only the write-back is broken.
+        }
+    }
+}

--- a/src/Listeners/OptimizeUploadedMedia.php
+++ b/src/Listeners/OptimizeUploadedMedia.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * Listener that runs the optimization pipeline against uploaded media rows.
+ *
+ * Wired from `PerformanceServiceProvider::registerMediaLibraryIntegration()`
+ * to fire whenever the artisanpack-ui/media-library package publishes a
+ * new `Media` row. The listener guards on the media_library_integration
+ * config surface so operators can force the wiring off without needing to
+ * uninstall the media-library package; it then dispatches
+ * `OptimizeMediaJob` to run the actual encoding work off the request
+ * thread.
+ *
+ * The `__invoke` entrypoint accepts either an Eloquent-created `Media`
+ * model (the standard Laravel model-event payload) or a hypothetical
+ * future `MediaUploaded` event exposing a `media` property so the same
+ * class can serve both integration paths.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Listeners;
+
+use ArtisanPackUI\Performance\Jobs\OptimizeMediaJob;
+use ArtisanPackUI\Performance\Services\MediaLibraryDetector;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Listener class for post-upload media optimization.
+ *
+ *
+ * @since      1.0.0
+ */
+class OptimizeUploadedMedia
+{
+    /**
+     * Media library detector.
+     *
+     * @since 1.0.0
+     */
+    protected MediaLibraryDetector $detector;
+
+    /**
+     * Creates a new listener instance.
+     *
+     * @since 1.0.0
+     */
+    public function __construct( MediaLibraryDetector $detector )
+    {
+        $this->detector = $detector;
+    }
+
+    /**
+     * Handles the payload.
+     *
+     * Accepts either a bare Media model (from Eloquent's `created` model
+     * event) or an event object exposing a `media` property. Non-image
+     * media rows are ignored — the Performance package has nothing useful
+     * to do with a video or PDF upload at this layer.
+     *
+     * @since 1.0.0
+     *
+     * @param  Model|object  $payload  Media model instance or wrapping event.
+     */
+    public function __invoke( object $payload ): void
+    {
+        if ( ! $this->detector->shouldOptimizeOnUpload() ) {
+            return;
+        }
+
+        $media = $this->resolveMedia( $payload );
+
+        if ( null === $media ) {
+            return;
+        }
+
+        if ( ! $this->isImageMedia( $media ) ) {
+            return;
+        }
+
+        OptimizeMediaJob::dispatch( $media, $this->buildJobOptions() );
+    }
+
+    /**
+     * Alias for `__invoke` so the class works with `Event::listen(..., handle)`.
+     *
+     * Laravel's event dispatcher accepts either an invokable class or a
+     * `handle` method — exposing both means the listener can be registered
+     * with either style without extra glue in the service provider.
+     *
+     * @since 1.0.0
+     *
+     * @param  Model|object  $payload  Media model instance or wrapping event.
+     */
+    public function handle( object $payload ): void
+    {
+        $this->__invoke( $payload );
+    }
+
+    /**
+     * Resolves the concrete Media model from the incoming payload.
+     *
+     * @since 1.0.0
+     */
+    protected function resolveMedia( object $payload ): ?Model
+    {
+        if ( $payload instanceof Model ) {
+            return $payload;
+        }
+
+        if ( property_exists( $payload, 'media' ) && $payload->media instanceof Model ) {
+            return $payload->media;
+        }
+
+        return null;
+    }
+
+    /**
+     * Reports whether the given media row represents an image.
+     *
+     * Prefers the model's own `isImage()` helper (media-library ships one);
+     * falls back to a mime-type inspection when the helper isn't available
+     * so consumers using a custom model still get the guard.
+     *
+     * @since 1.0.0
+     */
+    protected function isImageMedia( Model $media ): bool
+    {
+        if ( method_exists( $media, 'isImage' ) ) {
+            return (bool) $media->isImage();
+        }
+
+        $mime = $media->getAttribute( 'mime_type' );
+
+        return is_string( $mime ) && str_starts_with( $mime, 'image/' );
+    }
+
+    /**
+     * Builds the option array forwarded to `OptimizeMediaJob`.
+     *
+     * @since 1.0.0
+     *
+     * @return array<string, mixed>
+     */
+    protected function buildJobOptions(): array
+    {
+        $sizes = (array) config( 'artisanpack.performance.images.sizes', [] );
+
+        $formats = [];
+
+        foreach ( (array) config( 'artisanpack.performance.images.formats', [] ) as $key => $settings ) {
+            if ( ! empty( $settings['enabled'] ) ) {
+                $formats[] = (string) $key;
+            }
+        }
+
+        $extract = (bool) config( 'artisanpack.performance.images.dominant_color.enabled', true );
+
+        return [
+            'sizes'                  => array_values( array_map( 'intval', $sizes ) ),
+            'formats'                => $formats,
+            'extract_dominant_color' => $extract,
+        ];
+    }
+}

--- a/src/Listeners/OptimizeUploadedMedia.php
+++ b/src/Listeners/OptimizeUploadedMedia.php
@@ -29,6 +29,8 @@ namespace ArtisanPackUI\Performance\Listeners;
 use ArtisanPackUI\Performance\Jobs\OptimizeMediaJob;
 use ArtisanPackUI\Performance\Services\MediaLibraryDetector;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Storage;
+use Throwable;
 
 /**
  * Listener class for post-upload media optimization.
@@ -83,7 +85,20 @@ class OptimizeUploadedMedia
             return;
         }
 
-        OptimizeMediaJob::dispatch( $media, $this->buildJobOptions() );
+        // Skip factory/seeder rows whose file_path doesn't resolve on disk —
+        // the encoder would immediately fail on those and the queue would fill
+        // with pointless jobs during test runs.
+        if ( ! $this->hasReadableSource( $media ) ) {
+            return;
+        }
+
+        // afterCommit() defers the actual push until the enclosing DB
+        // transaction commits (a no-op outside a transaction). Without it,
+        // a queue worker on a separate connection can pick the job up
+        // before the media row is visible and blow up in SerializesModels'
+        // findOrFail() call.
+        OptimizeMediaJob::dispatch( $media, $this->buildJobOptions() )
+            ->afterCommit();
     }
 
     /**
@@ -143,6 +158,14 @@ class OptimizeUploadedMedia
     /**
      * Builds the option array forwarded to `OptimizeMediaJob`.
      *
+     * Accepts both shapes of the `images.formats` config:
+     *   - Documented shape: `['webp' => ['enabled' => true, ...], ...]`.
+     *   - Flat-list shape:  `['webp', 'avif']`.
+     *
+     * The flat-list branch prevents the silent-empty-formats failure mode
+     * an operator would otherwise hit by simplifying the config without
+     * realizing the enabled/quality subkeys are load-bearing.
+     *
      * @since 1.0.0
      *
      * @return array<string, mixed>
@@ -154,7 +177,13 @@ class OptimizeUploadedMedia
         $formats = [];
 
         foreach ( (array) config( 'artisanpack.performance.images.formats', [] ) as $key => $settings ) {
-            if ( ! empty( $settings['enabled'] ) ) {
+            if ( is_string( $settings ) && '' !== $settings ) {
+                $formats[] = strtolower( $settings );
+
+                continue;
+            }
+
+            if ( is_array( $settings ) && ! empty( $settings['enabled'] ) ) {
                 $formats[] = (string) $key;
             }
         }
@@ -163,8 +192,36 @@ class OptimizeUploadedMedia
 
         return [
             'sizes'                  => array_values( array_map( 'intval', $sizes ) ),
-            'formats'                => $formats,
+            'formats'                => array_values( array_unique( $formats ) ),
             'extract_dominant_color' => $extract,
         ];
+    }
+
+    /**
+     * Reports whether the media row points at a file that actually exists on disk.
+     *
+     * Returns `true` when `file_path` is set and the configured `disk`
+     * confirms the file exists; returns `false` for factory/seeder-created
+     * rows whose file_path is a placeholder. Errors from the storage
+     * layer are treated as "unreadable" so a transient disk hiccup skips
+     * the dispatch rather than corrupting the queue.
+     *
+     * @since 1.0.0
+     */
+    protected function hasReadableSource( Model $media ): bool
+    {
+        $filePath = $media->getAttribute( 'file_path' );
+
+        if ( ! is_string( $filePath ) || '' === $filePath ) {
+            return false;
+        }
+
+        $disk = (string) ( $media->getAttribute( 'disk' ) ?? 'public' );
+
+        try {
+            return Storage::disk( $disk )->exists( $filePath );
+        } catch ( Throwable ) {
+            return false;
+        }
     }
 }

--- a/src/PerformanceServiceProvider.php
+++ b/src/PerformanceServiceProvider.php
@@ -305,31 +305,39 @@ class PerformanceServiceProvider extends ServiceProvider
     /**
      * Wires the `OptimizeUploadedMedia` listener into the media-library upload path.
      *
-     * media-library does not (yet) publish a Laravel event on upload, so we
-     * hook Eloquent's `created` model event on its `Media` model — that
-     * fires from every code path that persists a new row (uploads,
-     * seeders, importers). If a future media-library release ships a
-     * dedicated `MediaUploaded` event we listen for that too, so
-     * consumers get the same optimization behavior once they upgrade
-     * without needing to reconfigure anything on our side.
+     * Chooses a single dispatch source to prevent duplicate job runs when
+     * both hooks are available:
+     *
+     *   1. If media-library publishes a dedicated `MediaUploaded` event,
+     *      subscribe to it — the intent-carrying event is preferred over
+     *      the generic Eloquent model event.
+     *   2. Otherwise, fall back to the `Media::created` Eloquent event.
+     *
+     * The fallback closure captures `$app` (not `$this`) as a `static`
+     * closure so the ServiceProvider instance isn't kept alive by the
+     * model's global event registry under Octane / long-running workers.
      *
      * @since 1.0.0
      */
     protected function wireMediaLibraryListeners(): void
     {
-        $mediaModel = '\ArtisanPackUI\MediaLibrary\Models\Media';
-
-        if ( class_exists( $mediaModel ) && method_exists( $mediaModel, 'created' ) ) {
-            $mediaModel::created( function ( $media ): void {
-                $this->app->make( OptimizeUploadedMedia::class )->handle( $media );
-            } );
-        }
-
         $uploadedEvent = '\ArtisanPackUI\MediaLibrary\Events\MediaUploaded';
 
         if ( class_exists( $uploadedEvent ) ) {
             $events = $this->app->make( 'events' );
             $events->listen( $uploadedEvent, [ OptimizeUploadedMedia::class, 'handle' ] );
+
+            return;
+        }
+
+        $mediaModel = '\ArtisanPackUI\MediaLibrary\Models\Media';
+
+        if ( class_exists( $mediaModel ) && method_exists( $mediaModel, 'created' ) ) {
+            $app = $this->app;
+
+            $mediaModel::created( static function ( $media ) use ( $app ): void {
+                $app->make( OptimizeUploadedMedia::class )->handle( $media );
+            } );
         }
     }
 

--- a/src/PerformanceServiceProvider.php
+++ b/src/PerformanceServiceProvider.php
@@ -39,6 +39,7 @@ use ArtisanPackUI\Performance\Http\Middleware\MinifyHtml;
 use ArtisanPackUI\Performance\Images\DominantColorExtractor;
 use ArtisanPackUI\Performance\Images\ResponsiveImageGenerator;
 use ArtisanPackUI\Performance\JavaScript\ScriptManager;
+use ArtisanPackUI\Performance\Listeners\OptimizeUploadedMedia;
 use ArtisanPackUI\Performance\Livewire\CacheManager as CacheManagerComponent;
 use ArtisanPackUI\Performance\Livewire\MetricsChart as MetricsChartComponent;
 use ArtisanPackUI\Performance\Livewire\PerformanceDashboard as PerformanceDashboardComponent;
@@ -298,8 +299,38 @@ class PerformanceServiceProvider extends ServiceProvider
             'generate_formats_on_upload' => $detector->shouldGenerateFormatsOnUpload(),
         ] );
 
-        // Actual listener wiring lands in a subsequent phase; the detector
-        // and the boot-level decision path are the surface #61 required.
+        $this->wireMediaLibraryListeners();
+    }
+
+    /**
+     * Wires the `OptimizeUploadedMedia` listener into the media-library upload path.
+     *
+     * media-library does not (yet) publish a Laravel event on upload, so we
+     * hook Eloquent's `created` model event on its `Media` model — that
+     * fires from every code path that persists a new row (uploads,
+     * seeders, importers). If a future media-library release ships a
+     * dedicated `MediaUploaded` event we listen for that too, so
+     * consumers get the same optimization behavior once they upgrade
+     * without needing to reconfigure anything on our side.
+     *
+     * @since 1.0.0
+     */
+    protected function wireMediaLibraryListeners(): void
+    {
+        $mediaModel = '\ArtisanPackUI\MediaLibrary\Models\Media';
+
+        if ( class_exists( $mediaModel ) && method_exists( $mediaModel, 'created' ) ) {
+            $mediaModel::created( function ( $media ): void {
+                $this->app->make( OptimizeUploadedMedia::class )->handle( $media );
+            } );
+        }
+
+        $uploadedEvent = '\ArtisanPackUI\MediaLibrary\Events\MediaUploaded';
+
+        if ( class_exists( $uploadedEvent ) ) {
+            $events = $this->app->make( 'events' );
+            $events->listen( $uploadedEvent, [ OptimizeUploadedMedia::class, 'handle' ] );
+        }
     }
 
     /**

--- a/src/Support/MediaOptimizationStatus.php
+++ b/src/Support/MediaOptimizationStatus.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Media optimization lifecycle status values.
+ *
+ * Small value-object-like class that owns the string constants written to
+ * the `media.optimization_status` column. Kept as a dedicated class rather
+ * than as trait constants because PHP disallows accessing trait constants
+ * from outside a class that uses the trait, and both the listener/job
+ * layer and consuming applications need to reference these values without
+ * `use`-ing the whole trait.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Support;
+
+/**
+ * Media optimization status constants.
+ *
+ *
+ * @since      1.0.0
+ */
+final class MediaOptimizationStatus
+{
+    /**
+     * Not yet processed.
+     *
+     * @since 1.0.0
+     */
+    public const PENDING = 'pending';
+
+    /**
+     * Currently being processed.
+     *
+     * @since 1.0.0
+     */
+    public const PROCESSING = 'processing';
+
+    /**
+     * All derivatives produced successfully.
+     *
+     * @since 1.0.0
+     */
+    public const COMPLETED = 'completed';
+
+    /**
+     * Optimization pipeline failed.
+     *
+     * @since 1.0.0
+     */
+    public const FAILED = 'failed';
+}

--- a/src/Traits/HasOptimizedMedia.php
+++ b/src/Traits/HasOptimizedMedia.php
@@ -35,13 +35,38 @@ use ArtisanPackUI\Performance\Support\MediaOptimizationStatus;
 trait HasOptimizedMedia
 {
     /**
+     * Boot hook that runs once per model instance to merge in the trait's
+     * casts for `optimized_formats`, `optimized_sizes`, and `optimized_at`.
+     *
+     * Registering the casts here means consuming models don't have to
+     * remember to add them by hand — the trait is self-contained and
+     * database writes go through the correct JSON/datetime encoding
+     * regardless of which model class the row is hydrated into.
+     *
+     * @since 1.0.0
+     */
+    public function initializeHasOptimizedMedia(): void
+    {
+        $this->mergeCasts( [
+            'optimized_formats' => 'array',
+            'optimized_sizes'   => 'array',
+            'optimized_at'      => 'datetime',
+        ] );
+    }
+
+    /**
      * Returns the URL of the optimized derivative for the given format/size.
      *
-     * Looks up the URL in the `optimized_formats` map first (format-specific
-     * variants like WebP or AVIF), then falls back to `optimized_sizes` when
-     * `$format` is null and only a size was requested. Returns `null` when
-     * no matching entry has been recorded — callers should typically fall
-     * back to the original media URL in that case.
+     * Lookup precedence:
+     *  1. When `$size` is provided, return the exact `optimized_formats[$format][$size]`
+     *     entry (or the size-only `optimized_sizes[$size]` entry when `$format` is null).
+     *  2. When only `$format` is provided and the entry is a `{width => url}` map, return
+     *     the URL for the LARGEST width — the natural "give me the best WebP" default.
+     *  3. When only `$format` is provided and the entry is a bare string, return it as-is
+     *     (older schema shape).
+     *
+     * Returns `null` when no matching entry has been recorded — callers should
+     * typically fall back to the original media URL in that case.
      *
      * @since 1.0.0
      *
@@ -54,14 +79,15 @@ trait HasOptimizedMedia
     {
         if ( null !== $format ) {
             $formats = $this->readOptimizedFormatsMap();
+            $entry   = $formats[ $format ] ?? null;
 
             if ( null === $size ) {
-                $entry = $formats[ $format ] ?? null;
+                if ( is_string( $entry ) ) {
+                    return $entry;
+                }
 
-                return is_string( $entry ) ? $entry : null;
+                return is_array( $entry ) ? $this->largestWidthUrl( $entry ) : null;
             }
-
-            $entry = $formats[ $format ] ?? null;
 
             if ( is_array( $entry ) ) {
                 $value = $entry[ (string) $size ] ?? null;
@@ -150,6 +176,37 @@ trait HasOptimizedMedia
         $value = $this->getAttribute( 'optimization_status' );
 
         return is_string( $value ) && '' !== $value ? $value : MediaOptimizationStatus::PENDING;
+    }
+
+    /**
+     * Picks the URL for the largest numeric width in a `{width => url}` map.
+     *
+     * Non-numeric keys and non-string values are skipped so the srcset
+     * contract stays well-formed even when the JSON blob was hand-edited.
+     *
+     * @since 1.0.0
+     *
+     * @param  array<string, mixed>  $entries  Width-keyed URL map.
+     */
+    protected function largestWidthUrl( array $entries ): ?string
+    {
+        $best      = null;
+        $bestWidth = -1;
+
+        foreach ( $entries as $width => $url ) {
+            if ( ! is_string( $url ) || '' === $url || ! is_numeric( $width ) ) {
+                continue;
+            }
+
+            $intWidth = (int) $width;
+
+            if ( $intWidth > $bestWidth ) {
+                $bestWidth = $intWidth;
+                $best      = $url;
+            }
+        }
+
+        return $best;
     }
 
     /**

--- a/src/Traits/HasOptimizedMedia.php
+++ b/src/Traits/HasOptimizedMedia.php
@@ -1,0 +1,235 @@
+<?php
+
+/**
+ * `HasOptimizedMedia` Eloquent trait.
+ *
+ * Add-on trait for the artisanpack-ui/media-library `Media` model that exposes
+ * the optimization metadata written by the Performance package's upload
+ * listener (`OptimizeUploadedMedia`) as convenient accessors: URLs for the
+ * generated derivatives, a compiled `srcset` string, the extracted dominant
+ * color, and the current lifecycle status.
+ *
+ * All accessors are read-only and safe to call whether or not optimization
+ * has run — every method returns a sensible empty/null result when the
+ * underlying columns are unpopulated, so views can render before the queued
+ * job completes without null-check gymnastics.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Traits;
+
+use ArtisanPackUI\Performance\Support\MediaOptimizationStatus;
+
+/**
+ * `HasOptimizedMedia` Eloquent trait.
+ *
+ *
+ * @since      1.0.0
+ */
+trait HasOptimizedMedia
+{
+    /**
+     * Returns the URL of the optimized derivative for the given format/size.
+     *
+     * Looks up the URL in the `optimized_formats` map first (format-specific
+     * variants like WebP or AVIF), then falls back to `optimized_sizes` when
+     * `$format` is null and only a size was requested. Returns `null` when
+     * no matching entry has been recorded — callers should typically fall
+     * back to the original media URL in that case.
+     *
+     * @since 1.0.0
+     *
+     * @param  string|null  $format  Format key (`webp`, `avif`, …) or null for the size-only map.
+     * @param  int|string|null  $size  Size key. Accepts either a symbolic name
+     *                                 (e.g. `large`) or a pixel width; matched
+     *                                 as a string against the JSON keys.
+     */
+    public function getOptimizedUrl( ?string $format = null, string|int|null $size = null ): ?string
+    {
+        if ( null !== $format ) {
+            $formats = $this->readOptimizedFormatsMap();
+
+            if ( null === $size ) {
+                $entry = $formats[ $format ] ?? null;
+
+                return is_string( $entry ) ? $entry : null;
+            }
+
+            $entry = $formats[ $format ] ?? null;
+
+            if ( is_array( $entry ) ) {
+                $value = $entry[ (string) $size ] ?? null;
+
+                return is_string( $value ) ? $value : null;
+            }
+
+            return null;
+        }
+
+        if ( null !== $size ) {
+            $sizes = $this->readOptimizedSizesMap();
+            $value = $sizes[ (string) $size ] ?? null;
+
+            return is_string( $value ) ? $value : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns a `srcset` attribute value built from the recorded sizes.
+     *
+     * When `$format` is provided the srcset is built from
+     * `optimized_formats[$format]` when that entry is a size-map; otherwise
+     * the base `optimized_sizes` map is used. Each entry is emitted as
+     * `<url> <width>w`. Returns an empty string when nothing is available so
+     * the attribute can be interpolated safely into a template.
+     *
+     * @since 1.0.0
+     *
+     * @param  string|null  $format  Optional format key (`webp`, `avif`, …).
+     */
+    public function getSrcset( ?string $format = null ): string
+    {
+        $entries = [];
+
+        if ( null !== $format ) {
+            $formats = $this->readOptimizedFormatsMap();
+            $entry   = $formats[ $format ] ?? null;
+
+            if ( is_array( $entry ) ) {
+                $entries = $entry;
+            }
+        }
+
+        if ( empty( $entries ) ) {
+            $entries = $this->readOptimizedSizesMap();
+        }
+
+        return $this->buildSrcsetFromMap( $entries );
+    }
+
+    /**
+     * Returns the extracted dominant color as a hex string.
+     *
+     * @since 1.0.0
+     */
+    public function getDominantColor(): ?string
+    {
+        $value = $this->getAttribute( 'dominant_color' );
+
+        return is_string( $value ) && '' !== $value ? $value : null;
+    }
+
+    /**
+     * Reports whether the optimization pipeline has completed successfully.
+     *
+     * @since 1.0.0
+     */
+    public function isOptimized(): bool
+    {
+        return MediaOptimizationStatus::COMPLETED === $this->getOptimizationStatus();
+    }
+
+    /**
+     * Returns the raw optimization lifecycle status.
+     *
+     * Defaults to `pending` when the column is empty or missing so callers can
+     * safely `match` on it without a null branch.
+     *
+     * @since 1.0.0
+     */
+    public function getOptimizationStatus(): string
+    {
+        $value = $this->getAttribute( 'optimization_status' );
+
+        return is_string( $value ) && '' !== $value ? $value : MediaOptimizationStatus::PENDING;
+    }
+
+    /**
+     * Reads and normalizes the `optimized_formats` JSON column into an array.
+     *
+     * The column is declared as `json` in the migration; Eloquent decodes it
+     * for us when the consuming model casts it as `array`/`json`, but not
+     * every application will cast it that way — mirror the tolerance here
+     * so the trait works with or without the cast.
+     *
+     * @since 1.0.0
+     *
+     * @return array<string, mixed>
+     */
+    protected function readOptimizedFormatsMap(): array
+    {
+        return $this->normalizeJsonAttribute( $this->getAttribute( 'optimized_formats' ) );
+    }
+
+    /**
+     * Reads and normalizes the `optimized_sizes` JSON column into an array.
+     *
+     * @since 1.0.0
+     *
+     * @return array<string, mixed>
+     */
+    protected function readOptimizedSizesMap(): array
+    {
+        return $this->normalizeJsonAttribute( $this->getAttribute( 'optimized_sizes' ) );
+    }
+
+    /**
+     * Normalizes a JSON-or-array attribute value into a keyed array.
+     *
+     * @since 1.0.0
+     *
+     * @return array<string, mixed>
+     */
+    protected function normalizeJsonAttribute( mixed $value ): array
+    {
+        if ( is_array( $value ) ) {
+            return $value;
+        }
+
+        if ( is_string( $value ) && '' !== $value ) {
+            $decoded = json_decode( $value, true );
+
+            return is_array( $decoded ) ? $decoded : [];
+        }
+
+        return [];
+    }
+
+    /**
+     * Builds a `srcset` string from a `{ width => url }` map.
+     *
+     * Entries with non-numeric keys are skipped — `srcset` only accepts width
+     * (`Nw`) or density (`Nx`) descriptors, and the map keys are always
+     * widths in the schema we control.
+     *
+     * @since 1.0.0
+     *
+     * @param  array<string, mixed>  $entries  Size-keyed map from the JSON column.
+     */
+    protected function buildSrcsetFromMap( array $entries ): string
+    {
+        $parts = [];
+
+        foreach ( $entries as $width => $url ) {
+            if ( ! is_string( $url ) || '' === $url ) {
+                continue;
+            }
+
+            if ( ! is_numeric( $width ) ) {
+                continue;
+            }
+
+            $parts[] = $url . ' ' . (int) $width . 'w';
+        }
+
+        return implode( ', ', $parts );
+    }
+}

--- a/tests/Feature/Database/MediaOptimizationMigrationTest.php
+++ b/tests/Feature/Database/MediaOptimizationMigrationTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+it( 'no-ops when the media table does not exist', function (): void {
+    // The package migrations already ran via the base test case; we only
+    // need to prove that the additive `media` migration didn't create a
+    // stub table when the media-library table is absent.
+    expect( Schema::hasTable( 'media' ) )->toBeFalse();
+} );
+
+it( 'adds the optimization columns when the media table exists', function (): void {
+    // Recreate a minimal `media` table to simulate what the media-library
+    // migration would provide, then run only the additive migration by
+    // requiring the migration file and calling `up()` directly.
+    Schema::create( 'media', function ( Blueprint $table ): void {
+        $table->id();
+        $table->string( 'file_path' )->nullable();
+        $table->timestamps();
+    } );
+
+    try {
+        $migration = require __DIR__ . '/../../../database/migrations/2026_01_01_000006_add_performance_columns_to_media_table.php';
+        $migration->up();
+
+        expect( Schema::hasColumns( 'media', [
+            'dominant_color',
+            'optimization_status',
+            'optimized_at',
+            'optimized_formats',
+            'optimized_sizes',
+        ] ) )->toBeTrue();
+
+        // Idempotent — running `up()` a second time must not error even
+        // though the columns already exist.
+        $migration->up();
+
+        expect( Schema::hasColumn( 'media', 'optimization_status' ) )->toBeTrue();
+    } finally {
+        Schema::dropIfExists( 'media' );
+    }
+} );
+
+it( 'drops the added columns on down when the table exists', function (): void {
+    Schema::create( 'media', function ( Blueprint $table ): void {
+        $table->id();
+        $table->string( 'file_path' )->nullable();
+        $table->timestamps();
+    } );
+
+    try {
+        $migration = require __DIR__ . '/../../../database/migrations/2026_01_01_000006_add_performance_columns_to_media_table.php';
+        $migration->up();
+        $migration->down();
+
+        expect( Schema::hasColumn( 'media', 'dominant_color' ) )->toBeFalse()
+            ->and( Schema::hasColumn( 'media', 'optimization_status' ) )->toBeFalse()
+            ->and( Schema::hasColumn( 'media', 'optimized_at' ) )->toBeFalse()
+            ->and( Schema::hasColumn( 'media', 'optimized_formats' ) )->toBeFalse()
+            ->and( Schema::hasColumn( 'media', 'optimized_sizes' ) )->toBeFalse();
+    } finally {
+        Schema::dropIfExists( 'media' );
+    }
+} );

--- a/tests/Feature/Jobs/OptimizeMediaJobTest.php
+++ b/tests/Feature/Jobs/OptimizeMediaJobTest.php
@@ -184,6 +184,35 @@ it( 'logs a warning when the write-back save() throws instead of silently swallo
         );
 } );
 
+it( 'derives storage root by trimming only the trailing file_path suffix', function (): void {
+    if ( ! function_exists( 'imagewebp' ) ) {
+        $this->markTestSkipped( 'GD WebP support is not available' );
+    }
+
+    // Regression: a file_path whose text appears more than once in the
+    // absolute path would previously have been stripped every time by
+    // str_replace, mangling the storage root. Use a path that contains
+    // a repeated segment (`media/1/media`) so any wrong-strip would
+    // yield a broken URL and drop the variant from optimized_formats.
+    $sourceFixture = makeTestImage( 'repeated-seg.jpg', 300, 200 );
+    Storage::disk( 'public' )->put( 'media/1/media', file_get_contents( $sourceFixture ) );
+
+    $media = MediaModelStub::create( [
+        'file_path' => 'media/1/media',
+        'disk'      => 'public',
+        'mime_type' => 'image/jpeg',
+    ] );
+
+    $job = new OptimizeMediaJob( $media, [
+        'sizes'   => [200],
+        'formats' => ['webp'],
+    ] );
+
+    $job->handle( app( ImageService::class ) );
+
+    expect( $media->refresh()->optimized_formats )->toHaveKey( 'webp' );
+} );
+
 it( 'skips the extract_dominant_color option when it is disabled', function (): void {
     if ( ! function_exists( 'imagewebp' ) ) {
         $this->markTestSkipped( 'GD WebP support is not available' );

--- a/tests/Feature/Jobs/OptimizeMediaJobTest.php
+++ b/tests/Feature/Jobs/OptimizeMediaJobTest.php
@@ -116,6 +116,74 @@ it( 'marks the row as failed when Laravel calls failed()', function (): void {
     expect( $media->refresh()->optimization_status )->toBe( MediaOptimizationStatus::FAILED );
 } );
 
+it( 'preserves optimized_at when the retry rewrites processing/failed status', function (): void {
+    $earlier = Illuminate\Support\Carbon::parse( '2026-06-20 10:00:00' );
+
+    $media = MediaModelStub::create( [
+        'file_path'           => 'media/1/photo.jpg',
+        'disk'                => 'public',
+        'mime_type'           => 'image/jpeg',
+        'optimization_status' => MediaOptimizationStatus::COMPLETED,
+        'optimized_at'        => $earlier,
+    ] );
+
+    $job = new OptimizeMediaJob( $media );
+
+    // A retry that begins reprocessing must not clear the last-successful
+    // timestamp before the encoder has produced a new one.
+    $reflection = new ReflectionMethod( $job, 'writeStatus' );
+    $reflection->setAccessible( true );
+    $reflection->invoke( $job, MediaOptimizationStatus::PROCESSING );
+
+    $media->refresh();
+
+    expect( $media->optimization_status )->toBe( MediaOptimizationStatus::PROCESSING )
+        ->and( $media->optimized_at->toDateTimeString() )->toBe( $earlier->toDateTimeString() );
+
+    // Same for FAILED — the previously-successful timestamp survives so
+    // dashboards can still show "last successful optimization".
+    $reflection->invoke( $job, MediaOptimizationStatus::FAILED );
+
+    $media->refresh();
+
+    expect( $media->optimization_status )->toBe( MediaOptimizationStatus::FAILED )
+        ->and( $media->optimized_at->toDateTimeString() )->toBe( $earlier->toDateTimeString() );
+} );
+
+it( 'logs a warning when the write-back save() throws instead of silently swallowing', function (): void {
+    $media = MediaModelStub::create( [
+        'file_path'           => 'media/1/photo.jpg',
+        'disk'                => 'public',
+        'mime_type'           => 'image/jpeg',
+        'optimization_status' => MediaOptimizationStatus::PENDING,
+    ] );
+
+    // Force the model into a state where save() throws — override the
+    // connection to one that rejects writes so the job's catch block fires.
+    $failing = new class extends MediaModelStub {
+        public function save( array $options = [] ): bool
+        {
+            throw new RuntimeException( 'simulated DB failure' );
+        }
+    };
+    $failing->exists = true;
+    $failing->setRawAttributes( $media->getAttributes(), true );
+
+    Illuminate\Support\Facades\Log::spy();
+
+    $job        = new OptimizeMediaJob( $failing );
+    $reflection = new ReflectionMethod( $job, 'safelyUpdateAttributes' );
+    $reflection->setAccessible( true );
+    $reflection->invoke( $job, [ 'optimization_status' => MediaOptimizationStatus::PROCESSING ] );
+
+    Illuminate\Support\Facades\Log::shouldHaveReceived( 'warning' )
+        ->once()
+        ->with(
+            'artisanpack-ui/performance: media optimization write-back failed',
+            Mockery::on( fn ( array $context ): bool => 'simulated DB failure' === $context['error'] ),
+        );
+} );
+
 it( 'skips the extract_dominant_color option when it is disabled', function (): void {
     if ( ! function_exists( 'imagewebp' ) ) {
         $this->markTestSkipped( 'GD WebP support is not available' );

--- a/tests/Feature/Jobs/OptimizeMediaJobTest.php
+++ b/tests/Feature/Jobs/OptimizeMediaJobTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Events\ImageOptimized;
+use ArtisanPackUI\Performance\Jobs\OptimizeMediaJob;
+use ArtisanPackUI\Performance\Services\ImageService;
+use ArtisanPackUI\Performance\Support\MediaOptimizationStatus;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use Tests\Fixtures\MediaModelStub;
+
+beforeEach( function (): void {
+    clearImageFixtures();
+
+    Schema::create( 'media_stubs', function ( $table ): void {
+        $table->id();
+        $table->string( 'file_path' )->nullable();
+        $table->string( 'disk' )->nullable();
+        $table->string( 'mime_type' )->nullable();
+        $table->string( 'dominant_color', 7 )->nullable();
+        $table->string( 'optimization_status' )->default( 'pending' );
+        $table->timestamp( 'optimized_at' )->nullable();
+        $table->json( 'optimized_formats' )->nullable();
+        $table->json( 'optimized_sizes' )->nullable();
+        $table->timestamps();
+    } );
+
+    Storage::fake( 'public' );
+} );
+
+afterEach( function (): void {
+    Schema::dropIfExists( 'media_stubs' );
+    clearImageFixtures();
+} );
+
+it( 'targets the configured queue, tries, and backoff', function (): void {
+    config( [
+        'artisanpack.performance.images.queue'        => 'media',
+        'artisanpack.performance.images.jobs.tries'   => 4,
+        'artisanpack.performance.images.jobs.backoff' => 45,
+    ] );
+
+    $media = MediaModelStub::create( [
+        'file_path' => 'nonexistent.jpg',
+        'disk'      => 'public',
+        'mime_type' => 'image/jpeg',
+    ] );
+
+    $job = new OptimizeMediaJob( $media );
+
+    expect( $job->queue )->toBe( 'media' )
+        ->and( $job->tries )->toBe( 4 )
+        ->and( $job->backoff )->toBe( 45 );
+} );
+
+it( 'marks the row as failed when the source file cannot be resolved', function (): void {
+    $media = MediaModelStub::create( [
+        'file_path' => 'missing/photo.jpg',
+        'disk'      => 'public',
+        'mime_type' => 'image/jpeg',
+    ] );
+
+    ( new OptimizeMediaJob( $media ) )->handle( app( ImageService::class ) );
+
+    expect( $media->refresh()->optimization_status )->toBe( MediaOptimizationStatus::FAILED );
+} );
+
+it( 'writes the optimized formats/sizes back to the media row on success', function (): void {
+    if ( ! function_exists( 'imagewebp' ) ) {
+        $this->markTestSkipped( 'GD WebP support is not available' );
+    }
+
+    Event::fake();
+
+    // Seed a real image inside the faked public disk so the job's path resolver
+    // returns an absolute path.
+    $sourceFixture = makeTestImage( 'opt-media.jpg', 400, 300 );
+    Storage::disk( 'public' )->put( 'media/1/photo.jpg', file_get_contents( $sourceFixture ) );
+
+    $media = MediaModelStub::create( [
+        'file_path' => 'media/1/photo.jpg',
+        'disk'      => 'public',
+        'mime_type' => 'image/jpeg',
+    ] );
+
+    $job = new OptimizeMediaJob( $media, [
+        'sizes'                  => [200],
+        'formats'                => ['webp'],
+        'extract_dominant_color' => true,
+    ] );
+
+    $job->handle( app( ImageService::class ) );
+
+    $media->refresh();
+
+    expect( $media->optimization_status )->toBe( MediaOptimizationStatus::COMPLETED )
+        ->and( $media->optimized_at )->not->toBeNull()
+        ->and( $media->optimized_formats )->toHaveKey( 'webp' )
+        ->and( $media->optimized_sizes )->toHaveKey( '200' )
+        ->and( $media->dominant_color )->toStartWith( '#' );
+
+    Event::assertDispatched( ImageOptimized::class );
+} );
+
+it( 'marks the row as failed when Laravel calls failed()', function (): void {
+    $media = MediaModelStub::create( [
+        'file_path' => 'media/1/photo.jpg',
+        'disk'      => 'public',
+        'mime_type' => 'image/jpeg',
+    ] );
+
+    ( new OptimizeMediaJob( $media ) )->failed( new RuntimeException( 'boom' ) );
+
+    expect( $media->refresh()->optimization_status )->toBe( MediaOptimizationStatus::FAILED );
+} );
+
+it( 'skips the extract_dominant_color option when it is disabled', function (): void {
+    if ( ! function_exists( 'imagewebp' ) ) {
+        $this->markTestSkipped( 'GD WebP support is not available' );
+    }
+
+    $sourceFixture = makeTestImage( 'no-dominant.jpg', 200, 200 );
+    Storage::disk( 'public' )->put( 'media/2/photo.jpg', file_get_contents( $sourceFixture ) );
+
+    $media = MediaModelStub::create( [
+        'file_path' => 'media/2/photo.jpg',
+        'disk'      => 'public',
+        'mime_type' => 'image/jpeg',
+    ] );
+
+    $job = new OptimizeMediaJob( $media, [
+        'sizes'                  => [100],
+        'formats'                => ['webp'],
+        'extract_dominant_color' => false,
+    ] );
+
+    $job->handle( app( ImageService::class ) );
+
+    expect( $media->refresh()->dominant_color )->toBeNull();
+} );

--- a/tests/Feature/Listeners/OptimizeUploadedMediaTest.php
+++ b/tests/Feature/Listeners/OptimizeUploadedMediaTest.php
@@ -6,10 +6,17 @@ use ArtisanPackUI\Performance\Jobs\OptimizeMediaJob;
 use ArtisanPackUI\Performance\Listeners\OptimizeUploadedMedia;
 use ArtisanPackUI\Performance\Services\MediaLibraryDetector;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
 use Tests\Fixtures\MediaModelStub;
 
 beforeEach( function (): void {
     Queue::fake();
+    Storage::fake( 'public' );
+
+    // Every image-media path in these tests points at this file so the
+    // listener's file-exists guard passes.
+    Storage::disk( 'public' )->put( 'media/1/photo.jpg', 'fake-image-bytes' );
+
     config( [
         'artisanpack.performance.media_library_integration.enabled'            => true,
         'artisanpack.performance.media_library_integration.optimize_on_upload' => true,
@@ -44,6 +51,8 @@ it( 'skips when media_library_integration is disabled entirely', function (): vo
 
     $media            = new MediaModelStub;
     $media->mime_type = 'image/jpeg';
+    $media->file_path = 'media/1/photo.jpg';
+    $media->disk      = 'public';
 
     ( new OptimizeUploadedMedia( new MediaLibraryDetector ) )( $media );
 
@@ -55,6 +64,8 @@ it( 'skips when optimize_on_upload is toggled off but integration is on', functi
 
     $media            = new MediaModelStub;
     $media->mime_type = 'image/jpeg';
+    $media->file_path = 'media/1/photo.jpg';
+    $media->disk      = 'public';
 
     ( new OptimizeUploadedMedia( new MediaLibraryDetector ) )( $media );
 
@@ -64,6 +75,19 @@ it( 'skips when optimize_on_upload is toggled off but integration is on', functi
 it( 'skips non-image media rows', function (): void {
     $media            = new MediaModelStub;
     $media->mime_type = 'application/pdf';
+    $media->file_path = 'media/1/photo.jpg';
+    $media->disk      = 'public';
+
+    ( new OptimizeUploadedMedia( new MediaLibraryDetector ) )( $media );
+
+    Queue::assertNothingPushed();
+} );
+
+it( 'skips rows whose file_path does not exist on disk (factory / seeder guard)', function (): void {
+    $media            = new MediaModelStub;
+    $media->mime_type = 'image/jpeg';
+    $media->file_path = 'seeded/does-not-exist.jpg';
+    $media->disk      = 'public';
 
     ( new OptimizeUploadedMedia( new MediaLibraryDetector ) )( $media );
 
@@ -73,6 +97,8 @@ it( 'skips non-image media rows', function (): void {
 it( 'unwraps a wrapping event object exposing a `media` property', function (): void {
     $media            = new MediaModelStub;
     $media->mime_type = 'image/png';
+    $media->file_path = 'media/1/photo.jpg';
+    $media->disk      = 'public';
 
     $event        = new stdClass;
     $event->media = $media;
@@ -91,9 +117,69 @@ it( 'ignores payloads that carry no resolvable media model', function (): void {
 it( 'exposes both `handle` and __invoke as entrypoints', function (): void {
     $media            = new MediaModelStub;
     $media->mime_type = 'image/jpeg';
+    $media->file_path = 'media/1/photo.jpg';
+    $media->disk      = 'public';
 
     $listener = new OptimizeUploadedMedia( new MediaLibraryDetector );
     $listener->handle( $media );
 
     Queue::assertPushed( OptimizeMediaJob::class );
+} );
+
+it( 'accepts a flat-list formats config (["webp","avif"]) as well as the associative shape', function (): void {
+    config( [
+        'artisanpack.performance.images.formats' => ['webp', 'avif'],
+    ] );
+
+    $media            = new MediaModelStub;
+    $media->mime_type = 'image/jpeg';
+    $media->file_path = 'media/1/photo.jpg';
+    $media->disk      = 'public';
+
+    ( new OptimizeUploadedMedia( new MediaLibraryDetector ) )( $media );
+
+    Queue::assertPushed( OptimizeMediaJob::class, function ( OptimizeMediaJob $job ): bool {
+        return ['webp', 'avif'] === $job->options['formats'];
+    } );
+} );
+
+it( 'dedupes formats when both shapes overlap', function (): void {
+    // Weird mixed config: normally you'd pick one shape, but the loop
+    // should dedupe when the operator has drifted.
+    config( [
+        'artisanpack.performance.images.formats' => [
+            'webp',
+            'avif' => ['enabled' => true],
+            'WEBP',
+        ],
+    ] );
+
+    $media            = new MediaModelStub;
+    $media->mime_type = 'image/jpeg';
+    $media->file_path = 'media/1/photo.jpg';
+    $media->disk      = 'public';
+
+    ( new OptimizeUploadedMedia( new MediaLibraryDetector ) )( $media );
+
+    Queue::assertPushed( OptimizeMediaJob::class, function ( OptimizeMediaJob $job ): bool {
+        return ['webp', 'avif'] === $job->options['formats'];
+    } );
+} );
+
+it( 'defers the dispatch until the outer transaction commits', function (): void {
+    $media            = new MediaModelStub;
+    $media->mime_type = 'image/jpeg';
+    $media->file_path = 'media/1/photo.jpg';
+    $media->disk      = 'public';
+
+    ( new OptimizeUploadedMedia( new MediaLibraryDetector ) )( $media );
+
+    Queue::assertPushed( OptimizeMediaJob::class, function ( OptimizeMediaJob $job ): bool {
+        // The Illuminate\Foundation\Bus\PendingDispatch::afterCommit() flag
+        // is captured on the pending dispatch object, but by the time the
+        // job lands on the fake queue the transaction wrapper has already
+        // resolved it. We assert the job has the property set to true so
+        // the wiring is unmistakable in the test transcript.
+        return true === $job->afterCommit;
+    } );
 } );

--- a/tests/Feature/Listeners/OptimizeUploadedMediaTest.php
+++ b/tests/Feature/Listeners/OptimizeUploadedMediaTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Jobs\OptimizeMediaJob;
+use ArtisanPackUI\Performance\Listeners\OptimizeUploadedMedia;
+use ArtisanPackUI\Performance\Services\MediaLibraryDetector;
+use Illuminate\Support\Facades\Queue;
+use Tests\Fixtures\MediaModelStub;
+
+beforeEach( function (): void {
+    Queue::fake();
+    config( [
+        'artisanpack.performance.media_library_integration.enabled'            => true,
+        'artisanpack.performance.media_library_integration.optimize_on_upload' => true,
+        'artisanpack.performance.images.sizes'                                 => [320, 640],
+        'artisanpack.performance.images.formats'                               => [
+            'webp' => ['enabled' => true, 'quality' => 80],
+            'avif' => ['enabled' => false, 'quality' => 70],
+        ],
+        'artisanpack.performance.images.dominant_color.enabled' => true,
+    ] );
+} );
+
+it( 'dispatches OptimizeMediaJob for an image media row', function (): void {
+    $media            = new MediaModelStub;
+    $media->mime_type = 'image/jpeg';
+    $media->file_path = 'media/1/photo.jpg';
+    $media->disk      = 'public';
+
+    $listener = new OptimizeUploadedMedia( new MediaLibraryDetector );
+    $listener( $media );
+
+    Queue::assertPushed( OptimizeMediaJob::class, function ( OptimizeMediaJob $job ) use ( $media ): bool {
+        return $job->media === $media
+            && [320, 640] === $job->options['sizes']
+            && ['webp'] === $job->options['formats']
+            && true === $job->options['extract_dominant_color'];
+    } );
+} );
+
+it( 'skips when media_library_integration is disabled entirely', function (): void {
+    config( [ 'artisanpack.performance.media_library_integration.enabled' => false ] );
+
+    $media            = new MediaModelStub;
+    $media->mime_type = 'image/jpeg';
+
+    ( new OptimizeUploadedMedia( new MediaLibraryDetector ) )( $media );
+
+    Queue::assertNothingPushed();
+} );
+
+it( 'skips when optimize_on_upload is toggled off but integration is on', function (): void {
+    config( [ 'artisanpack.performance.media_library_integration.optimize_on_upload' => false ] );
+
+    $media            = new MediaModelStub;
+    $media->mime_type = 'image/jpeg';
+
+    ( new OptimizeUploadedMedia( new MediaLibraryDetector ) )( $media );
+
+    Queue::assertNothingPushed();
+} );
+
+it( 'skips non-image media rows', function (): void {
+    $media            = new MediaModelStub;
+    $media->mime_type = 'application/pdf';
+
+    ( new OptimizeUploadedMedia( new MediaLibraryDetector ) )( $media );
+
+    Queue::assertNothingPushed();
+} );
+
+it( 'unwraps a wrapping event object exposing a `media` property', function (): void {
+    $media            = new MediaModelStub;
+    $media->mime_type = 'image/png';
+
+    $event        = new stdClass;
+    $event->media = $media;
+
+    ( new OptimizeUploadedMedia( new MediaLibraryDetector ) )( $event );
+
+    Queue::assertPushed( OptimizeMediaJob::class );
+} );
+
+it( 'ignores payloads that carry no resolvable media model', function (): void {
+    ( new OptimizeUploadedMedia( new MediaLibraryDetector ) )( new stdClass );
+
+    Queue::assertNothingPushed();
+} );
+
+it( 'exposes both `handle` and __invoke as entrypoints', function (): void {
+    $media            = new MediaModelStub;
+    $media->mime_type = 'image/jpeg';
+
+    $listener = new OptimizeUploadedMedia( new MediaLibraryDetector );
+    $listener->handle( $media );
+
+    Queue::assertPushed( OptimizeMediaJob::class );
+} );

--- a/tests/Feature/ServiceProviderTest.php
+++ b/tests/Feature/ServiceProviderTest.php
@@ -62,6 +62,24 @@ it( 'registers the perf:generate-webp console command', function (): void {
     expect( $registered )->toContain( 'perf:generate-webp' );
 } );
 
+it( 'boots without throwing when media-library is not installed', function (): void {
+    // The test environment does not depend on artisanpack-ui/media-library so
+    // the provider class does not exist. The Performance service provider
+    // must still boot cleanly — the media library integration path is
+    // guarded on the detector's status.
+    config( [ 'artisanpack.performance.media_library_integration.enabled' => null ] );
+
+    expect( fn () => app()->resolveProvider( PerformanceServiceProvider::class )->boot() )
+        ->not->toThrow( Throwable::class );
+} );
+
+it( 'skips listener wiring when the integration is forced off via config', function (): void {
+    config( [ 'artisanpack.performance.media_library_integration.enabled' => false ] );
+
+    expect( fn () => app()->resolveProvider( PerformanceServiceProvider::class )->boot() )
+        ->not->toThrow( Throwable::class );
+} );
+
 it( 'replaces list-valued config overrides wholesale instead of per-index', function (): void {
     // Regression test: array_replace_recursive would bleed the package defaults
     // through at higher indices (e.g. images.sizes default [320,640,768,1024,1280,1920]
@@ -72,8 +90,8 @@ it( 'replaces list-valued config overrides wholesale instead of per-index', func
 
     app()->resolveProvider( PerformanceServiceProvider::class )->boot();
 
-    expect( config( 'artisanpack.performance.images.sizes'))->toBe( [1200])
-        ->and( config( 'artisanpack.performance.speculative_loading.prefetch.exclude_patterns'))->toBe( ['/private'])
+    expect( config( 'artisanpack.performance.images.sizes' ) )->toBe( [1200] )
+        ->and( config( 'artisanpack.performance.speculative_loading.prefetch.exclude_patterns' ) )->toBe( ['/private'] )
         // Sanity: associative defaults still merge through (driver still resolves).
-        ->and( config( 'artisanpack.performance.images.driver'))->toBe( 'gd');
+        ->and( config( 'artisanpack.performance.images.driver' ) )->toBe( 'gd');
 });

--- a/tests/Feature/ServiceProviderTest.php
+++ b/tests/Feature/ServiceProviderTest.php
@@ -62,6 +62,33 @@ it( 'registers the perf:generate-webp console command', function (): void {
     expect( $registered )->toContain( 'perf:generate-webp' );
 } );
 
+it( 'registers only the MediaUploaded event listener when it exists (no double-dispatch)', function (): void {
+    // Simulate a future media-library release that ships the dedicated
+    // MediaUploaded event class. The provider should subscribe to that
+    // event and NOT also register the fallback Eloquent model closure —
+    // otherwise a single upload would enqueue OptimizeMediaJob twice.
+    if ( ! class_exists( 'ArtisanPackUI\\MediaLibrary\\Events\\MediaUploaded' ) ) {
+        eval( 'namespace ArtisanPackUI\\MediaLibrary\\Events; class MediaUploaded {}' );
+    }
+
+    config( [ 'artisanpack.performance.media_library_integration.enabled' => true ] );
+
+    $provider = app()->resolveProvider( PerformanceServiceProvider::class );
+
+    $reflection = new ReflectionClass( $provider );
+    $method     = $reflection->getMethod( 'wireMediaLibraryListeners' );
+    $method->setAccessible( true );
+    $method->invoke( $provider );
+
+    // Provider stores listeners keyed by the exact FQCN string passed to
+    // listen() — check both leading-backslash and no-backslash forms so
+    // this test doesn't depend on which convention the provider uses.
+    expect(
+        app( 'events' )->hasListeners( '\\ArtisanPackUI\\MediaLibrary\\Events\\MediaUploaded' )
+        || app( 'events' )->hasListeners( 'ArtisanPackUI\\MediaLibrary\\Events\\MediaUploaded' ),
+    )->toBeTrue();
+} );
+
 it( 'boots without throwing when media-library is not installed', function (): void {
     // The test environment does not depend on artisanpack-ui/media-library so
     // the provider class does not exist. The Performance service provider
@@ -93,5 +120,5 @@ it( 'replaces list-valued config overrides wholesale instead of per-index', func
     expect( config( 'artisanpack.performance.images.sizes' ) )->toBe( [1200] )
         ->and( config( 'artisanpack.performance.speculative_loading.prefetch.exclude_patterns' ) )->toBe( ['/private'] )
         // Sanity: associative defaults still merge through (driver still resolves).
-        ->and( config( 'artisanpack.performance.images.driver' ) )->toBe( 'gd');
-});
+        ->and( config( 'artisanpack.performance.images.driver' ) )->toBe( 'gd' );
+} );

--- a/tests/Feature/Traits/HasOptimizedMediaTest.php
+++ b/tests/Feature/Traits/HasOptimizedMediaTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Performance\Support\MediaOptimizationStatus;
+use ArtisanPackUI\Performance\Traits\HasOptimizedMedia;
+use Tests\Fixtures\MediaModelStub;
+
+it( 'returns pending status when the column is empty', function (): void {
+    $media = new MediaModelStub;
+
+    expect( $media->getOptimizationStatus() )->toBe( MediaOptimizationStatus::PENDING )
+        ->and( $media->isOptimized() )->toBeFalse();
+} );
+
+it( 'reports optimized only when the status column is completed', function (): void {
+    $media                      = new MediaModelStub;
+    $media->optimization_status = MediaOptimizationStatus::COMPLETED;
+
+    expect( $media->isOptimized() )->toBeTrue()
+        ->and( $media->getOptimizationStatus() )->toBe( 'completed' );
+
+    $media->optimization_status = MediaOptimizationStatus::PROCESSING;
+
+    expect( $media->isOptimized() )->toBeFalse()
+        ->and( $media->getOptimizationStatus() )->toBe( 'processing' );
+} );
+
+it( 'returns the dominant color when it is set, null when not', function (): void {
+    $media                 = new MediaModelStub;
+    $media->dominant_color = '#3b82f6';
+
+    expect( $media->getDominantColor() )->toBe( '#3b82f6' );
+
+    $media->dominant_color = null;
+    expect( $media->getDominantColor() )->toBeNull();
+
+    $media->dominant_color = '';
+    expect( $media->getDominantColor() )->toBeNull();
+} );
+
+it( 'resolves a format-only URL from the optimized_formats map', function (): void {
+    $media                    = new MediaModelStub;
+    $media->optimized_formats = [
+        'webp' => '/storage/media/1/optimized/image.webp',
+    ];
+
+    expect( $media->getOptimizedUrl( 'webp' ) )->toBe( '/storage/media/1/optimized/image.webp' )
+        ->and( $media->getOptimizedUrl( 'avif' ) )->toBeNull();
+} );
+
+it( 'resolves a format+size URL from the nested map', function (): void {
+    $media                    = new MediaModelStub;
+    $media->optimized_formats = [
+        'webp' => [
+            '320' => '/storage/media/1/optimized/image-320.webp',
+            '640' => '/storage/media/1/optimized/image-640.webp',
+        ],
+    ];
+
+    expect( $media->getOptimizedUrl( 'webp', 320 ) )->toBe( '/storage/media/1/optimized/image-320.webp' )
+        ->and( $media->getOptimizedUrl( 'webp', '640' ) )->toBe( '/storage/media/1/optimized/image-640.webp' )
+        ->and( $media->getOptimizedUrl( 'webp', 1024 ) )->toBeNull();
+} );
+
+it( 'resolves a size-only URL from the optimized_sizes map', function (): void {
+    $media                  = new MediaModelStub;
+    $media->optimized_sizes = [
+        '320' => '/storage/media/1/optimized/image-320.jpg',
+        '640' => '/storage/media/1/optimized/image-640.jpg',
+    ];
+
+    expect( $media->getOptimizedUrl( null, 320 ) )->toBe( '/storage/media/1/optimized/image-320.jpg' )
+        ->and( $media->getOptimizedUrl( null, 999 ) )->toBeNull();
+} );
+
+it( 'builds a srcset string from the optimized_sizes map', function (): void {
+    $media                  = new MediaModelStub;
+    $media->optimized_sizes = [
+        '320' => '/storage/media/1/optimized/image-320.jpg',
+        '640' => '/storage/media/1/optimized/image-640.jpg',
+    ];
+
+    expect( $media->getSrcset() )
+        ->toBe( '/storage/media/1/optimized/image-320.jpg 320w, /storage/media/1/optimized/image-640.jpg 640w' );
+} );
+
+it( 'builds a per-format srcset when the format map holds nested sizes', function (): void {
+    $media                    = new MediaModelStub;
+    $media->optimized_formats = [
+        'webp' => [
+            '320' => '/storage/media/1/optimized/image-320.webp',
+            '640' => '/storage/media/1/optimized/image-640.webp',
+        ],
+    ];
+
+    expect( $media->getSrcset( 'webp' ) )
+        ->toBe( '/storage/media/1/optimized/image-320.webp 320w, /storage/media/1/optimized/image-640.webp 640w' );
+} );
+
+it( 'returns an empty srcset when the columns are empty', function (): void {
+    $media = new MediaModelStub;
+
+    expect( $media->getSrcset() )->toBe( '' )
+        ->and( $media->getSrcset( 'webp' ) )->toBe( '' );
+} );
+
+it( 'skips entries with non-numeric width keys defensively', function (): void {
+    $media                  = new MediaModelStub;
+    $media->optimized_sizes = [
+        '320'  => '/storage/media/1/optimized/image-320.jpg',
+        'name' => '/storage/media/1/should-be-skipped.jpg',
+    ];
+
+    // Non-numeric keys are skipped so the descriptor stays well-formed.
+    expect( $media->getSrcset() )->toBe( '/storage/media/1/optimized/image-320.jpg 320w' );
+} );
+
+it( 'normalizes a raw JSON string returned by the getAttribute call', function (): void {
+    // Stub model without any casts — mirrors an application that opted out of
+    // registering the trait-managed columns as `array` casts. The trait must
+    // still decode the JSON.
+    $media = new class extends Illuminate\Database\Eloquent\Model {
+        use HasOptimizedMedia;
+
+        protected $guarded = [];
+    };
+
+    $media->setRawAttributes( [
+        'optimized_sizes' => json_encode( [
+            '320' => '/storage/media/1/optimized/image-320.jpg',
+        ] ),
+    ] );
+
+    expect( $media->getSrcset() )->toBe( '/storage/media/1/optimized/image-320.jpg 320w' );
+} );

--- a/tests/Feature/Traits/HasOptimizedMediaTest.php
+++ b/tests/Feature/Traits/HasOptimizedMediaTest.php
@@ -6,6 +6,19 @@ use ArtisanPackUI\Performance\Support\MediaOptimizationStatus;
 use ArtisanPackUI\Performance\Traits\HasOptimizedMedia;
 use Tests\Fixtures\MediaModelStub;
 
+it( 'auto-registers array/datetime casts on the consuming model via initializeHasOptimizedMedia', function (): void {
+    $media = new MediaModelStub;
+
+    // The stub declares its own casts too — merging via the trait hook
+    // must produce the expected cast types (idempotent when the model
+    // already casts the columns).
+    expect( $media->getCasts() )->toMatchArray( [
+        'optimized_formats' => 'array',
+        'optimized_sizes'   => 'array',
+        'optimized_at'      => 'datetime',
+    ] );
+} );
+
 it( 'returns pending status when the column is empty', function (): void {
     $media = new MediaModelStub;
 
@@ -39,7 +52,7 @@ it( 'returns the dominant color when it is set, null when not', function (): voi
     expect( $media->getDominantColor() )->toBeNull();
 } );
 
-it( 'resolves a format-only URL from the optimized_formats map', function (): void {
+it( 'resolves a format-only URL from a string entry (legacy schema)', function (): void {
     $media                    = new MediaModelStub;
     $media->optimized_formats = [
         'webp' => '/storage/media/1/optimized/image.webp',
@@ -47,6 +60,36 @@ it( 'resolves a format-only URL from the optimized_formats map', function (): vo
 
     expect( $media->getOptimizedUrl( 'webp' ) )->toBe( '/storage/media/1/optimized/image.webp' )
         ->and( $media->getOptimizedUrl( 'avif' ) )->toBeNull();
+} );
+
+it( 'returns the largest-width URL when a format-only lookup finds a nested size-map', function (): void {
+    $media                    = new MediaModelStub;
+    $media->optimized_formats = [
+        'webp' => [
+            '320' => '/storage/media/1/optimized/image-320.webp',
+            '640' => '/storage/media/1/optimized/image-640.webp',
+            '800' => '/storage/media/1/optimized/image-800.webp',
+        ],
+    ];
+
+    // Format-only lookup should return the LARGEST width — the natural
+    // "give me the best available WebP" default that matches the README's
+    // documented API contract.
+    expect( $media->getOptimizedUrl( 'webp' ) )
+        ->toBe( '/storage/media/1/optimized/image-800.webp' );
+} );
+
+it( 'ignores non-numeric keys when picking the largest width for a format-only lookup', function (): void {
+    $media                    = new MediaModelStub;
+    $media->optimized_formats = [
+        'webp' => [
+            '320'  => '/storage/media/1/image-320.webp',
+            'name' => '/storage/media/1/should-be-skipped.webp',
+        ],
+    ];
+
+    expect( $media->getOptimizedUrl( 'webp' ) )
+        ->toBe( '/storage/media/1/image-320.webp' );
 } );
 
 it( 'resolves a format+size URL from the nested map', function (): void {

--- a/tests/Fixtures/MediaModelStub.php
+++ b/tests/Fixtures/MediaModelStub.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Eloquent stub that mimics the artisanpack-ui/media-library `Media` model.
+ *
+ * Provides just enough surface for the Performance package's listener,
+ * job, and trait tests to run without the real media-library package
+ * installed as a test-time dependency. The stub is backed by a
+ * `media_stubs` table created inline by the tests that need persistence.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace Tests\Fixtures;
+
+use ArtisanPackUI\Performance\Traits\HasOptimizedMedia;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Media stub Eloquent model.
+ *
+ *
+ * @since      1.0.0
+ */
+class MediaModelStub extends Model
+{
+    use HasOptimizedMedia;
+
+    protected $table = 'media_stubs';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'optimized_formats' => 'array',
+        'optimized_sizes'   => 'array',
+        'optimized_at'      => 'datetime',
+    ];
+
+    /**
+     * Mirrors media-library's `Media::isImage()` helper so the listener's
+     * mime-type guard exercises the same code path in tests.
+     *
+     * @since 1.0.0
+     */
+    public function isImage(): bool
+    {
+        return is_string( $this->mime_type ) && str_starts_with( $this->mime_type, 'image/' );
+    }
+}


### PR DESCRIPTION
## Description

Bundles the five remaining Phase 9/10 issues into a single PR: they all
target the media-library integration surface plus the top-level package
docs, and each one is small enough that splitting the work would produce
mostly boilerplate PRs.

**Closes:** #62, #63, #64, #65, #66

## Type of Change

- [x] New feature (adds new functionality)
- [x] Documentation update

## Related Issues

- #62 Create media-library event listeners
- #63 Extend Media model with optimization methods
- #64 Create optimization metadata migration
- #65 Create media library integration tests
- #66 Complete package documentation

## Motivation and Context

Phase 9 wires the media-library upload lifecycle into the Performance
package's image optimization pipeline so uploads are automatically
converted to modern formats, resized responsively, and enriched with
dominant-color LQIP metadata. Phase 10 finishes the package's user-facing
documentation so consumers can adopt every feature without spelunking the
source.

## Changes Made

**Listener + job (#62)**
- `src/Listeners/OptimizeUploadedMedia.php` — invokable listener guarded on
  `media_library_integration.enabled` / `.optimize_on_upload`. Unwraps
  either a bare `Media` model (from Eloquent's `created` event) or a
  future `MediaUploaded` event.
- `src/Jobs/OptimizeMediaJob.php` — queued job that runs the full
  ImageService pipeline, extracts the dominant color, and writes the
  metadata back onto the media row (lifecycle: pending → processing →
  completed / failed).
- Service provider wires the listener to `Media::created` when
  media-library is installed and to `MediaUploaded::class` if that event
  type is ever published upstream.

**Trait (#63)**
- `src/Traits/HasOptimizedMedia.php` — read-only accessors:
  `getOptimizedUrl($format, $size)`, `getSrcset($format)`,
  `getDominantColor()`, `isOptimized()`, `getOptimizationStatus()`.
- `src/Support/MediaOptimizationStatus.php` — shared status constants
  (avoids the PHP restriction against reading trait constants from
  outside a using class).

**Migration (#64)**
- `database/migrations/2026_01_01_000006_add_performance_columns_to_media_table.php`
  adds `dominant_color`, `optimization_status`, `optimized_at`,
  `optimized_formats`, `optimized_sizes` when the `media` table exists;
  no-op otherwise so applications without media-library never fail
  `migrate`. Idempotent per-column guards.

**Tests (#65)**
- `tests/Feature/Listeners/OptimizeUploadedMediaTest.php`
- `tests/Feature/Jobs/OptimizeMediaJobTest.php`
- `tests/Feature/Traits/HasOptimizedMediaTest.php`
- `tests/Feature/Database/MediaOptimizationMigrationTest.php`
- `tests/Feature/ServiceProviderTest.php` — added graceful-degradation tests
- `tests/Fixtures/MediaModelStub.php` — media-library-shaped stub model

**Documentation (#66)**
- `README.md` — comprehensive rewrite covering install, config, every
  feature area, Blade components, Blade directives, Livewire components,
  Artisan commands, middleware, events, helper functions, troubleshooting,
  and FAQ.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- PHP Version: 8.4.22
- Project Version: 1.0.0

**Tests Performed:**
1. `./vendor/bin/pest --compact` — 694 passed, 1 skipped, 1426 assertions.
2. `./vendor/bin/php-cs-fixer fix` — clean.
3. `./vendor/bin/phpcs` — 173 files, zero errors.

## Accessibility Tests Run

Not applicable — backend-only changes (event listener, job, trait,
migration) plus README documentation. No UI surface introduced.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** 26 new test cases across four test files exercise the
listener (config guards, non-image skips, event/model unwrapping), the
job (queue config, source resolution, success write-back, failed
lifecycle, dominant-color opt-out), the trait (all accessor branches
including JSON string normalization), and the migration (no-op path,
column-add path, idempotency, down path).

## Documentation

- [x] Inline code documentation added
- [x] README updated

**Documentation details:** README is now a full package reference (~650
lines) with 20+ code examples and a table of contents.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Code passes all tests
- [x] Code has been linted (php-cs-fixer + phpcs both clean)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added media optimization support for uploads, including queued processing, status tracking, generated formats/sizes, and dominant color extraction.
  * Added helper accessors for optimized URLs, responsive srcsets, color data, and optimization state.
  * Expanded package documentation with setup, configuration, troubleshooting, FAQ, and feature references.

* **Bug Fixes**
  * Improved database migration safety and idempotency for media optimization fields.
  * Added fallback handling when optimization data or source files are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->