### PR TITLE
feat(install): perf:install command, Keep a Changelog, examples/ tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,270 @@
-# ArtisanPack UI Performance Changelog
+# Changelog
 
-## Unreleased
+All notable changes to the `artisanpack-ui/performance` package are documented
+in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2026-07-04
+
+Initial public release of the ArtisanPack UI Performance package. Every
+feature ships opt-in via `config/artisanpack/performance.php` so an install
+adds zero overhead until a feature is toggled on.
 
 ### Added
 
-- **React + Vue companion components.** The package now ships React (`.tsx`) and Vue 3 (`.vue`) equivalents of every user-facing Livewire component and every Blade view component that renders interactive UI, so applications outside the TALL stack can consume the dashboard, image, embed, and speculative-loading pieces without giving up parity with the Livewire surface. Ships:
-  - Shared vanilla client at `resources/js/performance.ts` — typed `PerformanceClient` with methods for the dashboard, chart, cache, queries, recommendations, and metrics-ingest endpoints. Auto-resolves the CSRF token from a `<meta name="csrf-token">` tag; consumers can override the base URL and fetch implementation.
-  - React entry: `@artisanpack-ui/performance/react`. Components: `LazyImage`, `ResponsiveImage`, `PerfEmbed`, `PerfPrefetch`, `SpeculativeRules`, `PerformanceDashboard`, `MetricsChart`, `CacheManager`, `QueryAnalyzer`, `RecommendationsPanel`. Hook: `usePerformance` — thin wrapper that returns the shared client's methods and a small `useAsyncPayload` helper for load-on-mount patterns.
-  - Vue entry: `@artisanpack-ui/performance/vue`. Same component set as `.vue` SFCs plus a `usePerformance` composable that mirrors the React hook's API. `LazyImage`, `PerfEmbed`, and `SpeculativeRules` use `<Teleport>`/head-portal patterns where applicable so the injected `<script>` / `<link>` elements land in `<head>`.
-  - `package.json` at the package root declares `@artisanpack-ui/performance` with optional peer dependencies on `react`, `react-dom`, and `vue`. Sub-path exports (`./react`, `./vue`, `./web-vitals`, `./metrics-chart`, `./speculative-rules`) so hosts pull in only what they need.
-  - `tsconfig.json` mirrors the privacy package's setup (`ES2022`, bundler resolution, `jsx: preserve`, `.vue` in the include list).
-- **Admin JSON API for the dashboard, chart, cache, queries, and recommendations surfaces.** New endpoints under `POST/GET /api/performance/admin/*` back the React/Vue components (Livewire dashboards previously kept state on the server and could not be consumed from a bundler-based front-end). All endpoints run through `AdminApiController::authorizeAdmin()`, which resolves the ability name from `artisanpack.performance.dashboard.gate` and falls back to `view-performance-dashboard` when the config is blanked out — a missing or empty config cannot inadvertently expose the endpoints.
-  - `GET /admin/dashboard` (`DashboardAdminApiController`) — overview + pages + cache summary payload keyed by the requested range (`24h|7d|30d|90d`).
-  - `GET /admin/chart` (`ChartAdminApiController`) — chart payload matching the shape the bundled `metrics-chart.js` renders; accepts `metrics`, `range`, `show_threshold`, `type`.
-  - `GET /admin/cache` + `POST /admin/cache/actions` (`CacheAdminApiController`) — page and fragment cache snapshot plus mutating actions (`flush`, `warm`, `invalidate-key`, `invalidate-tag`).
-  - `GET /admin/queries` + `GET /admin/queries/export` (`QueriesAdminApiController`) — grouped slow-query rows with `IndexSuggester` hints; CSV export uses the same formula-injection sanitizer as the Livewire panel.
-  - `GET /admin/recommendations` + `POST /admin/recommendations/actions` (`RecommendationsAdminApiController`) — recommendation list with `apply`/`dismiss`/`reset` actions. Dismissals share the `artisanpack.performance.dismissed_recommendations` session key with the Livewire panel so users see a consistent state across both surfaces.
-- `OutputBuffer` (`ArtisanPackUI\Performance\Output\OutputBuffer`) — instance-scoped wrapper around PHP's output-buffering primitives. Supports nested `start()`/`end()`, exception-safe `capture()`, and a transformer pipeline used by downstream response mutators. Registered as a container singleton with an Octane request-received reset hook so a leaked open buffer can't carry across requests.
-- `MinifyHtml` middleware (`ArtisanPackUI\Performance\Http\Middleware\MinifyHtml`) — runs HTML responses through `HtmlMinifier`, skipping streamed/binary responses, non-2xx status codes, non-HTML content types, and routes matched by `html_minification.exclude_routes`. Updates `Content-Length` when the original response declared one. Aliased as `perf.minify` for route-group use.
-- `EarlyHints` middleware (`ArtisanPackUI\Performance\Http\Middleware\EarlyHints`) — emits an HTTP 103 Early Hints interim response with preload/preconnect Link headers before the controller runs, and mirrors the same hints into the final response so 103-unaware intermediaries (older caches, simple reverse proxies) still see the metadata. Hints merge config-supplied `manual_hints` with auto-detected entries from `ResourceHintInjector`; both sources are deduplicated by `(rel, href, as)`. SAPI emission uses `header()` + `flush()` (or `fastcgi_finish_request` under FPM) and is swappable for tests. Aliased as `perf.early-hints`.
-- `@perfMonitor` Blade directive and `Support\MonitorDirectives` helper — bootstraps the Core Web Vitals RUM collector by emitting an inline configuration script (endpoint, sample rate, CSRF token, route/page context) followed by a deferred `<script type="module">` tag pointing at the published `web-vitals.js`. Accepts per-call overrides (`endpoint`, `sampleRate`, `extra`, `src`) for per-page customization. Renders nothing when `monitoring.enabled` or `monitoring.collect_web_vitals` is off so opted-out environments don't ship dead JavaScript. Config gained a `monitoring.endpoint` key (defaulting to `/api/performance/metrics`).
-- `resources/js/web-vitals.js` Core Web Vitals collector — ESM module that imports the `web-vitals` npm package and posts LCP, FID, CLS, INP, and TTFB to the configured endpoint as they resolve. Session-level sampling, connection / device-type capture, `sendBeacon`-first transport with a `fetch({ keepalive: true })` fallback, and CSRF token forwarding via `X-CSRF-TOKEN`. Published under `resources/js/vendor/artisanpack-performance/` via the `artisanpack-performance-js` publish tag.
-- Laravel 13 support. The `illuminate/support` constraint now allows `^13.0` alongside the existing `^10.0|^11.0|^12.0` range. Laravel 13 requires PHP 8.3+; the PHP floor for users staying on older Laravel versions is unchanged.
+#### Core infrastructure
+
+- `PerformanceServiceProvider` — registers configuration, migrations, event
+  listeners, Blade directives, Livewire components, middleware aliases, the
+  admin route file, and every console command; publishes the package's four
+  publish tags (`artisanpack-performance-config`, `artisanpack-performance-js`,
+  `performance-views`, `performance-css`).
+- `perf:install` Artisan command — publishes the package configuration,
+  optionally publishes views / JavaScript / stylesheet, runs migrations,
+  validates PHP and Laravel versions plus storage writability, clears
+  configuration and view caches, and prints the dashboard gate stub with
+  next-step guidance. Idempotent; skips migrations already run and only
+  overwrites existing published files with `--force`. Flags: `--config`,
+  `--views`, `--js`, `--css`, `--migrations`, `--skip-migrate`,
+  `--skip-checks`, `--force`, and standard `--no-interaction`.
+- `Performance` facade + container singleton for programmatic access to
+  every service.
+- Global helper functions autoloaded via Composer for the common
+  request-lifecycle operations (feature toggles, cache reads, hint
+  registration, RUM ingestion).
+- Event system — package emits `PerformanceMetricRecorded`,
+  `CacheHit`, `CacheMissed`, `SlowQueryDetected`, `N1QueryDetected`,
+  `ImageOptimized`, and `RecommendationGenerated` events so applications
+  can subscribe without patching the package.
+- Database migrations for performance metrics, slow queries, cache
+  entries, and optimized images tables.
+
+#### Image optimization
+
+- WebP and AVIF conversion pipeline with quality controls per format and
+  per source image.
+- Responsive image generation (`ResponsiveImageGenerator`) with configurable
+  breakpoints, `srcset`/`sizes` output, and per-breakpoint cropping rules.
+- Lazy loading with placeholder generation — low-quality image placeholders
+  (LQIP), dominant-color placeholders via `DominantColorExtractor`, and
+  configurable intersection-observer thresholds.
+- `fetchpriority` hint support on above-the-fold imagery.
+- Queued image processing so uploads never block the request thread.
+- `perf:generate-webp` Artisan command for bulk conversion of the media
+  library.
+
+#### JavaScript & CSS
+
+- Script loading strategies — `AsyncStrategy`, `DeferStrategy`,
+  `ModuleStrategy`, `InlineStrategy`, and `ConditionalStrategy`, all
+  routed through `ScriptManager`.
+- Critical CSS extraction (`CriticalCssExtractor`) with per-route caching,
+  above-the-fold selectors, and inline injection in the document head.
+- Resource hints (`preload`, `prefetch`, `preconnect`, `dns-prefetch`)
+  with auto-detected hints for critical assets and a manual registration
+  API for developer-supplied hints.
+- Blade directives and view components for hint registration and script
+  strategy selection.
+- `perf:critical-css` Artisan command for regenerating critical CSS across
+  the site.
+
+#### Speculative loading
+
+- Speculation Rules API support with configurable eagerness levels and
+  URL pattern matching (`UrlPatternMatcher`).
+- `<x-perf-prefetch>` component for per-link prefetch/prerender opt-in.
+- Embed optimizer for YouTube / Vimeo / Twitter embeds — replaces heavy
+  iframes with click-to-load placeholders.
+
+#### Caching
+
+- Full-page caching with configurable exclude routes, exclude closures,
+  query-string handling, and vary-by keys.
+- Fragment caching keyed by tags with TTL and cache-warming support.
+- Cache warming CLI command (`perf:warm-cache`) that pre-fetches configured
+  URLs or Livewire component states on a schedule.
+- Automatic invalidation via `CacheInvalidator` — wire model events or
+  application events to a cache-tag map to clear related fragments on
+  writes.
+- `CacheStrategyManager` — selects between page cache, fragment cache, and
+  model-level caching based on the request context.
+- `CachingEloquentBuilder` — opt-in Eloquent macro that transparently
+  caches query results with automatic tag invalidation.
+- `perf:purge-cache` Artisan command with `--type=page|fragment|all` and
+  `--pattern`/`--tag` targeting.
+
+#### Database optimization
+
+- N+1 query detection (`N1Detector`) that logs offending relations and
+  suggests eager-load fixes.
+- Slow query logging (`SlowQueryLogger`) with configurable threshold and
+  aggregation.
+- Index suggestions (`IndexSuggester`) based on observed slow queries.
+- `perf:suggest-indexes` Artisan command for offline analysis of the slow
+  query log.
+- `QueryAnalyzer` for grouping slow queries by normalized SQL fingerprint.
+
+#### Server-side
+
+- HTML minification middleware (`MinifyHtml` / `perf.minify`) — runs HTML
+  responses through `HtmlMinifier`, skipping streamed / binary responses,
+  non-2xx status codes, non-HTML content types, and routes matched by
+  `html_minification.exclude_routes`. Updates `Content-Length` when the
+  original response declared one.
+- HTTP/2 Early Hints middleware (`EarlyHints` / `perf.early-hints`) —
+  emits an HTTP 103 interim response with preload / preconnect Link
+  headers before the controller runs, and mirrors the same hints into the
+  final response so 103-unaware intermediaries (older caches, simple
+  reverse proxies) still see the metadata. Hints merge config-supplied
+  `manual_hints` with auto-detected entries from `ResourceHintInjector`;
+  both sources are deduplicated by `(rel, href, as)`. SAPI emission uses
+  `header()` + `flush()` (or `fastcgi_finish_request` under FPM) and is
+  swappable for tests.
+- `OutputBuffer` (`ArtisanPackUI\Performance\Output\OutputBuffer`) —
+  instance-scoped wrapper around PHP's output-buffering primitives with
+  nested `start()`/`end()`, exception-safe `capture()`, and a transformer
+  pipeline used by downstream response mutators. Registered as a container
+  singleton with an Octane request-received reset hook so a leaked open
+  buffer can't carry across requests.
+
+#### Performance monitoring
+
+- Core Web Vitals RUM collector — LCP, FID, CLS, INP, and TTFB posted to
+  the ingest endpoint as they resolve.
+- `@perfMonitor` Blade directive and `Support\MonitorDirectives` helper —
+  bootstraps the Core Web Vitals RUM collector by emitting an inline
+  configuration script (endpoint, sample rate, CSRF token, route/page
+  context) followed by a deferred `<script type="module">` tag pointing at
+  the published `web-vitals.js`. Accepts per-call overrides (`endpoint`,
+  `sampleRate`, `extra`, `src`) for per-page customization. Renders nothing
+  when `monitoring.enabled` or `monitoring.collect_web_vitals` is off so
+  opted-out environments don't ship dead JavaScript.
+- `resources/js/web-vitals.js` Core Web Vitals collector — ESM module that
+  imports the `web-vitals` npm package and posts metrics to the configured
+  endpoint as they resolve. Session-level sampling, connection / device-type
+  capture, `sendBeacon`-first transport with a `fetch({ keepalive: true })`
+  fallback, and CSRF token forwarding via `X-CSRF-TOKEN`. Published under
+  `resources/js/vendor/artisanpack-performance/` via the
+  `artisanpack-performance-js` publish tag.
+- Livewire performance dashboard — overview, per-page metrics, cache
+  manager, query analyzer, and recommendations panel.
+- `RecommendationEngine` — scans aggregated metrics for LCP hotspots,
+  N+1 offenders, oversized assets, and cache-miss patterns.
+- `MetricsAggregator` — rolls raw metric events into 24h, 7d, 30d, and
+  90d buckets, dispatched by the `perf:aggregate-metrics` scheduled
+  command.
+
+#### Admin JSON API
+
+- New endpoints under `POST/GET /api/performance/admin/*` back the
+  React/Vue components (Livewire dashboards previously kept state on the
+  server and could not be consumed from a bundler-based front-end). All
+  endpoints run through `AdminApiController::authorizeAdmin()`, which
+  resolves the ability name from `artisanpack.performance.dashboard.gate`
+  and falls back to `view-performance-dashboard` when the config is
+  blanked out — a missing or empty config cannot inadvertently expose the
+  endpoints.
+  - `GET /admin/dashboard` (`DashboardAdminApiController`) — overview +
+    pages + cache summary payload keyed by the requested range
+    (`24h|7d|30d|90d`).
+  - `GET /admin/chart` (`ChartAdminApiController`) — chart payload
+    matching the shape the bundled `metrics-chart.js` renders; accepts
+    `metrics`, `range`, `show_threshold`, `type`.
+  - `GET /admin/cache` + `POST /admin/cache/actions`
+    (`CacheAdminApiController`) — page and fragment cache snapshot plus
+    mutating actions (`flush`, `warm`, `invalidate-key`,
+    `invalidate-tag`).
+  - `GET /admin/queries` + `GET /admin/queries/export`
+    (`QueriesAdminApiController`) — grouped slow-query rows with
+    `IndexSuggester` hints; CSV export uses a formula-injection
+    sanitizer.
+  - `GET /admin/recommendations` + `POST /admin/recommendations/actions`
+    (`RecommendationsAdminApiController`) — recommendation list with
+    `apply`/`dismiss`/`reset` actions. Dismissals share the
+    `artisanpack.performance.dismissed_recommendations` session key with
+    the Livewire panel so users see a consistent state across both
+    surfaces.
+- Metrics ingest endpoint (`POST /api/performance/metrics`) — accepts
+  Core Web Vitals payloads from the browser collector, validates them
+  against `monitoring.sample_rate`, and dispatches
+  `PerformanceMetricRecorded` for downstream storage.
+
+#### React + Vue companion components
+
+- Shared vanilla client at `resources/js/performance.ts` — typed
+  `PerformanceClient` with methods for the dashboard, chart, cache,
+  queries, recommendations, and metrics-ingest endpoints. Auto-resolves
+  the CSRF token from a `<meta name="csrf-token">` tag; consumers can
+  override the base URL and fetch implementation.
+- React entry: `@artisanpack-ui/performance/react`. Components:
+  `LazyImage`, `ResponsiveImage`, `PerfEmbed`, `PerfPrefetch`,
+  `SpeculativeRules`, `PerformanceDashboard`, `MetricsChart`,
+  `CacheManager`, `QueryAnalyzer`, `RecommendationsPanel`. Hook:
+  `usePerformance` — thin wrapper that returns the shared client's
+  methods and a small `useAsyncPayload` helper for load-on-mount
+  patterns.
+- Vue entry: `@artisanpack-ui/performance/vue`. Same component set as
+  `.vue` SFCs plus a `usePerformance` composable that mirrors the React
+  hook's API. `LazyImage`, `PerfEmbed`, and `SpeculativeRules` use
+  `<Teleport>`/head-portal patterns where applicable so the injected
+  `<script>` / `<link>` elements land in `<head>`.
+- `package.json` at the package root declares
+  `@artisanpack-ui/performance` with optional peer dependencies on
+  `react`, `react-dom`, and `vue`. Sub-path exports (`./react`, `./vue`,
+  `./web-vitals`, `./metrics-chart`, `./speculative-rules`) so hosts
+  pull in only what they need.
+- `tsconfig.json` mirrors the privacy package's setup (`ES2022`, bundler
+  resolution, `jsx: preserve`, `.vue` in the include list).
+
+#### Documentation
+
+- `docs/` tree with feature guides for image optimization, caching,
+  database optimization, speculative loading, monitoring, and the admin
+  API.
+- `examples/` directory with runnable snippets covering the quick-start
+  path, image optimization, JavaScript / CSS optimization, caching,
+  database, monitoring, and existing-app integration.
+- `CHANGELOG.md` following Keep a Changelog format.
+- `README.md`, `CONTRIBUTING.md`, and inline PHPDoc on every public
+  class and method.
+
+### Changed
+
+- `illuminate/support` constraint now allows `^13.0` alongside the
+  existing `^10.0|^11.0|^12.0` range. Laravel 13 requires PHP 8.3+; the
+  PHP floor for users staying on older Laravel versions is unchanged.
+
+### Security
+
+- Admin JSON API endpoints fall back to the
+  `view-performance-dashboard` ability when the configured gate name is
+  blank so a mis-published config cannot inadvertently expose the
+  endpoints.
+- Slow-query CSV export sanitizes formula-injection payloads
+  (`=`, `+`, `-`, `@`, tab, carriage return) in every cell before
+  writing.
+- Metrics ingest endpoint validates payload shape and rejects unknown
+  metric names so a compromised browser cannot poison the aggregated
+  metrics store.
+
+### Migration notes
+
+- Fresh install: run `php artisan perf:install --no-interaction` after
+  `composer require artisanpack-ui/performance`. Every feature is off by
+  default; enable only what you need in
+  `config/artisanpack/performance.php`.
+- Define the `view-performance-dashboard` gate (or your configured gate
+  name) in `AuthServiceProvider::boot()` before the dashboard route is
+  reachable.
+- Add `@perfMonitor` to your main layout to start collecting Core Web
+  Vitals data.
+- Publish and rebuild the JavaScript bundle when integrating the
+  React / Vue components: `php artisan vendor:publish --tag=artisanpack-performance-js`
+  followed by your normal `npm run build`.
+
+[Unreleased]: https://github.com/ArtisanPack-UI/performance/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/ArtisanPack-UI/performance/releases/tag/v1.0.0

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,27 @@
+# Examples
+
+Runnable snippets that demonstrate how each feature of the
+`artisanpack-ui/performance` package fits into a Laravel application.
+
+Every feature ships **disabled** by default. The examples below assume
+you have already installed the package and run the install command:
+
+```bash
+composer require artisanpack-ui/performance
+php artisan perf:install --no-interaction
+```
+
+## Directory layout
+
+| Directory | What's inside |
+|-----------|---------------|
+| [`basic-setup/`](basic-setup) | Quick start, minimal config, and full-featured config |
+| [`image-optimization/`](image-optimization) | WebP/AVIF conversion, responsive images, lazy loading, custom sizes |
+| [`javascript-css/`](javascript-css) | Script defer/async, critical CSS, resource hints, module loading |
+| [`caching/`](caching) | Page caching, fragment caching, cache warming, invalidation patterns |
+| [`database/`](database) | N+1 detection, query optimization, slow query logging |
+| [`monitoring/`](monitoring) | Dashboard integration, custom metrics, API usage |
+| [`integrations/`](integrations) | Media library integration, existing-app integration, multi-tenant setup |
+
+Each subdirectory has its own `README.md` that walks through the
+snippets in the order you'd apply them to a real app.

--- a/examples/basic-setup/README.md
+++ b/examples/basic-setup/README.md
@@ -1,0 +1,52 @@
+# Basic Setup
+
+Three snippets that get the package from "installed" to "running".
+
+## 1. Quick start
+
+`composer require` + install command + a single feature toggle. This is
+enough to start collecting Core Web Vitals from every page.
+
+```bash
+composer require artisanpack-ui/performance
+php artisan perf:install --no-interaction
+```
+
+Then in `config/artisanpack/performance.php`:
+
+```php
+'features' => [
+    'monitoring' => true,
+],
+```
+
+And in `resources/views/layouts/app.blade.php`:
+
+```blade
+<head>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    {{-- other head tags --}}
+    @perfMonitor
+</head>
+```
+
+Reload any page. Web Vitals now POST to
+`/api/performance/metrics` and land in the `performance_metrics` table.
+
+See [`quick-start.md`](quick-start.md) for the fully commented walkthrough.
+
+## 2. Minimal configuration
+
+The smallest sensible config for a production app — page cache, HTML
+minification, and monitoring on. Nothing else.
+
+See [`minimal-config.php`](minimal-config.php).
+
+## 3. Full-featured configuration
+
+Every feature on, with production-grade tuning (short cache TTLs, low
+sample rate, aggressive image optimization). Copy into your
+`config/artisanpack/performance.php` as a starting point and pare back
+what you don't need.
+
+See [`full-featured-config.php`](full-featured-config.php).

--- a/examples/basic-setup/full-featured-config.php
+++ b/examples/basic-setup/full-featured-config.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Full-featured configuration example for artisanpack-ui/performance.
+ *
+ * Every feature toggle is on. Use this to see the shape of every knob
+ * before you decide what to enable in your app.
+ *
+ * A production install rarely wants ALL of these on — critical CSS,
+ * for example, has a real build cost. Pare back what you don't need.
+ */
+
+return [
+
+    'features' => [
+        'image_optimization'  => true,
+        'lazy_loading'        => true,
+        'script_optimization' => true,
+        'critical_css'        => true,
+        'resource_hints'      => true,
+        'speculative_loading' => true,
+        'html_minification'   => true,
+        'early_hints'         => true,
+        'page_caching'        => true,
+        'fragment_caching'    => true,
+        'query_optimization'  => true,
+        'monitoring'          => true,
+        'dashboard'           => true,
+    ],
+
+    'image_optimization' => [
+        'enabled'   => true,
+        'formats'   => [ 'webp', 'avif' ],
+        'quality'   => [
+            'webp' => 82,
+            'avif' => 65,
+        ],
+        'queue'     => 'images',
+        'sizes'     => [
+            'thumbnail' => [ 320, 240 ],
+            'medium'    => [ 768, 512 ],
+            'large'     => [ 1440, 960 ],
+        ],
+    ],
+
+    'page_cache' => [
+        'enabled'             => true,
+        'driver'              => env( 'CACHE_STORE', 'redis' ),
+        'ttl'                 => 3600,
+        'exclude_routes'      => [ 'admin/*', 'api/*' ],
+        'exclude_when'        => [],
+        'vary_by'             => [ 'auth' ],
+        'cache_query_strings' => false,
+    ],
+
+    'fragment_cache' => [
+        'enabled'     => true,
+        'driver'      => env( 'CACHE_STORE', 'redis' ),
+        'default_ttl' => 1800,
+    ],
+
+    'monitoring' => [
+        'enabled'            => true,
+        'collect_web_vitals' => true,
+        'sample_rate'        => 0.25,
+        'endpoint'           => '/api/performance/metrics',
+    ],
+
+    'dashboard' => [
+        'enabled'      => true,
+        'route_prefix' => 'admin/performance',
+        'middleware'   => [ 'web', 'auth' ],
+        'gate'         => 'view-performance-dashboard',
+    ],
+];

--- a/examples/basic-setup/minimal-config.php
+++ b/examples/basic-setup/minimal-config.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Minimal configuration example for artisanpack-ui/performance.
+ *
+ * This is the smallest config that still ships something useful in
+ * production — page cache, HTML minification, and Core Web Vitals
+ * monitoring. Copy this into config/artisanpack/performance.php as a
+ * starting point.
+ */
+
+return [
+
+    'features' => [
+        'page_caching'      => true,
+        'html_minification' => true,
+        'monitoring'        => true,
+        'dashboard'         => true,
+    ],
+
+    'page_cache' => [
+        'enabled'             => true,
+        'driver'              => env( 'CACHE_STORE', 'redis' ),
+        'ttl'                 => 3600,
+        'exclude_routes'      => [
+            'admin/*',
+            'api/*',
+            'login',
+            'logout',
+        ],
+        'exclude_when'        => [],
+        'vary_by'             => [ 'auth' ],
+        'cache_query_strings' => false,
+    ],
+
+    'html_minification' => [
+        'enabled'        => true,
+        'exclude_routes' => [
+            'admin/*',
+            'api/*',
+        ],
+    ],
+
+    'monitoring' => [
+        'enabled'            => true,
+        'collect_web_vitals' => true,
+        'sample_rate'        => 1.0,
+        'endpoint'           => '/api/performance/metrics',
+    ],
+
+    'dashboard' => [
+        'enabled'      => true,
+        'route_prefix' => 'admin/performance',
+        'middleware'   => [ 'web', 'auth' ],
+        'gate'         => 'view-performance-dashboard',
+    ],
+];

--- a/examples/basic-setup/quick-start.md
+++ b/examples/basic-setup/quick-start.md
@@ -1,0 +1,69 @@
+# Quick start
+
+The shortest path from a fresh Laravel app to a working Performance
+package install.
+
+## 1. Install
+
+```bash
+composer require artisanpack-ui/performance
+
+# Publishes config, runs migrations, prints the dashboard gate stub.
+php artisan perf:install --no-interaction
+```
+
+## 2. Toggle on the features you want
+
+Every feature is off after install. Open
+`config/artisanpack/performance.php` and set the toggles for the
+features you plan to use:
+
+```php
+'features' => [
+    'image_optimization'  => true,
+    'lazy_loading'        => true,
+    'script_optimization' => true,
+    'page_caching'        => true,
+    'monitoring'          => true,
+    'dashboard'           => true,
+],
+```
+
+Every feature also has a matching env var (`PERF_IMAGE_OPTIMIZATION`,
+`PERF_MONITORING`, …) so a feature can be toggled per-environment
+without editing config.
+
+## 3. Wire the dashboard gate
+
+Add to `AuthServiceProvider::boot()`:
+
+```php
+use Illuminate\Support\Facades\Gate;
+
+Gate::define('view-performance-dashboard', function ($user) {
+    return $user->hasRole('admin');
+});
+```
+
+## 4. Add the RUM collector
+
+In your main layout:
+
+```blade
+<head>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    {{-- everything else in <head> --}}
+    @perfMonitor
+</head>
+```
+
+Web Vitals now POST to `/api/performance/metrics` as visitors browse.
+
+## 5. Visit the dashboard
+
+`https://your-app.test/admin/performance`
+
+You'll see the overview, per-page metrics, cache manager, query
+analyzer, and recommendations panel. All of the panels are also
+available as React and Vue components under
+`@artisanpack-ui/performance/react` / `/vue`.

--- a/examples/caching/README.md
+++ b/examples/caching/README.md
@@ -1,0 +1,11 @@
+# Caching
+
+Snippets for page caching, fragment caching, cache warming, and
+invalidation patterns.
+
+## Examples
+
+- [`page-cache-setup.php`](page-cache-setup.php) — turn on full-page caching with exclude routes and vary-by keys
+- [`fragment-cache.blade.php`](fragment-cache.blade.php) — cache an expensive Blade fragment with `@perfCache`
+- [`cache-warming.php`](cache-warming.php) — schedule `perf:warm-cache` to keep hot URLs in cache
+- [`invalidation.php`](invalidation.php) — model observer + `CacheInvalidator` pattern for automatic tag invalidation

--- a/examples/caching/cache-warming.php
+++ b/examples/caching/cache-warming.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Cache warming.
+ *
+ * `perf:warm-cache` walks a list of URLs and requests each one so the
+ * page cache and fragment cache are populated before the first real
+ * visitor arrives. Combine with the deploy hook to avoid a
+ * cold-cache latency spike after every deploy.
+ */
+
+use Illuminate\Console\Scheduling\Schedule;
+
+// ---------------------------------------------------------------------
+// 1. Configure the URLs to warm.
+// ---------------------------------------------------------------------
+//
+// config/artisanpack/performance.php
+//
+//   'cache_warming' => [
+//       'enabled'     => true,
+//       'concurrency' => 4,
+//       'urls' => [
+//           '/',
+//           '/products',
+//           '/products/featured',
+//           '/blog',
+//           '/pricing',
+//       ],
+//       'sitemap' => 'https://example.com/sitemap.xml',
+//   ],
+
+// ---------------------------------------------------------------------
+// 2. Schedule the warm command.
+// ---------------------------------------------------------------------
+// routes/console.php (Laravel 12)
+
+/** @var Schedule $schedule */
+
+// Warm every 15 minutes so URLs never fall out of cache during peak.
+$schedule->command( 'perf:warm-cache' )
+    ->everyFifteenMinutes()
+    ->withoutOverlapping()
+    ->onOneServer();
+
+// Warm the sitemap-derived list once an hour.
+$schedule->command( 'perf:warm-cache', [ '--sitemap' => 'https://example.com/sitemap.xml' ] )
+    ->hourly()
+    ->withoutOverlapping()
+    ->onOneServer();
+
+// ---------------------------------------------------------------------
+// 3. Warm on deploy.
+// ---------------------------------------------------------------------
+//
+//   # deploy.sh
+//   php artisan config:cache
+//   php artisan route:cache
+//   php artisan perf:warm-cache --force

--- a/examples/caching/fragment-cache.blade.php
+++ b/examples/caching/fragment-cache.blade.php
@@ -1,0 +1,36 @@
+{{--
+    Fragment caching.
+
+    Wrap an expensive Blade fragment in @perfCache. The rendered HTML
+    is stored in the fragment cache under the given key and tagged so
+    it can be invalidated by tag from anywhere in the app.
+
+    Requires:
+      'features' => [
+          'fragment_caching' => true,
+      ],
+--}}
+
+{{-- Cache the header for 30 minutes; tag it so a nav change flushes it. --}}
+@perfCache( 'site-header', ttl: 1800, tags: [ 'nav', 'header' ] )
+    <header class="site-header">
+        <x-nav :items="$navItems" />
+    </header>
+@endPerfCache
+
+{{-- Per-user product recommendations — key includes the user id so
+     different users see different cached HTML. --}}
+@perfCache( "recs.user.{$user->id}", ttl: 900, tags: [ "user.{$user->id}", 'recommendations' ] )
+    <section class="recommendations">
+        @foreach ( $recommendations as $product )
+            <x-product-card :product="$product" />
+        @endforeach
+    </section>
+@endPerfCache
+
+{{-- Flush by tag from a controller / listener:
+
+     use ArtisanPackUI\Performance\Cache\CacheInvalidator;
+
+     app( CacheInvalidator::class )->invalidateFragmentTag( 'nav' );
+--}}

--- a/examples/caching/invalidation.php
+++ b/examples/caching/invalidation.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Cache invalidation.
+ *
+ * Two patterns:
+ *   1. Model observer — invalidate tags whenever a model is saved,
+ *      updated, or deleted.
+ *   2. Manual invalidation — call CacheInvalidator directly from a
+ *      controller / listener / job.
+ */
+
+namespace App\Observers;
+
+use App\Models\Product;
+use ArtisanPackUI\Performance\Cache\CacheInvalidator;
+
+class ProductObserver
+{
+    public function __construct(
+        protected CacheInvalidator $invalidator,
+    ) {}
+
+    public function saved( Product $product ): void
+    {
+        // Flush the individual product's fragment cache.
+        $this->invalidator->invalidateFragmentTag( "product.{$product->id}" );
+
+        // Flush any product-list pages that showed this product.
+        $this->invalidator->invalidateFragmentTag( 'product-list' );
+
+        // Flush the page cache for the product URL and its parent category.
+        $this->invalidator->invalidatePagePattern( "products/{$product->slug}" );
+        $this->invalidator->invalidatePagePattern( "categories/{$product->category->slug}" );
+    }
+
+    public function deleted( Product $product ): void
+    {
+        $this->invalidator->invalidateFragmentTag( "product.{$product->id}" );
+        $this->invalidator->invalidateFragmentTag( 'product-list' );
+        $this->invalidator->flushPageCache();
+    }
+}
+
+/*
+ * Register the observer in App\Providers\AppServiceProvider::boot():
+ *
+ *   Product::observe(ProductObserver::class);
+ *
+ * Manual invalidation from anywhere:
+ *
+ *   use ArtisanPackUI\Performance\Cache\CacheInvalidator;
+ *
+ *   app(CacheInvalidator::class)->purgeAll();               // Everything.
+ *   app(CacheInvalidator::class)->flushPageCache();          // All pages.
+ *   app(CacheInvalidator::class)->invalidatePagePattern('products/*');
+ *   app(CacheInvalidator::class)->invalidateFragmentTag('nav');
+ */

--- a/examples/caching/page-cache-setup.php
+++ b/examples/caching/page-cache-setup.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Page cache configuration example.
+ *
+ * The page cache stores a full HTML response keyed by URL + vary-by
+ * keys, then serves subsequent requests directly from cache. Excluded
+ * routes (auth, admin, POST) skip the cache entirely.
+ */
+
+return [
+
+    'features' => [
+        'page_caching' => true,
+    ],
+
+    'page_cache' => [
+
+        'enabled' => true,
+
+        // Any Laravel cache store — redis / memcached / dynamodb / file.
+        'driver' => env( 'CACHE_STORE', 'redis' ),
+
+        'ttl' => 3600,
+
+        // Routes that should NEVER hit the cache — auth, mutations,
+        // admin, API. Wildcards use Laravel's `Str::is()` matching.
+        'exclude_routes' => [
+            'admin/*',
+            'api/*',
+            'login',
+            'logout',
+            'checkout/*',
+        ],
+
+        // Closures that skip the cache for a specific request. Useful
+        // for logged-in previews, A/B test buckets, feature flags.
+        'exclude_when' => [
+            static function ( $request ): bool {
+                return $request->user()?->hasRole( 'preview' ) ?? false;
+            },
+        ],
+
+        // Cache keys are suffixed with the resolved value of each entry.
+        // Common choices: `auth` (segments authenticated vs guest), a
+        // header ('Accept-Language'), a cookie ('locale'), or a
+        // custom closure.
+        'vary_by' => [
+            'auth',
+            'header:Accept-Language',
+            static fn ( $request ) => $request->cookie( 'currency', 'USD' ),
+        ],
+
+        // When false, ?utm_source=… variants share a single cache
+        // entry. Turn on when query strings actually change the page
+        // (search, filters).
+        'cache_query_strings' => false,
+    ],
+];
+
+/*
+ * Add the middleware to the `web` group in bootstrap/app.php:
+ *
+ *   ->withMiddleware(function (Middleware $middleware) {
+ *       $middleware->web(append: [
+ *           \ArtisanPackUI\Performance\Http\Middleware\PageCache::class,
+ *       ]);
+ *   })
+ *
+ * The middleware is a no-op when the page_cache feature is off, so it
+ * is safe to leave in every environment.
+ */

--- a/examples/database/README.md
+++ b/examples/database/README.md
@@ -1,0 +1,10 @@
+# Database
+
+Snippets for N+1 detection, slow query logging, and index suggestions.
+
+## Examples
+
+- [`n1-detection.php`](n1-detection.php) — turn on N+1 detection and subscribe to the event
+- [`slow-query-logging.php`](slow-query-logging.php) — log slow queries and read them from the dashboard / API
+- [`index-suggestions.md`](index-suggestions.md) — run `perf:suggest-indexes` to convert observed slow queries into `CREATE INDEX` statements
+- [`query-optimization.php`](query-optimization.php) — opt into `CachingEloquentBuilder` for a specific model

--- a/examples/database/index-suggestions.md
+++ b/examples/database/index-suggestions.md
@@ -1,0 +1,40 @@
+# Index suggestions
+
+`perf:suggest-indexes` scans the `performance_slow_queries` table,
+groups by normalized SQL fingerprint, runs `EXPLAIN` on the slowest
+member of each group, and outputs `CREATE INDEX` statements for
+columns the planner filtered / sorted on without an index.
+
+## Run it
+
+```bash
+# Print index suggestions to STDOUT.
+php artisan perf:suggest-indexes
+
+# Only look at queries logged in the last 24 hours.
+php artisan perf:suggest-indexes --range=24h
+
+# Only queries slower than 500ms.
+php artisan perf:suggest-indexes --threshold=500
+
+# Write the suggested statements to a migration file.
+php artisan perf:suggest-indexes --output=database/migrations/2026_07_04_000000_add_perf_indexes.php
+```
+
+## Example output
+
+```sql
+-- Slow: orders.user_id filtered, no index. avg 812ms, 43 hits, 24h.
+CREATE INDEX orders_user_id_index ON orders (user_id);
+
+-- Slow: order_items.order_id + created_at composite filter. avg 611ms, 38 hits, 24h.
+CREATE INDEX order_items_order_id_created_at_index ON order_items (order_id, created_at);
+```
+
+## Review before applying
+
+The command is a suggestion engine, not a schema migrator — it never
+runs `CREATE INDEX` for you. Review each suggestion, drop redundant
+indexes, and roll them out as normal migrations. Long-running index
+creation on a large table needs the usual care (`ALGORITHM=INPLACE`,
+`LOCK=NONE`, off-peak deploy).

--- a/examples/database/n1-detection.php
+++ b/examples/database/n1-detection.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * N+1 detection.
+ *
+ * `N1Detector` hooks Laravel's query log and flags relations that were
+ * loaded lazily inside a loop. It emits an `N1QueryDetected` event so
+ * you can log, alert, or fail tests.
+ */
+
+// ---------------------------------------------------------------------
+// 1. Enable in config.
+// ---------------------------------------------------------------------
+
+// config/artisanpack/performance.php
+return [
+
+    'features' => [
+        'query_optimization' => true,
+    ],
+
+    'query_optimization' => [
+        'detect_n1'   => true,
+        'threshold'   => 5,                 // Flag when >= 5 queries hit the same relation.
+        'fail_tests'  => env( 'APP_ENV' ) === 'testing',
+    ],
+];
+
+// ---------------------------------------------------------------------
+// 2. Subscribe to the event.
+// ---------------------------------------------------------------------
+
+namespace App\Providers;
+
+use ArtisanPackUI\Performance\Events\N1QueryDetected;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\ServiceProvider;
+
+class N1EventProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        Event::listen( function ( N1QueryDetected $event ): void {
+            Log::channel( 'performance' )->warning( 'N+1 detected', [
+                'model'    => $event->model,
+                'relation' => $event->relation,
+                'count'    => $event->count,
+                'url'      => $event->url,
+            ] );
+        } );
+    }
+}
+
+/*
+ * Once enabled, the shipped RecommendationEngine will also pick up
+ * repeated N+1 offenders and surface them in the dashboard's
+ * Recommendations panel with the suggested `->with(...)` fix.
+ */

--- a/examples/database/query-optimization.php
+++ b/examples/database/query-optimization.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Query optimization — CachingEloquentBuilder.
+ *
+ * Opt a specific model into a transparent query-result cache. The
+ * builder caches the result of any query, tags it with the model's
+ * table, and flushes the tag on save/update/delete via a shipped
+ * model observer.
+ */
+
+namespace App\Models;
+
+use ArtisanPackUI\Performance\Traits\HasCachingQueryBuilder;
+use Illuminate\Database\Eloquent\Model;
+
+class Category extends Model
+{
+    use HasCachingQueryBuilder;
+
+    /**
+     * TTL (seconds) for cached query results for this model.
+     * Optional — defaults to `artisanpack.performance.query_cache.default_ttl`.
+     */
+    protected int $queryCacheTtl = 3600;
+}
+
+/*
+ * Reads now transparently hit the query cache:
+ *
+ *   $tree = Category::whereNull('parent_id')
+ *       ->with('children')
+ *       ->orderBy('name')
+ *       ->get(); // First call runs the SQL and caches the result.
+ *
+ *   Category::query()->orderBy('name')->get(); // Second call hits the cache.
+ *
+ * Writes invalidate automatically:
+ *
+ *   Category::create(['name' => 'New', 'parent_id' => 1]); // Cache flushed.
+ *
+ * Disable per-call when you need fresh data (admin panels, reports):
+ *
+ *   Category::query()->withoutQueryCache()->orderBy('name')->get();
+ */

--- a/examples/database/slow-query-logging.php
+++ b/examples/database/slow-query-logging.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Slow query logging.
+ *
+ * SlowQueryLogger writes every query slower than the configured
+ * threshold to the `performance_slow_queries` table with a normalized
+ * SQL fingerprint so the dashboard can group them.
+ */
+
+return [
+
+    'features' => [
+        'query_optimization' => true,
+    ],
+
+    'query_optimization' => [
+
+        'log_slow_queries' => true,
+
+        // Anything slower than this (ms) gets logged. Start high and
+        // tighten as you clean up offenders.
+        'slow_threshold' => 100,
+
+        // Sample rate keeps write volume in check on high-traffic apps.
+        // 1.0 = log every slow query; 0.1 = log 10%.
+        'sample_rate' => 1.0,
+
+        // Optional allowlist. When set, only queries against these
+        // connections are logged.
+        'connections' => [ 'mysql', 'analytics' ],
+    ],
+];
+
+/*
+ * Read slow queries from the API:
+ *
+ *   GET /api/performance/admin/queries?range=24h
+ *
+ * Or from Tinker:
+ *
+ *   use ArtisanPackUI\Performance\Models\PerformanceSlowQuery;
+ *
+ *   PerformanceSlowQuery::query()
+ *       ->where('duration_ms', '>=', 500)
+ *       ->groupBy('normalized_sql')
+ *       ->selectRaw('normalized_sql, count(*) as hits, avg(duration_ms) as avg_ms')
+ *       ->orderByDesc('avg_ms')
+ *       ->take(20)
+ *       ->get();
+ */

--- a/examples/image-optimization/README.md
+++ b/examples/image-optimization/README.md
@@ -1,0 +1,22 @@
+# Image optimization
+
+Snippets covering WebP/AVIF conversion, responsive images, lazy
+loading, and registering custom image sizes.
+
+## Enable the feature
+
+`config/artisanpack/performance.php`:
+
+```php
+'features' => [
+    'image_optimization' => true,
+    'lazy_loading'       => true,
+],
+```
+
+## Examples
+
+- [`webp-avif-conversion.php`](webp-avif-conversion.php) — bulk convert existing images to WebP + AVIF via the `perf:generate-webp` command and the queued job pipeline
+- [`responsive-images.blade.php`](responsive-images.blade.php) — `<x-perf-responsive-image>` with automatic `srcset` and `sizes`
+- [`lazy-loading.blade.php`](lazy-loading.blade.php) — lazy-loaded image with a dominant-color placeholder
+- [`custom-sizes.php`](custom-sizes.php) — register a `product-thumb` image size and use it in a Blade view

--- a/examples/image-optimization/custom-sizes.php
+++ b/examples/image-optimization/custom-sizes.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Registering custom image sizes.
+ *
+ * Register once in a service provider; the size is then available to
+ * every Blade component, the queued conversion pipeline, and the
+ * `perf:generate-webp` command.
+ */
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class ImageSizeServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        // Register at boot so the size is picked up before views render.
+        config( [
+            'artisanpack.performance.image_optimization.sizes.product-thumb' => [ 300, 300 ],
+            'artisanpack.performance.image_optimization.sizes.hero'          => [ 1920, 1080 ],
+            'artisanpack.performance.image_optimization.sizes.og'            => [ 1200, 630 ],
+        ] );
+    }
+}
+
+/*
+ * Use the registered size in a Blade view:
+ *
+ *   <x-perf-responsive-image
+ *       :src="asset('uploads/mug.jpg')"
+ *       alt="Ceramic mug"
+ *       size="product-thumb"
+ *   />
+ *
+ * Or via the shipped helper function:
+ *
+ *   {{ perfImageUrl('uploads/mug.jpg', 'product-thumb') }}
+ *
+ * The queued conversion pipeline picks up new sizes on the next
+ * `perf:generate-webp` run.
+ */

--- a/examples/image-optimization/lazy-loading.blade.php
+++ b/examples/image-optimization/lazy-loading.blade.php
@@ -1,0 +1,41 @@
+{{--
+    Lazy loading with a dominant-color placeholder.
+
+    <x-perf-lazy-image> ships a data-src attribute, a solid-color
+    placeholder computed from the source image's dominant color, and an
+    IntersectionObserver bootstrap that swaps in the real src when the
+    element enters the viewport.
+
+    Requires:
+      'features' => [
+          'image_optimization' => true,
+          'lazy_loading'       => true,
+      ],
+--}}
+
+{{-- Basic lazy image with a computed dominant-color placeholder. --}}
+<x-perf-lazy-image
+    :src="asset( 'uploads/product-1.jpg' )"
+    alt="Handmade ceramic mug"
+    width="800"
+    height="600"
+/>
+
+{{-- Custom threshold — start loading 200px before the image enters the viewport. --}}
+<x-perf-lazy-image
+    :src="asset( 'uploads/product-2.jpg' )"
+    alt="Handmade ceramic bowl"
+    width="800"
+    height="600"
+    :threshold="200"
+/>
+
+{{-- Force above-the-fold images to load eagerly and hint fetchpriority. --}}
+<x-perf-lazy-image
+    :src="asset( 'uploads/hero.jpg' )"
+    alt="Store hero"
+    width="1920"
+    height="800"
+    loading="eager"
+    fetchpriority="high"
+/>

--- a/examples/image-optimization/responsive-images.blade.php
+++ b/examples/image-optimization/responsive-images.blade.php
@@ -1,0 +1,46 @@
+{{--
+    Responsive image example.
+
+    Uses the shipped <x-perf-responsive-image> component. The component
+    reads registered image sizes from
+    artisanpack.performance.image_optimization.sizes and generates a
+    srcset covering every size, plus a sensible sizes attribute.
+
+    Requires:
+      'features' => [
+          'image_optimization' => true,
+      ],
+--}}
+
+<x-perf-responsive-image
+    :src="asset( 'uploads/hero.jpg' )"
+    alt="Product hero shot"
+    sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+    fetchpriority="high"
+    class="w-full h-auto"
+/>
+
+{{--
+    Rendered output (illustrative):
+
+    <picture>
+        <source
+            type="image/avif"
+            srcset="/uploads/hero-320.avif 320w, /uploads/hero-768.avif 768w, /uploads/hero-1440.avif 1440w"
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+        />
+        <source
+            type="image/webp"
+            srcset="/uploads/hero-320.webp 320w, /uploads/hero-768.webp 768w, /uploads/hero-1440.webp 1440w"
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+        />
+        <img
+            src="/uploads/hero.jpg"
+            srcset="/uploads/hero-320.jpg 320w, /uploads/hero-768.jpg 768w, /uploads/hero-1440.jpg 1440w"
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+            alt="Product hero shot"
+            fetchpriority="high"
+            class="w-full h-auto"
+        />
+    </picture>
+--}}

--- a/examples/image-optimization/webp-avif-conversion.php
+++ b/examples/image-optimization/webp-avif-conversion.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * WebP + AVIF conversion example.
+ *
+ * Two paths:
+ *   1. Bulk: convert every image in the media library (or a specific
+ *      disk) via the shipped Artisan command.
+ *   2. On upload: dispatch the queued job so newly uploaded images are
+ *      converted without blocking the request.
+ */
+
+// ---------------------------------------------------------------------
+// 1. Bulk convert existing images from the CLI.
+// ---------------------------------------------------------------------
+
+// Convert everything under storage/app/public/uploads to WebP + AVIF.
+//
+//   php artisan perf:generate-webp --disk=public --path=uploads --format=webp
+//   php artisan perf:generate-webp --disk=public --path=uploads --format=avif
+//
+// The command chunks by directory and queues per-image conversions
+// through the `images` queue defined in
+// artisanpack.performance.image_optimization.queue.
+
+// ---------------------------------------------------------------------
+// 2. Convert on upload.
+// ---------------------------------------------------------------------
+
+use ArtisanPackUI\Performance\Jobs\OptimizeImageJob;
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Route;
+
+Route::post( '/upload', function ( Request $request ): array {
+    /** @var UploadedFile $file */
+    $file = $request->file( 'image' );
+    $path = $file->store( 'uploads', 'public' );
+
+    // Queue conversion so the response returns immediately.
+    OptimizeImageJob::dispatch( 'public', $path )
+        ->onQueue( config( 'artisanpack.performance.image_optimization.queue', 'default' ) );
+
+    return [
+        'path' => $path,
+    ];
+} );

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -1,0 +1,11 @@
+# Integrations
+
+Snippets for integrating with the ArtisanPack UI media library, adding
+the package to an existing Laravel app, and running in a multi-tenant
+setup.
+
+## Examples
+
+- [`media-library.php`](media-library.php) — auto-optimize every upload that flows through `artisanpack-ui/media-library`
+- [`existing-app.md`](existing-app.md) — a phased rollout plan for adding the package to a live app without breaking cache-invalidation or SEO
+- [`multi-tenant.php`](multi-tenant.php) — per-tenant config overrides, cache prefixing, and dashboard gating

--- a/examples/integrations/existing-app.md
+++ b/examples/integrations/existing-app.md
@@ -1,0 +1,115 @@
+# Adding the package to an existing app
+
+Every feature is disabled after install so a `composer require` +
+`perf:install` is safe on a live app. Rolling features on one at a
+time avoids surprising cache-invalidation and SEO regressions.
+
+## Phase 1 — install and observe
+
+```bash
+composer require artisanpack-ui/performance
+php artisan perf:install --no-interaction
+```
+
+Turn on **monitoring only**:
+
+```php
+'features' => [
+    'monitoring' => true,
+    'dashboard'  => true,
+    'query_optimization' => true, // Slow-query logging only, no caching yet.
+],
+
+'query_optimization' => [
+    'log_slow_queries' => true,
+    'slow_threshold'   => 200,
+    'detect_n1'        => true,
+    'sample_rate'      => 0.1, // Keep write volume low at first.
+],
+```
+
+Add `@perfMonitor` to your main layout and wait a week. Now you have a
+baseline.
+
+## Phase 2 — safe wins
+
+Toggle on features that don't change output HTML:
+
+```php
+'features' => [
+    // ... phase 1
+    'resource_hints' => true,
+    'lazy_loading'   => true,
+],
+```
+
+## Phase 3 — HTML mutations
+
+Turn on features that rewrite HTML on the way out. Watch for cache
+poisoning and CDN edge cases.
+
+```php
+'features' => [
+    // ... phase 2
+    'image_optimization'  => true,
+    'script_optimization' => true,
+    'html_minification'   => true,
+],
+```
+
+`html_minification.exclude_routes` should list any route where the
+raw HTML matters (webhooks that echo XML, `/humans.txt`, etc.).
+
+## Phase 4 — caching
+
+Full-page caching is the biggest win and the biggest footgun. Roll it
+out with a short TTL first and only after you've mapped every mutation
+to an invalidation.
+
+```php
+'features' => [
+    // ... phase 3
+    'page_caching'     => true,
+    'fragment_caching' => true,
+],
+
+'page_cache' => [
+    'ttl' => 300, // 5 minutes to start. Grow this after a week of clean logs.
+    'exclude_routes' => [
+        'admin/*',
+        'api/*',
+        'account/*',
+        'checkout/*',
+        'cart/*',
+    ],
+    'vary_by' => ['auth'],
+],
+```
+
+Wire model observers to `CacheInvalidator` (see
+[`../caching/invalidation.php`](../caching/invalidation.php)) before
+you extend the TTL.
+
+## Phase 5 — critical CSS + early hints
+
+Both features need infrastructure the earlier phases don't:
+
+- Critical CSS needs a headless browser (Chrome/Chromium) reachable
+  from the CLI.
+- Early Hints needs an HTTP/2 or HTTP/3 upstream that respects 103
+  interim responses (Nginx 1.13.9+, Caddy, HAProxy 2.7+, Cloudflare).
+
+Toggle them on once those prerequisites are in place.
+
+## Phase 6 — speculative loading
+
+Speculation Rules is a progressive enhancement — browsers that don't
+support it just ignore the rules. Turn it on last so you know every
+other feature is stable first.
+
+```php
+'features' => [
+    // ... phase 5
+    'speculative_loading' => true,
+],
+```

--- a/examples/integrations/media-library.php
+++ b/examples/integrations/media-library.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Media library integration.
+ *
+ * When both `artisanpack-ui/media-library` and
+ * `artisanpack-ui/performance` are installed, the performance package
+ * ships a listener that subscribes to the media library's `MediaUploaded`
+ * event and dispatches the image optimization pipeline for the new
+ * asset.
+ *
+ * This example wires the integration explicitly so a host can subclass
+ * or intercept the listener.
+ */
+
+namespace App\Providers;
+
+use ArtisanPackUI\MediaLibrary\Events\MediaUploaded;
+use ArtisanPackUI\Performance\Jobs\OptimizeImageJob;
+use ArtisanPackUI\Performance\Listeners\OptimizeUploadedMedia;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\ServiceProvider;
+
+class MediaIntegrationProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        // Option 1 — use the shipped listener as-is.
+        Event::listen( MediaUploaded::class, OptimizeUploadedMedia::class );
+
+        // Option 2 — inline handler with custom filtering.
+        Event::listen( function ( MediaUploaded $event ): void {
+            if ( ! str_starts_with( (string) $event->media->mime_type, 'image/' ) ) {
+                return;
+            }
+
+            OptimizeImageJob::dispatch(
+                $event->media->disk,
+                $event->media->path,
+                sizes: [ 'thumbnail', 'medium', 'large', 'product-thumb' ],
+            )->onQueue( 'images' );
+        } );
+    }
+}
+
+/*
+ * The media library's Media model gains a `->url('webp')` helper when
+ * both packages are installed:
+ *
+ *   $media = Media::find(42);
+ *   $media->url();             // Original.
+ *   $media->url('webp');       // WebP variant, generated if missing.
+ *   $media->imageUrl('medium', 'avif'); // AVIF medium.
+ */

--- a/examples/integrations/multi-tenant.php
+++ b/examples/integrations/multi-tenant.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Multi-tenant setup.
+ *
+ * Two things need per-tenant scoping when running the Performance
+ * package multi-tenant:
+ *
+ *   1. Cache keys — so tenant A can't see tenant B's cached pages.
+ *   2. Metric rows — so the dashboard only shows the current tenant's
+ *      Web Vitals and slow queries.
+ *
+ * Runtime config overrides (before the service provider caches
+ * anything for the request) handle both.
+ */
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class ScopePerformanceToTenant
+{
+    public function handle( Request $request, Closure $next )
+    {
+        $tenant = $request->route( 'tenant' ) ?? tenant();
+
+        if ( ! $tenant ) {
+            return $next( $request );
+        }
+
+        // 1. Prefix every cache key with the tenant id so page and
+        //    fragment caches segregate cleanly.
+        $prefix = "t{$tenant->id}";
+
+        config( [
+            'artisanpack.performance.page_cache.key_prefix'     => $prefix,
+            'artisanpack.performance.fragment_cache.key_prefix' => $prefix,
+        ] );
+
+        // 2. Scope monitoring rows.
+        config( [
+            'artisanpack.performance.monitoring.tags' => [
+                'tenant' => (string) $tenant->id,
+            ],
+        ] );
+
+        // 3. Custom dashboard gate — tenant-scoped admins only.
+        config( [
+            'artisanpack.performance.dashboard.gate' => "view-tenant-{$tenant->id}-performance",
+        ] );
+
+        return $next( $request );
+    }
+}
+
+/*
+ * Register the middleware early in bootstrap/app.php so it runs
+ * before the Performance package's own middleware:
+ *
+ *   ->withMiddleware(function (Middleware $middleware) {
+ *       $middleware->web(prepend: [
+ *           \App\Http\Middleware\ScopePerformanceToTenant::class,
+ *       ]);
+ *   })
+ *
+ * Define the tenant-scoped gate in AuthServiceProvider:
+ *
+ *   foreach (Tenant::all() as $tenant) {
+ *       Gate::define("view-tenant-{$tenant->id}-performance", function ($user) use ($tenant) {
+ *           return $user->tenant_id === $tenant->id && $user->hasRole('admin');
+ *       });
+ *   }
+ */

--- a/examples/javascript-css/README.md
+++ b/examples/javascript-css/README.md
@@ -1,0 +1,11 @@
+# JavaScript & CSS
+
+Snippets for script loading strategies, critical CSS, resource hints,
+and module loading.
+
+## Examples
+
+- [`script-defer-async.blade.php`](script-defer-async.blade.php) — pick between `async`, `defer`, `module`, `inline`, and `conditional` script strategies
+- [`critical-css.md`](critical-css.md) — extract, cache, and inline above-the-fold CSS with `perf:critical-css`
+- [`resource-hints.php`](resource-hints.php) — register `preload`, `preconnect`, `prefetch`, and `dns-prefetch` hints
+- [`module-loading.blade.php`](module-loading.blade.php) — load an ES module conditionally on a matching URL pattern

--- a/examples/javascript-css/critical-css.md
+++ b/examples/javascript-css/critical-css.md
@@ -1,0 +1,84 @@
+# Critical CSS
+
+Extract the above-the-fold CSS for a route, cache it, and inline it
+into the document head so first paint doesn't wait on a stylesheet
+round-trip.
+
+## Enable
+
+```php
+// config/artisanpack/performance.php
+'features' => [
+    'critical_css' => true,
+],
+
+'critical_css' => [
+    'enabled'          => true,
+    'cache_driver'     => env( 'CACHE_STORE', 'redis' ),
+    'cache_ttl'        => 86400,
+    'viewport_width'   => 1280,
+    'viewport_height'  => 900,
+    'stylesheets'      => [
+        resource_path( 'css/app.css' ),
+    ],
+    'routes'           => [
+        '/',
+        '/products',
+        '/products/*',
+    ],
+],
+```
+
+## Extract from the CLI
+
+```bash
+# Extract critical CSS for every configured route and cache it.
+php artisan perf:critical-css
+
+# Extract for a single route.
+php artisan perf:critical-css --route=/products
+
+# Force re-extraction (bypass the cache).
+php artisan perf:critical-css --force
+```
+
+## Inline it in a Blade layout
+
+Add the shipped directive to your layout's `<head>`:
+
+```blade
+<head>
+    <meta charset="utf-8">
+    <title>{{ $title }}</title>
+
+    {{-- Critical CSS inline for fast first paint. --}}
+    @perfCriticalCss
+
+    {{-- Load the full stylesheet asynchronously so it doesn't block render. --}}
+    <link
+        rel="preload"
+        as="style"
+        href="{{ mix( 'css/app.css' ) }}"
+        onload="this.rel='stylesheet'"
+    >
+    <noscript>
+        <link rel="stylesheet" href="{{ mix( 'css/app.css' ) }}">
+    </noscript>
+</head>
+```
+
+`@perfCriticalCss` reads the cached critical CSS for the current route
+and emits a `<style>` block inline. If the route is not in the cache
+the directive renders nothing so an unwarmed route still ships a
+working page.
+
+## Refresh on deploy
+
+Wire the command into your deploy hook so the critical CSS cache
+tracks the deployed stylesheet:
+
+```yaml
+# .github/workflows/deploy.yml (fragment)
+- name: Refresh critical CSS
+  run: php artisan perf:critical-css --force
+```

--- a/examples/javascript-css/module-loading.blade.php
+++ b/examples/javascript-css/module-loading.blade.php
@@ -1,0 +1,25 @@
+{{--
+    Module loading with a conditional strategy.
+
+    Loads the checkout ES module only on routes that match the checkout
+    pattern. On every other page the tag renders nothing — no bytes on
+    the wire, no parse cost.
+--}}
+
+@if ( request()->routeIs( 'checkout.*' ) )
+    <x-perf-script
+        src="{{ asset( 'js/checkout.mjs' ) }}"
+        strategy="module"
+        integrity="sha384-abc123..."
+        crossorigin="anonymous"
+    />
+@endif
+
+{{-- Or with the shipped conditional strategy so the check lives in one
+     place and the fallback strategy is explicit: --}}
+<x-perf-script
+    src="{{ asset( 'js/product-viewer.mjs' ) }}"
+    strategy="conditional"
+    :when="request()->routeIs( 'products.show' )"
+    strategy-fallback="module"
+/>

--- a/examples/javascript-css/resource-hints.php
+++ b/examples/javascript-css/resource-hints.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Resource hints — preload, preconnect, prefetch, dns-prefetch.
+ *
+ * The Performance package's ResourceHintInjector accepts hints from
+ * two sources: config-declared hints (always emitted) and
+ * request-scoped hints registered from a middleware / controller /
+ * view composer via the Performance facade.
+ *
+ * When the `early_hints` feature is on the same hints are also emitted
+ * as an HTTP 103 Early Hints interim response so upstream
+ * intermediaries can begin fetching before the app has rendered.
+ */
+
+namespace App\Providers;
+
+use ArtisanPackUI\Performance\Facades\Performance;
+use Illuminate\Support\ServiceProvider;
+
+class ResourceHintServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        // 1. Static hints from config — apply to every response.
+        config( [
+            'artisanpack.performance.resource_hints.manual_hints' => [
+                [ 'rel' => 'preconnect', 'href' => 'https://fonts.googleapis.com' ],
+                [ 'rel' => 'preconnect', 'href' => 'https://cdn.example.com', 'crossorigin' => 'anonymous' ],
+                [ 'rel' => 'dns-prefetch', 'href' => 'https://api.example.com' ],
+            ],
+        ] );
+
+        // 2. Route-scoped hints — register from a view composer so the
+        //    checkout page preloads its own bundle.
+        view()->composer( 'checkout', function (): void {
+            Performance::hint( 'preload', asset( 'js/checkout.js' ), [ 'as' => 'script' ] );
+            Performance::hint( 'preload', asset( 'css/checkout.css' ), [ 'as' => 'style' ] );
+            Performance::hint( 'prefetch', route( 'checkout.confirm' ) );
+        } );
+    }
+}

--- a/examples/javascript-css/script-defer-async.blade.php
+++ b/examples/javascript-css/script-defer-async.blade.php
@@ -1,0 +1,45 @@
+{{--
+    Script strategies.
+
+    <x-perf-script> picks an AbstractScriptStrategy from
+    ArtisanPackUI\Performance\JavaScript based on the `strategy`
+    attribute. Every strategy renders a plain <script> tag with the
+    right attributes — no JavaScript wrappers required.
+
+    Requires:
+      'features' => [
+          'script_optimization' => true,
+      ],
+--}}
+
+{{-- defer: runs after HTML parsing, in order relative to other defers. --}}
+<x-perf-script
+    src="{{ asset( 'js/analytics.js' ) }}"
+    strategy="defer"
+/>
+
+{{-- async: runs as soon as the file loads, out of order. --}}
+<x-perf-script
+    src="https://plausible.io/js/script.js"
+    strategy="async"
+    data-domain="example.com"
+/>
+
+{{-- module: <script type="module"> — HTTP/2 friendly, tree-shakeable. --}}
+<x-perf-script
+    src="{{ asset( 'js/app.js' ) }}"
+    strategy="module"
+/>
+
+{{-- inline: emit a small snippet inline so no extra request is made. --}}
+<x-perf-script strategy="inline">
+    window.APP_LOCALE = @json( app()->getLocale() );
+</x-perf-script>
+
+{{-- conditional: only load on routes matching the pattern. --}}
+<x-perf-script
+    src="{{ asset( 'js/checkout.js' ) }}"
+    strategy="conditional"
+    :when="request()->routeIs( 'checkout.*' )"
+    strategy-fallback="defer"
+/>

--- a/examples/monitoring/README.md
+++ b/examples/monitoring/README.md
@@ -1,0 +1,9 @@
+# Monitoring
+
+Snippets for the dashboard, custom metrics, and the JSON API.
+
+## Examples
+
+- [`dashboard-integration.md`](dashboard-integration.md) — enable the Livewire dashboard or embed React/Vue components in your own admin
+- [`custom-metrics.php`](custom-metrics.php) — record app-specific metrics alongside the shipped Core Web Vitals
+- [`api-usage.md`](api-usage.md) — hit the admin JSON API from a custom front-end

--- a/examples/monitoring/api-usage.md
+++ b/examples/monitoring/api-usage.md
@@ -1,0 +1,116 @@
+# Admin API usage
+
+The admin JSON API sits behind the same gate as the Livewire dashboard
+(`view-performance-dashboard` by default). Every endpoint accepts JSON
+and returns JSON.
+
+## Auth
+
+All admin endpoints require:
+
+1. A session cookie for an authenticated user, and
+2. That user to pass the configured gate.
+
+Set `<meta name="csrf-token" content="{{ csrf_token() }}">` in your
+layout so the shipped `PerformanceClient` can find the token.
+
+## Endpoints
+
+### Dashboard overview
+
+```http
+GET /api/performance/admin/dashboard?range=24h
+```
+
+```json
+{
+    "overview": {
+        "requests": 12483,
+        "lcp_p75": 1820,
+        "inp_p75": 148,
+        "cls_p75": 0.04
+    },
+    "pages": [...],
+    "cache": { "hit_rate": 0.83, "size_mb": 142 }
+}
+```
+
+### Chart payload
+
+```http
+GET /api/performance/admin/chart?metrics[]=lcp&metrics[]=inp&range=7d&show_threshold=1
+```
+
+### Cache manager
+
+```http
+GET  /api/performance/admin/cache
+POST /api/performance/admin/cache/actions
+Content-Type: application/json
+X-CSRF-TOKEN: ...
+
+{ "action": "flush" }
+{ "action": "warm" }
+{ "action": "invalidate-tag", "tag": "nav" }
+{ "action": "invalidate-key", "key": "products/*" }
+```
+
+### Slow queries
+
+```http
+GET /api/performance/admin/queries?range=24h
+GET /api/performance/admin/queries/export?range=7d
+```
+
+### Recommendations
+
+```http
+GET  /api/performance/admin/recommendations
+POST /api/performance/admin/recommendations/actions
+
+{ "action": "dismiss", "id": "rec-abc" }
+{ "action": "apply",   "id": "rec-abc" }
+{ "action": "reset" }
+```
+
+## From your own front-end
+
+```ts
+import { PerformanceClient } from '@artisanpack-ui/performance'
+
+const client = new PerformanceClient({ baseUrl: '/api/performance/admin' })
+
+const dashboard = await client.dashboard({ range: '24h' })
+const chart     = await client.chart({ metrics: ['lcp', 'inp'], range: '7d' })
+
+await client.cache.action('flush')
+await client.cache.action('invalidate-tag', { tag: 'nav' })
+
+const recs = await client.recommendations.list()
+await client.recommendations.action('dismiss', { id: recs[0].id })
+```
+
+## Metrics ingest
+
+The one endpoint that does *not* sit behind the admin gate is the
+metrics ingest endpoint. It accepts CSRF-protected POSTs from the
+browser Web Vitals collector.
+
+```http
+POST /api/performance/metrics
+Content-Type: application/json
+X-CSRF-TOKEN: ...
+
+{
+    "name": "LCP",
+    "value": 1820,
+    "id": "v3-1699999999-1234567890",
+    "route": "products.show",
+    "url": "/products/mug"
+}
+```
+
+`sample_rate` in `artisanpack.performance.monitoring` throttles what
+the browser sends; the server also validates the metric name against
+an allowlist so custom metrics from a compromised browser cannot
+poison the store.

--- a/examples/monitoring/custom-metrics.php
+++ b/examples/monitoring/custom-metrics.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Custom metrics.
+ *
+ * The Performance facade exposes `record()` for arbitrary metrics.
+ * Recorded metrics land in the `performance_metrics` table alongside
+ * Core Web Vitals so the aggregator, recommendations engine, and
+ * dashboard can render them.
+ */
+
+namespace App\Http\Controllers;
+
+use ArtisanPackUI\Performance\Facades\Performance;
+use Illuminate\Http\Request;
+
+class CheckoutController
+{
+    public function complete( Request $request ): array
+    {
+        $start = microtime( true );
+
+        $order = $this->processOrder( $request );
+
+        $elapsedMs = (int) ( ( microtime( true ) - $start ) * 1000 );
+
+        // Record a domain-specific metric.
+        Performance::record( 'checkout.duration', $elapsedMs, [
+            'route'      => $request->route()->getName(),
+            'items'      => $order->items->count(),
+            'total'      => $order->total,
+            'gateway'    => $order->gateway,
+        ] );
+
+        return [ 'id' => $order->id ];
+    }
+
+    protected function processOrder( Request $request ): object
+    {
+        // Domain logic...
+        return (object) [
+            'id'      => 1,
+            'items'   => collect(),
+            'total'   => 0,
+            'gateway' => 'stripe',
+        ];
+    }
+}
+
+/*
+ * Query the aggregated metric from Tinker / a report:
+ *
+ *   use ArtisanPackUI\Performance\Models\PerformanceMetric;
+ *
+ *   PerformanceMetric::where('name', 'checkout.duration')
+ *       ->where('created_at', '>=', now()->subDay())
+ *       ->selectRaw('avg(value) as avg_ms, percentile_cont(0.95) within group (order by value) as p95')
+ *       ->first();
+ *
+ * Or from the admin API — pass the metric name to the chart endpoint:
+ *
+ *   GET /api/performance/admin/chart?metrics[]=checkout.duration&range=24h
+ */

--- a/examples/monitoring/dashboard-integration.md
+++ b/examples/monitoring/dashboard-integration.md
@@ -1,0 +1,84 @@
+# Dashboard integration
+
+Three ways to expose the dashboard to your admins.
+
+## 1. Shipped Livewire dashboard
+
+Turn on the `dashboard` feature and define the gate.
+
+```php
+// config/artisanpack/performance.php
+'features' => [
+    'dashboard' => true,
+    'monitoring' => true,
+],
+
+'dashboard' => [
+    'enabled'      => true,
+    'route_prefix' => 'admin/performance',
+    'middleware'   => ['web', 'auth'],
+    'gate'         => 'view-performance-dashboard',
+],
+```
+
+```php
+// app/Providers/AuthServiceProvider.php
+Gate::define('view-performance-dashboard', function ($user) {
+    return $user->hasRole('admin');
+});
+```
+
+Visit `/admin/performance`. That's it.
+
+## 2. Embed React components in an existing admin
+
+```tsx
+// resources/js/pages/admin/performance.tsx
+import {
+    PerformanceDashboard,
+    MetricsChart,
+    CacheManager,
+    QueryAnalyzer,
+    RecommendationsPanel,
+} from '@artisanpack-ui/performance/react'
+
+export default function PerformancePage() {
+    return (
+        <div className="space-y-8">
+            <PerformanceDashboard range="24h" />
+            <MetricsChart metrics={['lcp', 'inp', 'cls']} range="7d" showThreshold />
+            <CacheManager />
+            <QueryAnalyzer range="24h" />
+            <RecommendationsPanel />
+        </div>
+    )
+}
+```
+
+## 3. Embed Vue components in an existing admin
+
+```vue
+<script setup lang="ts">
+import {
+    PerformanceDashboard,
+    MetricsChart,
+    CacheManager,
+    QueryAnalyzer,
+    RecommendationsPanel,
+} from '@artisanpack-ui/performance/vue'
+</script>
+
+<template>
+    <div class="space-y-8">
+        <PerformanceDashboard range="24h" />
+        <MetricsChart :metrics="['lcp', 'inp', 'cls']" range="7d" show-threshold />
+        <CacheManager />
+        <QueryAnalyzer range="24h" />
+        <RecommendationsPanel />
+    </div>
+</template>
+```
+
+Both React and Vue components resolve the CSRF token from
+`<meta name="csrf-token">` and hit the same admin JSON API the Livewire
+dashboard uses — no separate auth story.

--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -1,0 +1,395 @@
+<?php
+
+/**
+ * `perf:install` artisan command.
+ *
+ * Bootstraps the Performance package inside a host application. Publishes
+ * the package configuration, optionally publishes views, the client-side
+ * JavaScript bundle and stylesheet, runs the package's database migrations,
+ * validates environment requirements, clears configuration and view caches,
+ * and prints the dashboard gate stub plus the next-step guidance a
+ * developer needs to finish the install.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\App;
+
+/**
+ * Installs the Performance package into a host application.
+ *
+ * The command is idempotent — re-running it publishes the same assets,
+ * skips migrations that already ran, and never mutates existing published
+ * files unless `--force` is supplied.
+ *
+ * @since 1.0.0
+ */
+class InstallCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    protected $signature = 'perf:install
+			{--config : Only publish the package configuration.}
+			{--views : Publish the package Blade views for customization.}
+			{--js : Publish the package JavaScript bundle.}
+			{--css : Publish the package stylesheet.}
+			{--migrations : Publish and run the package migrations.}
+			{--skip-migrate : Skip running migrations after publishing.}
+			{--skip-checks : Skip environment validation (PHP, Laravel, permissions).}
+			{--force : Overwrite any existing published files.}';
+
+    /**
+     * The console command description.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    protected $description = 'Install the ArtisanPack UI Performance package: publish assets, run migrations, and print next-step guidance.';
+
+    /**
+     * Executes the command.
+     *
+     * @since 1.0.0
+     */
+    public function handle(): int
+    {
+        $this->info( __( 'Installing ArtisanPack UI Performance…' ) );
+
+        if ( ! $this->option( 'skip-checks' ) && ! $this->runEnvironmentChecks() ) {
+            return self::FAILURE;
+        }
+
+        $force = (bool) $this->option( 'force' );
+
+        // Explicit --config short-circuits every other action so callers can
+        // republish the config file without touching migrations or views.
+        if ( $this->option( 'config' ) && ! $this->anyOtherPublishFlag() ) {
+            $this->publishConfig( $force );
+            $this->clearCaches();
+            $this->line( __( 'Configuration published. Re-run without --config to complete the install.' ) );
+
+            return self::SUCCESS;
+        }
+
+        $this->publishConfig( $force );
+
+        if ( $this->shouldPublishViews() ) {
+            $this->publishViews( $force );
+        }
+
+        if ( $this->shouldPublishJs() ) {
+            $this->publishJs( $force );
+        }
+
+        if ( $this->shouldPublishCss() ) {
+            $this->publishCss( $force );
+        }
+
+        if ( $this->shouldRunMigrations() ) {
+            $this->runMigrations();
+        }
+
+        $this->clearCaches();
+        $this->printGateStub();
+        $this->printNextSteps();
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Validates the runtime environment against the package's requirements.
+     *
+     * Fails fast on unsupported PHP, unsupported Laravel, or a
+     * non-writable storage path so the developer sees the actionable error
+     * before any files are published.
+     *
+     * @since 1.0.0
+     */
+    protected function runEnvironmentChecks(): bool
+    {
+        $this->line( __( 'Verifying environment…' ) );
+
+        if ( version_compare( PHP_VERSION, '8.2.0', '<' ) ) {
+            $this->error( __( 'PHP 8.2 or higher is required (running :version).', [ 'version' => PHP_VERSION ] ) );
+
+            return false;
+        }
+
+        $laravelVersion = App::version();
+
+        if ( version_compare( $laravelVersion, '10.0.0', '<' ) ) {
+            $this->error( __( 'Laravel 10 or higher is required (running :version).', [ 'version' => $laravelVersion ] ) );
+
+            return false;
+        }
+
+        $storagePath = storage_path();
+
+        if ( ! is_writable( $storagePath ) ) {
+            $this->error( __( 'Storage path is not writable: :path', [ 'path' => $storagePath ] ) );
+
+            return false;
+        }
+
+        $this->line( __( '  PHP :php · Laravel :laravel · storage writable.', [
+            'php'     => PHP_VERSION,
+            'laravel' => $laravelVersion,
+        ] ) );
+
+        return true;
+    }
+
+    /**
+     * Publishes the package configuration file.
+     *
+     * @since 1.0.0
+     *
+     * @param  bool  $force  Whether to overwrite an existing config file.
+     */
+    protected function publishConfig( bool $force ): void
+    {
+        $this->line( __( 'Publishing configuration…' ) );
+        $this->callSilently( 'vendor:publish', array_filter( [
+            '--tag'   => 'artisanpack-performance-config',
+            '--force' => $force ?: null,
+        ] ) );
+        $this->info( __( '  ✓ Configuration published to config/artisanpack/performance.php' ) );
+    }
+
+    /**
+     * Publishes the Blade views so applications can fork any template.
+     *
+     * @since 1.0.0
+     *
+     * @param  bool  $force  Whether to overwrite existing published views.
+     */
+    protected function publishViews( bool $force ): void
+    {
+        $this->line( __( 'Publishing views…' ) );
+        $this->callSilently( 'vendor:publish', array_filter( [
+            '--tag'   => 'performance-views',
+            '--force' => $force ?: null,
+        ] ) );
+        $this->info( __( '  ✓ Views published to resources/views/vendor/artisanpack-ui/performance' ) );
+    }
+
+    /**
+     * Publishes the client-side JavaScript bundle.
+     *
+     * @since 1.0.0
+     *
+     * @param  bool  $force  Whether to overwrite existing published JS files.
+     */
+    protected function publishJs( bool $force ): void
+    {
+        $this->line( __( 'Publishing JavaScript bundle…' ) );
+        $this->callSilently( 'vendor:publish', array_filter( [
+            '--tag'   => 'artisanpack-performance-js',
+            '--force' => $force ?: null,
+        ] ) );
+        $this->info( __( '  ✓ JavaScript bundle published to resources/js/vendor/artisanpack-performance' ) );
+    }
+
+    /**
+     * Publishes the package stylesheet.
+     *
+     * @since 1.0.0
+     *
+     * @param  bool  $force  Whether to overwrite an existing published stylesheet.
+     */
+    protected function publishCss( bool $force ): void
+    {
+        $this->line( __( 'Publishing stylesheet…' ) );
+        $this->callSilently( 'vendor:publish', array_filter( [
+            '--tag'   => 'performance-css',
+            '--force' => $force ?: null,
+        ] ) );
+        $this->info( __( '  ✓ Stylesheet published to resources/css/vendor/artisanpack-ui/performance.css' ) );
+    }
+
+    /**
+     * Runs the package's database migrations.
+     *
+     * Non-interactive runs (CI/CD via `--no-interaction`) proceed without a
+     * prompt; interactive runs default to yes so the happy path stays a
+     * single Enter keypress.
+     *
+     * @since 1.0.0
+     */
+    protected function runMigrations(): void
+    {
+        $shouldRun = ! $this->input->isInteractive()
+            || $this->confirm( __( 'Run database migrations now?' ), true );
+
+        if ( ! $shouldRun ) {
+            $this->comment( __( 'Skipped migrations. Run `php artisan migrate` when ready.' ) );
+
+            return;
+        }
+
+        $this->line( __( 'Running migrations…' ) );
+        $this->call( 'migrate', [ '--force' => true ] );
+        $this->info( __( '  ✓ Migrations complete' ) );
+    }
+
+    /**
+     * Clears the application configuration and view caches so publishes and
+     * config changes take effect on the next request.
+     *
+     * @since 1.0.0
+     */
+    protected function clearCaches(): void
+    {
+        $this->line( __( 'Clearing caches…' ) );
+        $this->callSilently( 'config:clear' );
+        $this->callSilently( 'view:clear' );
+    }
+
+    /**
+     * Prints the dashboard gate stub for the developer to paste into their
+     * AuthServiceProvider.
+     *
+     * @since 1.0.0
+     */
+    protected function printGateStub(): void
+    {
+        $gate = (string) config( 'artisanpack.performance.dashboard.gate', 'view-performance-dashboard' );
+
+        if ( '' === $gate ) {
+            $gate = 'view-performance-dashboard';
+        }
+
+        $this->newLine();
+        $this->info( __( 'Performance package installed.' ) );
+        $this->newLine();
+        $this->comment( __( 'Add the following gate definition to your AuthServiceProvider::boot() method to authorize dashboard access:' ) );
+        $this->newLine();
+        $this->line( '    use Illuminate\\Support\\Facades\\Gate;' );
+        $this->newLine();
+        $this->line( "    Gate::define('{$gate}', function (\$user) {" );
+        $this->line( '        // Customize this to match your authorization model.' );
+        $this->line( "        return method_exists(\$user, 'hasRole') && \$user->hasRole('admin');" );
+        $this->line( '    });' );
+    }
+
+    /**
+     * Prints developer-facing next-steps guidance.
+     *
+     * @since 1.0.0
+     */
+    protected function printNextSteps(): void
+    {
+        $this->newLine();
+        $this->comment( __( 'Next steps:' ) );
+        $this->line( '  1. ' . __( 'Toggle features on in config/artisanpack/performance.php (all features ship disabled).' ) );
+        $this->line( '  2. ' . __( 'Define the dashboard gate shown above in AuthServiceProvider.' ) );
+        $this->line( '  3. ' . __( 'Add `@perfMonitor` to your layout to start collecting Core Web Vitals.' ) );
+        $this->line( '  4. ' . __( 'Visit /admin/performance (or your configured route prefix) to review the dashboard.' ) );
+        $this->line( '  5. ' . __( 'For React/Vue hosts, import from `@artisanpack-ui/performance` and rebuild your bundle.' ) );
+        $this->newLine();
+        $this->comment( __( 'See CHANGELOG.md and the examples/ directory for feature-by-feature usage.' ) );
+    }
+
+    /**
+     * Reports whether any publish-scope flag other than `--config` was set.
+     *
+     * @since 1.0.0
+     */
+    protected function anyOtherPublishFlag(): bool
+    {
+        return (bool) $this->option( 'views' )
+            || (bool) $this->option( 'js' )
+            || (bool) $this->option( 'css' )
+            || (bool) $this->option( 'migrations' );
+    }
+
+    /**
+     * Decides whether the views should be published on this run.
+     *
+     * `--views` always publishes; otherwise the interactive prompt asks and
+     * non-interactive runs default to yes so a hands-off install still gets
+     * a working dashboard.
+     *
+     * @since 1.0.0
+     */
+    protected function shouldPublishViews(): bool
+    {
+        if ( $this->option( 'views' ) ) {
+            return true;
+        }
+
+        if ( ! $this->input->isInteractive() ) {
+            return true;
+        }
+
+        return (bool) $this->confirm( __( 'Publish views for customization?' ), false );
+    }
+
+    /**
+     * Decides whether the JavaScript bundle should be published on this run.
+     *
+     * @since 1.0.0
+     */
+    protected function shouldPublishJs(): bool
+    {
+        if ( $this->option( 'js' ) ) {
+            return true;
+        }
+
+        if ( ! $this->input->isInteractive() ) {
+            return true;
+        }
+
+        return (bool) $this->confirm( __( 'Publish the JavaScript bundle (web-vitals, metrics-chart, etc.)?' ), true );
+    }
+
+    /**
+     * Decides whether the stylesheet should be published on this run.
+     *
+     * @since 1.0.0
+     */
+    protected function shouldPublishCss(): bool
+    {
+        if ( $this->option( 'css' ) ) {
+            return true;
+        }
+
+        if ( ! $this->input->isInteractive() ) {
+            return true;
+        }
+
+        return (bool) $this->confirm( __( 'Publish the package stylesheet?' ), false );
+    }
+
+    /**
+     * Decides whether migrations should be run on this invocation.
+     *
+     * @since 1.0.0
+     */
+    protected function shouldRunMigrations(): bool
+    {
+        if ( $this->option( 'skip-migrate' ) ) {
+            return false;
+        }
+
+        if ( $this->option( 'migrations' ) ) {
+            return true;
+        }
+
+        return true;
+    }
+}

--- a/src/PerformanceServiceProvider.php
+++ b/src/PerformanceServiceProvider.php
@@ -26,6 +26,7 @@ use ArtisanPackUI\Performance\Cache\PageCacheManager;
 use ArtisanPackUI\Performance\Console\Commands\AggregateMetricsCommand;
 use ArtisanPackUI\Performance\Console\Commands\GenerateCriticalCssCommand;
 use ArtisanPackUI\Performance\Console\Commands\GenerateWebPCommand;
+use ArtisanPackUI\Performance\Console\Commands\InstallCommand;
 use ArtisanPackUI\Performance\Console\Commands\PurgeCacheCommand;
 use ArtisanPackUI\Performance\Console\Commands\SuggestIndexesCommand;
 use ArtisanPackUI\Performance\Console\Commands\WarmCacheCommand;
@@ -430,6 +431,7 @@ class PerformanceServiceProvider extends ServiceProvider
     {
         if ( $this->app->runningInConsole() ) {
             $this->commands( [
+                InstallCommand::class,
                 GenerateWebPCommand::class,
                 GenerateCriticalCssCommand::class,
                 WarmCacheCommand::class,

--- a/tests/Feature/Console/InstallCommandTest.php
+++ b/tests/Feature/Console/InstallCommandTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare( strict_types=1 );
+
+it( 'runs the perf:install command non-interactively to completion', function (): void {
+    $this->artisan( 'perf:install', [ '--no-interaction' => true, '--force' => true ] )
+        ->assertExitCode( 0 )
+        ->expectsOutputToContain( 'Performance package installed.' );
+} );
+
+it( 'publishes the package configuration to the config path', function (): void {
+    $configPath = config_path( 'artisanpack/performance.php' );
+
+    if ( file_exists( $configPath ) ) {
+        @unlink( $configPath );
+    }
+
+    $this->artisan( 'perf:install', [
+        '--no-interaction' => true,
+        '--force'          => true,
+        '--skip-migrate'   => true,
+    ] )->assertExitCode( 0 );
+
+    expect( file_exists( $configPath ) )->toBeTrue();
+
+    @unlink( $configPath );
+} );
+
+it( 'short-circuits with --config to publish only the configuration file', function (): void {
+    $this->artisan( 'perf:install', [
+        '--config'         => true,
+        '--no-interaction' => true,
+        '--force'          => true,
+    ] )
+        ->assertExitCode( 0 )
+        ->expectsOutputToContain( 'Configuration published.' );
+} );
+
+it( 'prints the dashboard gate stub', function (): void {
+    $this->artisan( 'perf:install', [
+        '--no-interaction' => true,
+        '--force'          => true,
+        '--skip-migrate'   => true,
+    ] )
+        ->assertExitCode( 0 )
+        ->expectsOutputToContain( "Gate::define('view-performance-dashboard'" );
+} );
+
+it( 'honors a custom dashboard gate name from config', function (): void {
+    config()->set( 'artisanpack.performance.dashboard.gate', 'manage-perf' );
+
+    $this->artisan( 'perf:install', [
+        '--no-interaction' => true,
+        '--force'          => true,
+        '--skip-migrate'   => true,
+    ] )
+        ->assertExitCode( 0 )
+        ->expectsOutputToContain( "Gate::define('manage-perf'" );
+} );
+
+it( 'skips migrations when --skip-migrate is set', function (): void {
+    $this->artisan( 'perf:install', [
+        '--no-interaction' => true,
+        '--force'          => true,
+        '--skip-migrate'   => true,
+    ] )
+        ->assertExitCode( 0 )
+        ->doesntExpectOutput( 'Running migrations…' );
+} );
+
+it( 'prints the next-step guidance', function (): void {
+    $this->artisan( 'perf:install', [
+        '--no-interaction' => true,
+        '--force'          => true,
+        '--skip-migrate'   => true,
+    ] )
+        ->assertExitCode( 0 )
+        ->expectsOutputToContain( 'Next steps:' );
+} );
+
+it( 'reports the PHP and Laravel versions during the environment check', function (): void {
+    $this->artisan( 'perf:install', [
+        '--no-interaction' => true,
+        '--force'          => true,
+        '--skip-migrate'   => true,
+    ] )
+        ->assertExitCode( 0 )
+        ->expectsOutputToContain( 'Verifying environment…' );
+} );


### PR DESCRIPTION
## Summary

Bundles the three release/1.0 documentation-and-install issues into one branch:

- **#74 — `perf:install` command**: full-featured Artisan installer with interactive prompts, `--config`/`--views`/`--js`/`--css`/`--migrations`/`--skip-migrate`/`--skip-checks`/`--force` options, PHP 8.2+ and Laravel 10+ validation, storage-writable check, config/view cache clearing, and a printed dashboard gate stub plus next-step guidance.
- **#73 — CHANGELOG**: rewritten in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with a full `[1.0.0] - 2026-07-04` section grouped by feature area (Added / Changed / Security / Migration notes) plus GitHub compare/tag links at the bottom.
- **#72 — Examples**: `examples/` tree with `basic-setup`, `image-optimization`, `javascript-css`, `caching`, `database`, `monitoring`, and `integrations` subdirs. Each subdir has its own README pointing at runnable snippets (`.php`, `.blade.php`, `.md`) covering everything listed on issue #72's acceptance criteria.

## Test plan

- [x] `./vendor/bin/pest tests/Feature/Console/InstallCommandTest.php` — 8 new cases, all pass
- [x] `./vendor/bin/pest` — full suite: 749 passed / 5 benchmark-skipped
- [x] `./vendor/bin/php-cs-fixer fix` — no fixes needed
- [x] `./vendor/bin/phpcs` — clean
- [ ] Manual smoke: `php artisan perf:install --no-interaction --force` in a fresh Laravel app
- [ ] Verify examples/ layout renders correctly on the GitHub PR (Markdown, syntax highlighting)

Closes #72
Closes #73
Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)