### PR TITLE
feat(ai): PerformanceInsight + OptimizationSuggestion agents (#95, #96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A comprehensive performance optimization toolkit for Laravel applications. Image
 - 🗄 **Caching** — page cache, fragment cache, tag-based invalidation, cache warming
 - 🧮 **Database optimization** — N+1 detection, slow query logging, query cache, index suggestions
 - 📊 **Real-user monitoring** — Web Vitals collection, aggregation, and a Livewire admin dashboard
+- 🤖 **AI features** — query-insight and portfolio-level optimization suggestions, with Livewire, React, and Vue trigger components in the box
 - 🧰 **Artisan tooling** — `perf:install`, `perf:warm-cache`, `perf:purge-cache`, `perf:aggregate-metrics`, `perf:critical-css`, `perf:generate-webp`, `perf:suggest-indexes`
 - 🎛 **Every feature is opt-in** — nothing runs until you toggle it on
 
@@ -95,6 +96,53 @@ Performance::script(asset('js/analytics.js'))
 - [docs/home.md](docs/home.md) — documentation home
 - [docs/guides.md](docs/guides.md) — feature walkthroughs
 - [docs/api.md](docs/api.md) — programmatic API reference
+
+### AI features
+
+The performance package registers two AI features via `artisanpack-ui/ai`. Both are gated by the `artisanpack.ai.features.<key>.enabled` toggle and will no-op when the toggle is off.
+
+| Feature key | Purpose | Livewire | React | Vue |
+|-------------|---------|----------|-------|-----|
+| `performance.query_insight` | Explain why a slow query is slow, suggest indexes and rewrites (never runs DDL). | `perf-ai-query-insight-panel` | `QueryInsightPanel` | `QueryInsightPanel` |
+| `performance.optimization_suggestion` | Look at aggregate metrics over a date range and recommend where to focus optimization work. | `perf-ai-optimization-suggestion-panel` | `OptimizationSuggestionPanel` | `OptimizationSuggestionPanel` |
+
+The React and Vue components live inside this package (not in `@artisanpack-ui/react` / `@artisanpack-ui/vue`) so both frameworks are supported without adding a coupling to the shared UI packages.
+
+```blade
+{{-- Livewire --}}
+<livewire:perf-ai-query-insight-panel />
+<livewire:perf-ai-optimization-suggestion-panel window-days="14" />
+```
+
+```tsx
+// React
+import { QueryInsightPanel, OptimizationSuggestionPanel } from '@artisanpack-ui/performance/react';
+
+<QueryInsightPanel clientOptions={ { baseUrl: '/api/performance' } } />
+<OptimizationSuggestionPanel
+    range={ { from: '2026-07-01', to: '2026-07-07' } }
+    metrics={ metrics }
+    clientOptions={ { baseUrl: '/api/performance' } }
+/>
+```
+
+```vue
+<!-- Vue -->
+<script setup lang="ts">
+import { QueryInsightPanel, OptimizationSuggestionPanel } from '@artisanpack-ui/performance/vue';
+</script>
+
+<template>
+    <QueryInsightPanel :client-options="{ baseUrl: '/api/performance' }" />
+    <OptimizationSuggestionPanel
+        :range="{ from: '2026-07-01', to: '2026-07-07' }"
+        :metrics="metrics"
+        :client-options="{ baseUrl: '/api/performance' }"
+    />
+</template>
+```
+
+The React and Vue triggers POST to `POST /api/performance/ai/query-insight` and `POST /api/performance/ai/optimization-suggestion`. Responses are shaped as `{ data: <agent output>, feature_key: string }`. Disabled features return `409`; missing credentials return `412`; validation errors return `422`.
 
 ### Feature guides
 

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
   "require": {
     "php": "^8.2",
     "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+    "artisanpack-ui/ai": "^1.0",
     "artisanpack-ui/core": "^1.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,80 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4d8cbcda9e309698933189af15b8ba02",
+    "content-hash": "18090653b6cf6659004a02101230bdf3",
     "packages": [
+        {
+            "name": "artisanpack-ui/ai",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ArtisanPack-UI/ai.git",
+                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/ai/zipball/082f1cd337742d34b8035d116c6c5ad8e5453fca",
+                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca",
+                "shasum": ""
+            },
+            "require": {
+                "artisanpack-ui/core": "^1.0",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/ai": "^0.8",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.1",
+                "artisanpack-ui/code-style-pint": "^1.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "friendsofphp/php-cs-fixer": "^3.75",
+                "laravel/pint": "^1.26",
+                "livewire/livewire": "^3.6",
+                "orchestra/testbench": "^10.2|^11.0",
+                "pestphp/pest": "^3.8|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.2|^4.1"
+            },
+            "suggest": {
+                "artisanpack-ui/cms-framework": "Automatically registers AI credentials, features, budget and cache setting groups under the CMS admin surface.",
+                "artisanpack-ui/livewire-ui-components": "Renders the AI Settings and Usage admin surfaces using x-artisanpack-* components.",
+                "livewire/livewire": "Required to mount the AI Settings and Usage dashboard Livewire components under cms-framework's admin nav."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Ai": "ArtisanPackUI\\Ai\\Facades\\Ai"
+                    },
+                    "providers": [
+                        "ArtisanPackUI\\Ai\\AiServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "ArtisanPackUI\\Ai\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "Shared AI foundation for the ArtisanPack UI ecosystem, built on top of laravel/ai.",
+            "support": {
+                "issues": "https://github.com/ArtisanPack-UI/ai/issues",
+                "source": "https://github.com/ArtisanPack-UI/ai/tree/v1.0.0"
+            },
+            "time": "2026-07-06T21:25:38+00:00"
+        },
         {
             "name": "artisanpack-ui/core",
             "version": "1.2.0",
@@ -74,6 +146,157 @@
                 "source": "https://github.com/ArtisanPack-UI/core/tree/v1.2.0"
             },
             "time": "2026-05-24T02:53:50+00:00"
+        },
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.388.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "6dd9a0674641ef7d302a50cc8f275eb443182dc9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/6dd9a0674641ef7d302a50cc8f275eb443182dc9",
+                "reference": "6dd9a0674641ef7d302a50cc8f275eb443182dc9",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.4.5",
+                "mtdowling/jmespath.php": "^2.9.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^10.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "https://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.388.0"
+            },
+            "time": "2026-07-07T18:11:48+00:00"
         },
         {
             "name": "brick/math",
@@ -1205,6 +1428,80 @@
             "time": "2026-05-23T22:00:21+00:00"
         },
         {
+            "name": "laravel/ai",
+            "version": "v0.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/ai.git",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/ai/zipball/b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.339",
+                "illuminate/console": "^12.0|^13.0",
+                "illuminate/container": "^12.0|^13.0",
+                "illuminate/contracts": "^12.0|^13.0",
+                "illuminate/database": "^12.0|^13.0",
+                "illuminate/filesystem": "^12.0|^13.0",
+                "illuminate/json-schema": "^12.62|^13.15",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/prompts": "^0.3.6",
+                "laravel/serializable-closure": "^2.0",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "laravel/mcp": "^0.8",
+                "laravel/pint": "^1.26",
+                "mockery/mockery": "^1.6.12",
+                "orchestra/testbench": "^10.6|^11.0",
+                "pestphp/pest": "^3.0|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+                "phpstan/phpstan": "^2.1"
+            },
+            "suggest": {
+                "laravel/mcp": "Required to use MCP client tools or MCP server tools with Laravel AI agents."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Ai\\AiServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Ai\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The official AI SDK for Laravel.",
+            "homepage": "https://github.com/laravel/ai",
+            "keywords": [
+                "ai",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/ai/issues",
+                "source": "https://github.com/laravel/ai"
+            },
+            "time": "2026-06-10T11:23:35+00:00"
+        },
+        {
             "name": "laravel/framework",
             "version": "v12.62.0",
             "source": {
@@ -2207,6 +2504,72 @@
                 }
             ],
             "time": "2026-01-02T08:56:05+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.52"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.2"
+            },
+            "time": "2026-07-06T18:56:19+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -3805,6 +4168,77 @@
                 }
             ],
             "time": "2026-01-05T13:30:16+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/99aec13b82b4967ec5088222c4a3ecca955949c2",
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/finder",
@@ -10970,77 +11404,6 @@
                 }
             ],
             "time": "2024-10-20T05:08:20+00:00"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "v8.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/99aec13b82b4967ec5088222c4a3ecca955949c2",
-                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.4.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8"
-            },
-            "require-dev": {
-                "symfony/process": "^7.4|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides basic utilities for the filesystem",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v8.1.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/options-resolver",

--- a/config/performance.php
+++ b/config/performance.php
@@ -386,6 +386,11 @@ return [
             \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
         ],
+        // Middleware for the AI JSON API endpoints under /ai/*. These
+        // dispatch to paid LLM providers, so the default gates them behind
+        // Sanctum + the `performance.ai.use` Gate. Hosts using a different
+        // guard (e.g. web-session) can override — the Gate check still runs.
+        'ai_middleware' => ['api', 'auth:sanctum'],
         'api_throttle' => env('PERF_API_THROTTLE', '60,1'),
     ],
 

--- a/resources/js/performance.ts
+++ b/resources/js/performance.ts
@@ -140,6 +140,100 @@ export interface QueriesQuery {
 	sort?: QuerySortKey;
 }
 
+export type AiFeatureKey =
+	| 'performance.query_insight'
+	| 'performance.optimization_suggestion';
+
+export type OptimizationLevel = 'high' | 'medium' | 'low';
+
+export interface SuggestedIndex {
+	table: string;
+	columns: string[];
+	rationale: string;
+}
+
+export interface QueryRewrite {
+	original: string;
+	suggested: string;
+	rationale: string;
+}
+
+export interface QueryInsightInput {
+	query: string;
+	explain?: string | Record<string, unknown> | unknown[] | null;
+	// `schema` is what the caller pasted into the schema hint textarea —
+	// the agent accepts a decoded JSON structure, a plain-text description,
+	// or nothing. The React/Vue/Livewire panels all parse it the same way
+	// so the "JSON or text" placeholder is honest across surfaces.
+	schema?: string | Record<string, unknown> | unknown[] | null;
+	time_ms?: number | null;
+	connection?: string | null;
+}
+
+export interface QueryInsight {
+	summary: string;
+	bottlenecks: string[];
+	suggested_indexes: SuggestedIndex[];
+	rewrites: QueryRewrite[];
+	caveats: string[];
+}
+
+export interface OptimizationFocusArea {
+	title: string;
+	routes: string[];
+	impact: OptimizationLevel;
+	effort: OptimizationLevel;
+	rationale: string;
+	actions: string[];
+}
+
+export interface OptimizationMetricRow {
+	metric: string;
+	route?: string | null;
+	p50?: number;
+	p75?: number;
+	p90?: number;
+	p99?: number;
+	samples?: number;
+	device?: string | null;
+	[key: string]: unknown;
+}
+
+export interface OptimizationSuggestionInput {
+	range: { from: string; to: string };
+	metrics: OptimizationMetricRow[];
+	context?: {
+		traffic_mix?: string;
+		recent_changes?: string;
+		business_priority?: string;
+	};
+}
+
+export interface OptimizationSuggestion {
+	summary: string;
+	focus_areas: OptimizationFocusArea[];
+	quick_wins: string[];
+	caveats: string[];
+}
+
+export interface AiAgentResponse<TOutput> {
+	data: TOutput;
+	feature_key: AiFeatureKey;
+}
+
+export class PerformanceAiError extends Error {
+	public readonly status: number;
+
+	public readonly featureKey: AiFeatureKey | null;
+
+	constructor( message: string, status: number, featureKey: AiFeatureKey | null = null ) {
+		super( message );
+		this.name = 'PerformanceAiError';
+		this.status = status;
+		this.featureKey = featureKey;
+	}
+}
+
 export interface WebVitalReport {
 	name: WebVitalName;
 	value: number;
@@ -300,6 +394,24 @@ export class PerformanceClient {
 		return this.post<{ success: boolean; reason?: string }>( '/metrics', vital );
 	}
 
+	async suggestQueryInsight( input: QueryInsightInput ): Promise<QueryInsight> {
+		const response = await this.postAi<QueryInsight>(
+			'/ai/query-insight',
+			'performance.query_insight',
+			input as unknown as Record<string, unknown>,
+		);
+		return response.data;
+	}
+
+	async suggestOptimization( input: OptimizationSuggestionInput ): Promise<OptimizationSuggestion> {
+		const response = await this.postAi<OptimizationSuggestion>(
+			'/ai/optimization-suggestion',
+			'performance.optimization_suggestion',
+			input as unknown as Record<string, unknown>,
+		);
+		return response.data;
+	}
+
 	private async get<T>( path: string ): Promise<T> {
 		const response = await this.fetchImpl( `${ this.baseUrl }${ path }`, {
 			method: 'GET',
@@ -326,6 +438,51 @@ export class PerformanceClient {
 			throw new Error( `Performance API POST ${ path } failed: ${ response.status }` );
 		}
 		return ( await response.json() ) as T;
+	}
+
+	private async postAi<T>(
+		path: string,
+		featureKey: AiFeatureKey,
+		body: Record<string, unknown>,
+	): Promise<AiAgentResponse<T>> {
+		const response = await this.fetchImpl( `${ this.baseUrl }${ path }`, {
+			method: 'POST',
+			credentials: 'same-origin',
+			headers: {
+				...buildHeaders( this.csrfToken ),
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify( body ),
+		} );
+
+		let parsed: unknown = null;
+		try {
+			parsed = await response.json();
+		} catch {
+			// Non-JSON body (e.g. 5xx HTML error page) — swallow so the
+			// thrown PerformanceAiError still carries the status code.
+		}
+
+		if ( ! response.ok ) {
+			const message = 'object' === typeof parsed && null !== parsed && 'string' === typeof ( parsed as { message?: unknown } ).message
+				? ( parsed as { message: string } ).message
+				: `Performance AI request failed: ${ response.status }`;
+			throw new PerformanceAiError( message, response.status, featureKey );
+		}
+
+		// A 2xx with a null / non-object / missing-`data` body is still a
+		// broken response — surface it as a PerformanceAiError so callers'
+		// existing catch branch fires instead of letting `response.data`
+		// throw an uncaught TypeError one frame away.
+		if ( null === parsed || 'object' !== typeof parsed || ! ( 'data' in parsed ) ) {
+			throw new PerformanceAiError(
+				`Performance AI request returned a malformed response (${ response.status }).`,
+				response.status,
+				featureKey,
+			);
+		}
+
+		return parsed as AiAgentResponse<T>;
 	}
 }
 

--- a/resources/js/react/OptimizationSuggestionPanel.tsx
+++ b/resources/js/react/OptimizationSuggestionPanel.tsx
@@ -1,0 +1,234 @@
+/**
+ * OptimizationSuggestionPanel — React trigger for the OptimizationSuggestionAgent.
+ *
+ * Consumers provide the metric batch (typically drawn from their own
+ * PerformanceClient.getChart / getDashboard results) plus optional context
+ * hints; the component orchestrates the agent call and renders the
+ * returned focus areas, quick wins, and caveats.
+ *
+ * @since 1.1.0
+ */
+
+import { type FC, useState } from 'react';
+
+import {
+	getPerformanceClient,
+	type OptimizationMetricRow,
+	type OptimizationSuggestion,
+	PerformanceAiError,
+	type PerformanceClient,
+	type PerformanceClientOptions,
+} from '../performance';
+
+export interface OptimizationSuggestionPanelProps {
+	client?: PerformanceClient;
+	clientOptions?: PerformanceClientOptions;
+	/** Metrics batch to analyze. Required — pass in whatever the app aggregated. */
+	metrics: OptimizationMetricRow[];
+	/** Date range covered by `metrics`. */
+	range: { from: string; to: string };
+	initialBusinessPriority?: string;
+	initialRecentChanges?: string;
+	initialTrafficMix?: string;
+	onSuggestion?: ( suggestion: OptimizationSuggestion ) => void;
+}
+
+export const OptimizationSuggestionPanel: FC<OptimizationSuggestionPanelProps> = ( {
+	client,
+	clientOptions,
+	metrics,
+	range,
+	initialBusinessPriority = '',
+	initialRecentChanges = '',
+	initialTrafficMix = '',
+	onSuggestion,
+} ) => {
+	const resolvedClient = client ?? getPerformanceClient( clientOptions );
+
+	const [businessPriority, setBusinessPriority] = useState<string>( initialBusinessPriority );
+	const [recentChanges, setRecentChanges] = useState<string>( initialRecentChanges );
+	const [trafficMix, setTrafficMix] = useState<string>( initialTrafficMix );
+	const [suggestion, setSuggestion] = useState<OptimizationSuggestion | null>( null );
+	const [error, setError] = useState<string | null>( null );
+	const [isLoading, setIsLoading] = useState<boolean>( false );
+
+	const disabled = isLoading || 0 === metrics.length;
+
+	const handleSuggest = async (): Promise<void> => {
+		setError( null );
+		setSuggestion( null );
+		setIsLoading( true );
+
+		try {
+			const context: Record<string, string> = {};
+			if ( '' !== businessPriority.trim() ) {
+				context.business_priority = businessPriority.trim();
+			}
+			if ( '' !== recentChanges.trim() ) {
+				context.recent_changes = recentChanges.trim();
+			}
+			if ( '' !== trafficMix.trim() ) {
+				context.traffic_mix = trafficMix.trim();
+			}
+
+			const result = await resolvedClient.suggestOptimization( {
+				range,
+				metrics,
+				context: 0 === Object.keys( context ).length ? undefined : context,
+			} );
+
+			setSuggestion( result );
+			onSuggestion?.( result );
+		} catch ( caught ) {
+			if ( caught instanceof PerformanceAiError ) {
+				setError( caught.message );
+			} else if ( caught instanceof Error ) {
+				setError( caught.message );
+			} else {
+				setError( 'The AI agent could not complete this request.' );
+			}
+		} finally {
+			setIsLoading( false );
+		}
+	};
+
+	return (
+		<div className="performance-ai-panel" data-feature="performance.optimization_suggestion">
+			<div className="performance-ai-panel__fields">
+				<label className="performance-ai-panel__label" htmlFor="optimization-priority-react">
+					Business priority (optional)
+				</label>
+				<input
+					id="optimization-priority-react"
+					className="performance-ai-panel__input"
+					type="text"
+					value={ businessPriority }
+					onChange={ ( event ) => setBusinessPriority( event.target.value ) }
+					placeholder="checkout > blog"
+				/>
+
+				<label className="performance-ai-panel__label" htmlFor="optimization-recent-react">
+					Recent changes (optional)
+				</label>
+				<textarea
+					id="optimization-recent-react"
+					className="performance-ai-panel__textarea"
+					rows={ 2 }
+					value={ recentChanges }
+					onChange={ ( event ) => setRecentChanges( event.target.value ) }
+					placeholder="switched to Vite last week"
+				/>
+
+				<label className="performance-ai-panel__label" htmlFor="optimization-traffic-react">
+					Traffic mix (optional)
+				</label>
+				<input
+					id="optimization-traffic-react"
+					className="performance-ai-panel__input"
+					type="text"
+					value={ trafficMix }
+					onChange={ ( event ) => setTrafficMix( event.target.value ) }
+					placeholder="65% mobile, 35% desktop"
+				/>
+			</div>
+
+			<button
+				type="button"
+				className="performance-ai-panel__button"
+				disabled={ disabled }
+				onClick={ () => {
+					void handleSuggest();
+				} }
+			>
+				{ isLoading ? 'Analyzing…' : 'Suggest optimizations' }
+			</button>
+
+			{ error && (
+				<p className="performance-ai-panel__error" role="alert">
+					{ error }
+				</p>
+			) }
+
+			{ suggestion && (
+				<div className="performance-ai-panel__result">
+					{ suggestion.summary && (
+						<p className="performance-ai-panel__summary">{ suggestion.summary }</p>
+					) }
+
+					{ suggestion.focus_areas.length > 0 && (
+						<>
+							<h4 className="performance-ai-panel__heading">Focus areas</h4>
+							<ul className="performance-ai-panel__list">
+								{ suggestion.focus_areas.map( ( area, index ) => (
+									<li key={ `focus-${ index }` } className="performance-ai-panel__focus-area">
+										<div className="performance-ai-panel__focus-area-header">
+											<strong>{ area.title }</strong>
+											<span
+												className={ `performance-ai-panel__tag performance-ai-panel__tag--impact-${ area.impact }` }
+											>
+												Impact: { area.impact }
+											</span>
+											<span
+												className={ `performance-ai-panel__tag performance-ai-panel__tag--effort-${ area.effort }` }
+											>
+												Effort: { area.effort }
+											</span>
+										</div>
+
+										{ area.routes.length > 0 && (
+											<p className="performance-ai-panel__routes">
+												Routes:{ ' ' }
+												{ area.routes.map( ( route, routeIndex ) => (
+													<span key={ `route-${ index }-${ routeIndex }` }>
+														<code>{ route }</code>
+														{ routeIndex < area.routes.length - 1 ? ', ' : '' }
+													</span>
+												) ) }
+											</p>
+										) }
+
+										{ area.rationale && (
+											<p className="performance-ai-panel__rationale">{ area.rationale }</p>
+										) }
+
+										{ area.actions.length > 0 && (
+											<ul className="performance-ai-panel__actions">
+												{ area.actions.map( ( action, actionIndex ) => (
+													<li key={ `action-${ index }-${ actionIndex }` }>{ action }</li>
+												) ) }
+											</ul>
+										) }
+									</li>
+								) ) }
+							</ul>
+						</>
+					) }
+
+					{ suggestion.quick_wins.length > 0 && (
+						<>
+							<h4 className="performance-ai-panel__heading">Quick wins</h4>
+							<ul className="performance-ai-panel__list">
+								{ suggestion.quick_wins.map( ( win, index ) => (
+									<li key={ `win-${ index }` }>{ win }</li>
+								) ) }
+							</ul>
+						</>
+					) }
+
+					{ suggestion.caveats.length > 0 && (
+						<>
+							<h4 className="performance-ai-panel__heading">Caveats</h4>
+							<ul className="performance-ai-panel__list performance-ai-panel__list--muted">
+								{ suggestion.caveats.map( ( caveat, index ) => (
+									<li key={ `caveat-${ index }` }>{ caveat }</li>
+								) ) }
+							</ul>
+						</>
+					) }
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default OptimizationSuggestionPanel;

--- a/resources/js/react/QueryInsightPanel.tsx
+++ b/resources/js/react/QueryInsightPanel.tsx
@@ -1,0 +1,276 @@
+/**
+ * QueryInsightPanel — React trigger for the PerformanceInsightAgent.
+ *
+ * Package-local (not exported through @artisanpack-ui/react) because the
+ * agent's input shape and rendering are specific to the performance
+ * package's domain model.
+ *
+ * @since 1.1.0
+ */
+
+import { type FC, useState } from 'react';
+
+import {
+	getPerformanceClient,
+	PerformanceAiError,
+	type PerformanceClient,
+	type PerformanceClientOptions,
+	type QueryInsight,
+	type QueryInsightInput,
+} from '../performance';
+
+export interface QueryInsightPanelProps {
+	/** Optional shared client. Falls back to the singleton. */
+	client?: PerformanceClient;
+	/** Options forwarded to `getPerformanceClient` when no client is passed. */
+	clientOptions?: PerformanceClientOptions;
+	/** Pre-populate the query textarea. */
+	initialQuery?: string;
+	/** Pre-populate the EXPLAIN plan textarea. */
+	initialExplain?: string;
+	/** Pre-populate the schema hint textarea (JSON or plain text). */
+	initialSchema?: string;
+	/** Pre-populate the connection driver input (e.g. `mysql`). */
+	initialConnection?: string;
+	/** Pre-populate the observed duration in ms. */
+	initialTimeMs?: number | null;
+	/** Called with the fresh insight after a successful analyze. */
+	onInsight?: ( insight: QueryInsight ) => void;
+}
+
+function parseSchema( raw: string ): QueryInsightInput['schema'] {
+	const trimmed = raw.trim();
+	if ( '' === trimmed ) {
+		return null;
+	}
+	try {
+		const parsed = JSON.parse( trimmed );
+		if ( 'object' === typeof parsed && null !== parsed ) {
+			return parsed as QueryInsightInput['schema'];
+		}
+	} catch {
+		// Not JSON — pass the raw text through so the agent can still use
+		// it as a plain-text schema hint, matching the "JSON or text"
+		// placeholder the panel promises.
+	}
+	return trimmed;
+}
+
+export const QueryInsightPanel: FC<QueryInsightPanelProps> = ( {
+	client,
+	clientOptions,
+	initialQuery = '',
+	initialExplain = '',
+	initialSchema = '',
+	initialConnection = '',
+	initialTimeMs = null,
+	onInsight,
+} ) => {
+	const resolvedClient = client ?? getPerformanceClient( clientOptions );
+
+	const [query, setQuery] = useState<string>( initialQuery );
+	const [explain, setExplain] = useState<string>( initialExplain );
+	const [schema, setSchema] = useState<string>( initialSchema );
+	const [connection, setConnection] = useState<string>( initialConnection );
+	const [timeMs, setTimeMs] = useState<number | null>( initialTimeMs );
+	const [insight, setInsight] = useState<QueryInsight | null>( null );
+	const [error, setError] = useState<string | null>( null );
+	const [isLoading, setIsLoading] = useState<boolean>( false );
+
+	const disabled = isLoading || '' === query.trim();
+
+	const handleAnalyze = async (): Promise<void> => {
+		setError( null );
+		setInsight( null );
+		setIsLoading( true );
+
+		try {
+			const parsedSchema = parseSchema( schema );
+			const explainValue = '' === explain.trim() ? null : explain;
+			const connectionValue = '' === connection.trim() ? null : connection.trim();
+
+			const result = await resolvedClient.suggestQueryInsight( {
+				query,
+				explain: explainValue,
+				schema: parsedSchema,
+				time_ms: timeMs,
+				connection: connectionValue,
+			} );
+
+			setInsight( result );
+			onInsight?.( result );
+		} catch ( caught ) {
+			if ( caught instanceof PerformanceAiError ) {
+				setError( caught.message );
+			} else if ( caught instanceof Error ) {
+				setError( caught.message );
+			} else {
+				setError( 'The AI agent could not complete this request.' );
+			}
+		} finally {
+			setIsLoading( false );
+		}
+	};
+
+	return (
+		<div className="performance-ai-panel" data-feature="performance.query_insight">
+			<div className="performance-ai-panel__fields">
+				<label className="performance-ai-panel__label" htmlFor="query-insight-query-react">
+					Query
+				</label>
+				<textarea
+					id="query-insight-query-react"
+					className="performance-ai-panel__textarea"
+					rows={ 5 }
+					value={ query }
+					onChange={ ( event ) => setQuery( event.target.value ) }
+					placeholder="SELECT * FROM …"
+				/>
+
+				<label className="performance-ai-panel__label" htmlFor="query-insight-explain-react">
+					EXPLAIN plan (optional)
+				</label>
+				<textarea
+					id="query-insight-explain-react"
+					className="performance-ai-panel__textarea"
+					rows={ 4 }
+					value={ explain }
+					onChange={ ( event ) => setExplain( event.target.value ) }
+					placeholder="EXPLAIN output …"
+				/>
+
+				<label className="performance-ai-panel__label" htmlFor="query-insight-schema-react">
+					Relevant schema (optional, JSON or text)
+				</label>
+				<textarea
+					id="query-insight-schema-react"
+					className="performance-ai-panel__textarea"
+					rows={ 4 }
+					value={ schema }
+					onChange={ ( event ) => setSchema( event.target.value ) }
+					placeholder='{ "articles": { "id": "bigint", "slug": "varchar(191)" } }'
+				/>
+
+				<div className="performance-ai-panel__meta">
+					<label className="performance-ai-panel__label" htmlFor="query-insight-connection-react">
+						Connection
+					</label>
+					<input
+						id="query-insight-connection-react"
+						className="performance-ai-panel__input"
+						type="text"
+						value={ connection }
+						onChange={ ( event ) => setConnection( event.target.value ) }
+						placeholder="mysql"
+					/>
+
+					<label className="performance-ai-panel__label" htmlFor="query-insight-time-react">
+						Observed duration (ms)
+					</label>
+					<input
+						id="query-insight-time-react"
+						className="performance-ai-panel__input"
+						type="number"
+						step="0.01"
+						value={ null === timeMs ? '' : timeMs }
+						onChange={ ( event ) => {
+							const raw = event.target.value;
+							setTimeMs( '' === raw ? null : Number( raw ) );
+						} }
+						placeholder="120.5"
+					/>
+				</div>
+			</div>
+
+			<button
+				type="button"
+				className="performance-ai-panel__button"
+				disabled={ disabled }
+				onClick={ () => {
+					void handleAnalyze();
+				} }
+			>
+				{ isLoading ? 'Analyzing…' : 'Analyze query' }
+			</button>
+
+			{ error && (
+				<p className="performance-ai-panel__error" role="alert">
+					{ error }
+				</p>
+			) }
+
+			{ insight && (
+				<div className="performance-ai-panel__result">
+					{ insight.summary && <p className="performance-ai-panel__summary">{ insight.summary }</p> }
+
+					{ insight.bottlenecks.length > 0 && (
+						<>
+							<h4 className="performance-ai-panel__heading">Bottlenecks</h4>
+							<ol className="performance-ai-panel__list">
+								{ insight.bottlenecks.map( ( bottleneck, index ) => (
+									<li key={ `bottleneck-${ index }` }>{ bottleneck }</li>
+								) ) }
+							</ol>
+						</>
+					) }
+
+					{ insight.suggested_indexes.length > 0 && (
+						<>
+							<h4 className="performance-ai-panel__heading">Suggested indexes</h4>
+							<ul className="performance-ai-panel__list">
+								{ insight.suggested_indexes.map( ( index, key ) => (
+									<li key={ `index-${ key }` }>
+										<code>
+											{ index.table }({ index.columns.join( ', ' ) })
+										</code>
+										{ index.rationale && (
+											<span className="performance-ai-panel__rationale">{ index.rationale }</span>
+										) }
+									</li>
+								) ) }
+							</ul>
+						</>
+					) }
+
+					{ insight.rewrites.length > 0 && (
+						<>
+							<h4 className="performance-ai-panel__heading">Suggested rewrites</h4>
+							<ul className="performance-ai-panel__list">
+								{ insight.rewrites.map( ( rewrite, index ) => (
+									<li key={ `rewrite-${ index }` }>
+										<div className="performance-ai-panel__rewrite">
+											<div className="performance-ai-panel__rewrite-before">
+												<span className="performance-ai-panel__rewrite-label">Before</span>
+												<code>{ rewrite.original }</code>
+											</div>
+											<div className="performance-ai-panel__rewrite-after">
+												<span className="performance-ai-panel__rewrite-label">After</span>
+												<code>{ rewrite.suggested }</code>
+											</div>
+										</div>
+										{ rewrite.rationale && (
+											<span className="performance-ai-panel__rationale">{ rewrite.rationale }</span>
+										) }
+									</li>
+								) ) }
+							</ul>
+						</>
+					) }
+
+					{ insight.caveats.length > 0 && (
+						<>
+							<h4 className="performance-ai-panel__heading">Caveats</h4>
+							<ul className="performance-ai-panel__list performance-ai-panel__list--muted">
+								{ insight.caveats.map( ( caveat, index ) => (
+									<li key={ `caveat-${ index }` }>{ caveat }</li>
+								) ) }
+							</ul>
+						</>
+					) }
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default QueryInsightPanel;

--- a/resources/js/react/index.ts
+++ b/resources/js/react/index.ts
@@ -34,10 +34,18 @@ export type { QueryAnalyzerProps } from './QueryAnalyzer';
 export { RecommendationsPanel } from './RecommendationsPanel';
 export type { RecommendationsPanelProps } from './RecommendationsPanel';
 
+export { QueryInsightPanel } from './QueryInsightPanel';
+export type { QueryInsightPanelProps } from './QueryInsightPanel';
+
+export { OptimizationSuggestionPanel } from './OptimizationSuggestionPanel';
+export type { OptimizationSuggestionPanelProps } from './OptimizationSuggestionPanel';
+
 export { usePerformance } from './usePerformance';
 export type { UsePerformanceOptions, UsePerformanceResult } from './usePerformance';
 
 export type {
+	AiAgentResponse,
+	AiFeatureKey,
 	CacheActionResult,
 	CachePayload,
 	CacheSummary,
@@ -47,6 +55,11 @@ export type {
 	DashboardPayload,
 	DateRangeKey,
 	FragmentTag,
+	OptimizationFocusArea,
+	OptimizationLevel,
+	OptimizationMetricRow,
+	OptimizationSuggestion,
+	OptimizationSuggestionInput,
 	OverviewRow,
 	PageEntry,
 	PageRow,
@@ -54,12 +67,18 @@ export type {
 	PerformanceClientOptions,
 	QueriesPayload,
 	QueriesQuery,
+	QueryInsight,
+	QueryInsightInput,
+	QueryRewrite,
 	QuerySortKey,
 	Recommendation,
 	RecommendationActionResult,
 	RecommendationsPayload,
 	SlowQueryRow,
+	SuggestedIndex,
 	WebVitalName,
 	WebVitalReport,
 	WebVitalStatus,
 } from '../performance';
+
+export { PerformanceAiError } from '../performance';

--- a/resources/js/vue/OptimizationSuggestionPanel.vue
+++ b/resources/js/vue/OptimizationSuggestionPanel.vue
@@ -1,0 +1,199 @@
+<script setup lang="ts">
+/**
+ * OptimizationSuggestionPanel — Vue trigger for the OptimizationSuggestionAgent.
+ *
+ * @since 1.1.0
+ */
+
+import { computed, ref } from 'vue';
+
+import {
+	getPerformanceClient,
+	type OptimizationMetricRow,
+	type OptimizationSuggestion,
+	PerformanceAiError,
+	type PerformanceClient,
+	type PerformanceClientOptions,
+} from '../performance';
+
+interface Props {
+	client?: PerformanceClient;
+	clientOptions?: PerformanceClientOptions;
+	metrics: OptimizationMetricRow[];
+	range: { from: string; to: string };
+	initialBusinessPriority?: string;
+	initialRecentChanges?: string;
+	initialTrafficMix?: string;
+}
+
+const props = withDefaults( defineProps<Props>(), {
+	initialBusinessPriority: '',
+	initialRecentChanges: '',
+	initialTrafficMix: '',
+} );
+
+const emit = defineEmits<{
+	( event: 'suggestion', suggestion: OptimizationSuggestion ): void;
+}>();
+
+const resolvedClient: PerformanceClient = props.client ?? getPerformanceClient( props.clientOptions );
+
+const businessPriority = ref<string>( props.initialBusinessPriority );
+const recentChanges = ref<string>( props.initialRecentChanges );
+const trafficMix = ref<string>( props.initialTrafficMix );
+const suggestion = ref<OptimizationSuggestion | null>( null );
+const error = ref<string | null>( null );
+const isLoading = ref<boolean>( false );
+
+const disabled = computed<boolean>( () => isLoading.value || 0 === props.metrics.length );
+
+async function suggest(): Promise<void> {
+	error.value = null;
+	suggestion.value = null;
+	isLoading.value = true;
+
+	try {
+		const context: Record<string, string> = {};
+		if ( '' !== businessPriority.value.trim() ) {
+			context.business_priority = businessPriority.value.trim();
+		}
+		if ( '' !== recentChanges.value.trim() ) {
+			context.recent_changes = recentChanges.value.trim();
+		}
+		if ( '' !== trafficMix.value.trim() ) {
+			context.traffic_mix = trafficMix.value.trim();
+		}
+
+		const result = await resolvedClient.suggestOptimization( {
+			range: props.range,
+			metrics: props.metrics,
+			context: 0 === Object.keys( context ).length ? undefined : context,
+		} );
+
+		suggestion.value = result;
+		emit( 'suggestion', result );
+	} catch ( caught ) {
+		if ( caught instanceof PerformanceAiError ) {
+			error.value = caught.message;
+		} else if ( caught instanceof Error ) {
+			error.value = caught.message;
+		} else {
+			error.value = 'The AI agent could not complete this request.';
+		}
+	} finally {
+		isLoading.value = false;
+	}
+}
+</script>
+
+<template>
+	<div class="performance-ai-panel" data-feature="performance.optimization_suggestion">
+		<div class="performance-ai-panel__fields">
+			<label class="performance-ai-panel__label" for="optimization-priority-vue">
+				Business priority (optional)
+			</label>
+			<input
+				id="optimization-priority-vue"
+				v-model="businessPriority"
+				class="performance-ai-panel__input"
+				type="text"
+				placeholder="checkout > blog"
+			/>
+
+			<label class="performance-ai-panel__label" for="optimization-recent-vue">
+				Recent changes (optional)
+			</label>
+			<textarea
+				id="optimization-recent-vue"
+				v-model="recentChanges"
+				class="performance-ai-panel__textarea"
+				rows="2"
+				placeholder="switched to Vite last week"
+			/>
+
+			<label class="performance-ai-panel__label" for="optimization-traffic-vue">
+				Traffic mix (optional)
+			</label>
+			<input
+				id="optimization-traffic-vue"
+				v-model="trafficMix"
+				class="performance-ai-panel__input"
+				type="text"
+				placeholder="65% mobile, 35% desktop"
+			/>
+		</div>
+
+		<button
+			type="button"
+			class="performance-ai-panel__button"
+			:disabled="disabled"
+			@click="suggest"
+		>
+			<template v-if="isLoading">Analyzing…</template>
+			<template v-else>Suggest optimizations</template>
+		</button>
+
+		<p v-if="error" class="performance-ai-panel__error" role="alert">{{ error }}</p>
+
+		<div v-if="suggestion" class="performance-ai-panel__result">
+			<p v-if="suggestion.summary" class="performance-ai-panel__summary">{{ suggestion.summary }}</p>
+
+			<template v-if="suggestion.focus_areas.length > 0">
+				<h4 class="performance-ai-panel__heading">Focus areas</h4>
+				<ul class="performance-ai-panel__list">
+					<li
+						v-for="( area, index ) in suggestion.focus_areas"
+						:key="`focus-${ index }`"
+						class="performance-ai-panel__focus-area"
+					>
+						<div class="performance-ai-panel__focus-area-header">
+							<strong>{{ area.title }}</strong>
+							<span :class="`performance-ai-panel__tag performance-ai-panel__tag--impact-${ area.impact }`">
+								Impact: {{ area.impact }}
+							</span>
+							<span :class="`performance-ai-panel__tag performance-ai-panel__tag--effort-${ area.effort }`">
+								Effort: {{ area.effort }}
+							</span>
+						</div>
+
+						<p v-if="area.routes.length > 0" class="performance-ai-panel__routes">
+							Routes:
+							<template v-for="( route, routeIndex ) in area.routes" :key="`route-${ index }-${ routeIndex }`">
+								<code>{{ route }}</code><template v-if="routeIndex < area.routes.length - 1">, </template>
+							</template>
+						</p>
+
+						<p v-if="area.rationale" class="performance-ai-panel__rationale">{{ area.rationale }}</p>
+
+						<ul v-if="area.actions.length > 0" class="performance-ai-panel__actions">
+							<li
+								v-for="( action, actionIndex ) in area.actions"
+								:key="`action-${ index }-${ actionIndex }`"
+							>
+								{{ action }}
+							</li>
+						</ul>
+					</li>
+				</ul>
+			</template>
+
+			<template v-if="suggestion.quick_wins.length > 0">
+				<h4 class="performance-ai-panel__heading">Quick wins</h4>
+				<ul class="performance-ai-panel__list">
+					<li v-for="( win, index ) in suggestion.quick_wins" :key="`win-${ index }`">
+						{{ win }}
+					</li>
+				</ul>
+			</template>
+
+			<template v-if="suggestion.caveats.length > 0">
+				<h4 class="performance-ai-panel__heading">Caveats</h4>
+				<ul class="performance-ai-panel__list performance-ai-panel__list--muted">
+					<li v-for="( caveat, index ) in suggestion.caveats" :key="`caveat-${ index }`">
+						{{ caveat }}
+					</li>
+				</ul>
+			</template>
+		</div>
+	</div>
+</template>

--- a/resources/js/vue/QueryInsightPanel.vue
+++ b/resources/js/vue/QueryInsightPanel.vue
@@ -1,0 +1,228 @@
+<script setup lang="ts">
+/**
+ * QueryInsightPanel — Vue trigger for the PerformanceInsightAgent.
+ *
+ * Package-local (not exported through @artisanpack-ui/vue) because the
+ * agent's input shape and rendering are specific to the performance
+ * package's domain model.
+ *
+ * @since 1.1.0
+ */
+
+import { computed, ref } from 'vue';
+
+import {
+	getPerformanceClient,
+	PerformanceAiError,
+	type PerformanceClient,
+	type PerformanceClientOptions,
+	type QueryInsight,
+	type QueryInsightInput,
+} from '../performance';
+
+interface Props {
+	client?: PerformanceClient;
+	clientOptions?: PerformanceClientOptions;
+	initialQuery?: string;
+	initialExplain?: string;
+	initialSchema?: string;
+	initialConnection?: string;
+	initialTimeMs?: number | null;
+}
+
+const props = withDefaults( defineProps<Props>(), {
+	initialQuery: '',
+	initialExplain: '',
+	initialSchema: '',
+	initialConnection: '',
+	initialTimeMs: null,
+} );
+
+const emit = defineEmits<{
+	( event: 'insight', insight: QueryInsight ): void;
+}>();
+
+const resolvedClient: PerformanceClient = props.client ?? getPerformanceClient( props.clientOptions );
+
+const query = ref<string>( props.initialQuery );
+const explain = ref<string>( props.initialExplain );
+const schema = ref<string>( props.initialSchema );
+const connection = ref<string>( props.initialConnection );
+const timeMs = ref<number | null>( props.initialTimeMs );
+const insight = ref<QueryInsight | null>( null );
+const error = ref<string | null>( null );
+const isLoading = ref<boolean>( false );
+
+const disabled = computed<boolean>( () => isLoading.value || '' === query.value.trim() );
+
+function parseSchema( raw: string ): QueryInsightInput['schema'] {
+	const trimmed = raw.trim();
+	if ( '' === trimmed ) {
+		return null;
+	}
+	try {
+		const parsed = JSON.parse( trimmed );
+		if ( 'object' === typeof parsed && null !== parsed ) {
+			return parsed as QueryInsightInput['schema'];
+		}
+	} catch {
+		// Not JSON — pass the raw text through so the agent can still use
+		// it as a plain-text schema hint.
+	}
+	return trimmed;
+}
+
+async function analyze(): Promise<void> {
+	error.value = null;
+	insight.value = null;
+	isLoading.value = true;
+
+	try {
+		const parsedSchema = parseSchema( schema.value );
+		const explainValue = '' === explain.value.trim() ? null : explain.value;
+		const connectionValue = '' === connection.value.trim() ? null : connection.value.trim();
+
+		const result = await resolvedClient.suggestQueryInsight( {
+			query: query.value,
+			explain: explainValue,
+			schema: parsedSchema,
+			time_ms: timeMs.value,
+			connection: connectionValue,
+		} );
+
+		insight.value = result;
+		emit( 'insight', result );
+	} catch ( caught ) {
+		if ( caught instanceof PerformanceAiError ) {
+			error.value = caught.message;
+		} else if ( caught instanceof Error ) {
+			error.value = caught.message;
+		} else {
+			error.value = 'The AI agent could not complete this request.';
+		}
+	} finally {
+		isLoading.value = false;
+	}
+}
+</script>
+
+<template>
+	<div class="performance-ai-panel" data-feature="performance.query_insight">
+		<div class="performance-ai-panel__fields">
+			<label class="performance-ai-panel__label" for="query-insight-query-vue">Query</label>
+			<textarea
+				id="query-insight-query-vue"
+				v-model="query"
+				class="performance-ai-panel__textarea"
+				rows="5"
+				placeholder="SELECT * FROM …"
+			/>
+
+			<label class="performance-ai-panel__label" for="query-insight-explain-vue">EXPLAIN plan (optional)</label>
+			<textarea
+				id="query-insight-explain-vue"
+				v-model="explain"
+				class="performance-ai-panel__textarea"
+				rows="4"
+				placeholder="EXPLAIN output …"
+			/>
+
+			<label class="performance-ai-panel__label" for="query-insight-schema-vue">
+				Relevant schema (optional, JSON or text)
+			</label>
+			<textarea
+				id="query-insight-schema-vue"
+				v-model="schema"
+				class="performance-ai-panel__textarea"
+				rows="4"
+				placeholder='{ "articles": { "id": "bigint", "slug": "varchar(191)" } }'
+			/>
+
+			<div class="performance-ai-panel__meta">
+				<label class="performance-ai-panel__label" for="query-insight-connection-vue">Connection</label>
+				<input
+					id="query-insight-connection-vue"
+					v-model="connection"
+					class="performance-ai-panel__input"
+					type="text"
+					placeholder="mysql"
+				/>
+
+				<label class="performance-ai-panel__label" for="query-insight-time-vue">Observed duration (ms)</label>
+				<input
+					id="query-insight-time-vue"
+					v-model.number="timeMs"
+					class="performance-ai-panel__input"
+					type="number"
+					step="0.01"
+					placeholder="120.5"
+				/>
+			</div>
+		</div>
+
+		<button
+			type="button"
+			class="performance-ai-panel__button"
+			:disabled="disabled"
+			@click="analyze"
+		>
+			<template v-if="isLoading">Analyzing…</template>
+			<template v-else>Analyze query</template>
+		</button>
+
+		<p v-if="error" class="performance-ai-panel__error" role="alert">{{ error }}</p>
+
+		<div v-if="insight" class="performance-ai-panel__result">
+			<p v-if="insight.summary" class="performance-ai-panel__summary">{{ insight.summary }}</p>
+
+			<template v-if="insight.bottlenecks.length > 0">
+				<h4 class="performance-ai-panel__heading">Bottlenecks</h4>
+				<ol class="performance-ai-panel__list">
+					<li v-for="( bottleneck, index ) in insight.bottlenecks" :key="`bottleneck-${ index }`">
+						{{ bottleneck }}
+					</li>
+				</ol>
+			</template>
+
+			<template v-if="insight.suggested_indexes.length > 0">
+				<h4 class="performance-ai-panel__heading">Suggested indexes</h4>
+				<ul class="performance-ai-panel__list">
+					<li v-for="( index, key ) in insight.suggested_indexes" :key="`index-${ key }`">
+						<code>{{ index.table }}({{ index.columns.join( ', ' ) }})</code>
+						<span v-if="index.rationale" class="performance-ai-panel__rationale">{{ index.rationale }}</span>
+					</li>
+				</ul>
+			</template>
+
+			<template v-if="insight.rewrites.length > 0">
+				<h4 class="performance-ai-panel__heading">Suggested rewrites</h4>
+				<ul class="performance-ai-panel__list">
+					<li v-for="( rewrite, index ) in insight.rewrites" :key="`rewrite-${ index }`">
+						<div class="performance-ai-panel__rewrite">
+							<div class="performance-ai-panel__rewrite-before">
+								<span class="performance-ai-panel__rewrite-label">Before</span>
+								<code>{{ rewrite.original }}</code>
+							</div>
+							<div class="performance-ai-panel__rewrite-after">
+								<span class="performance-ai-panel__rewrite-label">After</span>
+								<code>{{ rewrite.suggested }}</code>
+							</div>
+						</div>
+						<span v-if="rewrite.rationale" class="performance-ai-panel__rationale">
+							{{ rewrite.rationale }}
+						</span>
+					</li>
+				</ul>
+			</template>
+
+			<template v-if="insight.caveats.length > 0">
+				<h4 class="performance-ai-panel__heading">Caveats</h4>
+				<ul class="performance-ai-panel__list performance-ai-panel__list--muted">
+					<li v-for="( caveat, index ) in insight.caveats" :key="`caveat-${ index }`">
+						{{ caveat }}
+					</li>
+				</ul>
+			</template>
+		</div>
+	</div>
+</template>

--- a/resources/js/vue/index.ts
+++ b/resources/js/vue/index.ts
@@ -27,10 +27,16 @@ export { default as QueryAnalyzer } from './QueryAnalyzer.vue';
 
 export { default as RecommendationsPanel } from './RecommendationsPanel.vue';
 
+export { default as QueryInsightPanel } from './QueryInsightPanel.vue';
+
+export { default as OptimizationSuggestionPanel } from './OptimizationSuggestionPanel.vue';
+
 export { usePerformance } from './usePerformance';
 export type { UsePerformanceOptions, UsePerformanceResult } from './usePerformance';
 
 export type {
+	AiAgentResponse,
+	AiFeatureKey,
 	CacheActionResult,
 	CachePayload,
 	CacheSummary,
@@ -40,6 +46,11 @@ export type {
 	DashboardPayload,
 	DateRangeKey,
 	FragmentTag,
+	OptimizationFocusArea,
+	OptimizationLevel,
+	OptimizationMetricRow,
+	OptimizationSuggestion,
+	OptimizationSuggestionInput,
 	OverviewRow,
 	PageEntry,
 	PageRow,
@@ -47,12 +58,18 @@ export type {
 	PerformanceClientOptions,
 	QueriesPayload,
 	QueriesQuery,
+	QueryInsight,
+	QueryInsightInput,
+	QueryRewrite,
 	QuerySortKey,
 	Recommendation,
 	RecommendationActionResult,
 	RecommendationsPayload,
 	SlowQueryRow,
+	SuggestedIndex,
 	WebVitalName,
 	WebVitalReport,
 	WebVitalStatus,
 } from '../performance';
+
+export { PerformanceAiError } from '../performance';

--- a/resources/views/livewire/ai/optimization-suggestion-panel.blade.php
+++ b/resources/views/livewire/ai/optimization-suggestion-panel.blade.php
@@ -1,0 +1,131 @@
+<div class="performance-ai-panel" data-feature="performance.optimization_suggestion">
+	@if ( ! $this->isEnabled )
+		<p class="performance-ai-panel__disabled">
+			{{ __( 'AI optimization suggestions are currently disabled.' ) }}
+		</p>
+	@else
+		<div class="performance-ai-panel__fields">
+			<label class="performance-ai-panel__label" for="optimization-window">
+				{{ __( 'Window (days)' ) }}
+			</label>
+			<input
+				id="optimization-window"
+				type="number"
+				min="1"
+				max="90"
+				wire:model.live="windowDays"
+				class="performance-ai-panel__input"
+			/>
+
+			<label class="performance-ai-panel__label" for="optimization-priority">
+				{{ __( 'Business priority (optional)' ) }}
+			</label>
+			<input
+				id="optimization-priority"
+				type="text"
+				wire:model.live="businessPriority"
+				class="performance-ai-panel__input"
+				placeholder="checkout > blog"
+			/>
+
+			<label class="performance-ai-panel__label" for="optimization-recent">
+				{{ __( 'Recent changes (optional)' ) }}
+			</label>
+			<textarea
+				id="optimization-recent"
+				wire:model.live="recentChanges"
+				class="performance-ai-panel__textarea"
+				rows="2"
+				placeholder="switched to Vite last week"
+			></textarea>
+		</div>
+
+		<button
+			type="button"
+			wire:click="suggest"
+			wire:loading.attr="disabled"
+			wire:target="suggest"
+			@disabled( $isLoading )
+			class="performance-ai-panel__button"
+		>
+			<span wire:loading.remove wire:target="suggest">
+				{{ __( 'Suggest optimizations' ) }}
+			</span>
+			<span wire:loading wire:target="suggest">
+				{{ __( 'Analyzing…' ) }}
+			</span>
+		</button>
+
+		@if ( null !== $error )
+			<p class="performance-ai-panel__error" role="alert">
+				{{ $error }}
+			</p>
+		@endif
+
+		@if ( null !== $suggestion )
+			<div class="performance-ai-panel__result">
+				@if ( ! empty( $suggestion['summary'] ) )
+					<p class="performance-ai-panel__summary">{{ $suggestion['summary'] }}</p>
+				@endif
+
+				@if ( ! empty( $suggestion['focus_areas'] ) )
+					<h4 class="performance-ai-panel__heading">{{ __( 'Focus areas' ) }}</h4>
+					<ul class="performance-ai-panel__list">
+						@foreach ( $suggestion['focus_areas'] as $area )
+							<li class="performance-ai-panel__focus-area">
+								<div class="performance-ai-panel__focus-area-header">
+									<strong>{{ $area['title'] }}</strong>
+									<span class="performance-ai-panel__tag performance-ai-panel__tag--impact-{{ $area['impact'] }}">
+										{{ __( 'Impact' ) }}: {{ $area['impact'] }}
+									</span>
+									<span class="performance-ai-panel__tag performance-ai-panel__tag--effort-{{ $area['effort'] }}">
+										{{ __( 'Effort' ) }}: {{ $area['effort'] }}
+									</span>
+								</div>
+
+								@if ( ! empty( $area['routes'] ) )
+									<p class="performance-ai-panel__routes">
+										{{ __( 'Routes' ) }}:
+										@foreach ( $area['routes'] as $route )
+											<code>{{ $route }}</code>@if ( ! $loop->last ), @endif
+										@endforeach
+									</p>
+								@endif
+
+								@if ( '' !== $area['rationale'] )
+									<p class="performance-ai-panel__rationale">{{ $area['rationale'] }}</p>
+								@endif
+
+								@if ( ! empty( $area['actions'] ) )
+									<ul class="performance-ai-panel__actions">
+										@foreach ( $area['actions'] as $action )
+											<li>{{ $action }}</li>
+										@endforeach
+									</ul>
+								@endif
+							</li>
+						@endforeach
+					</ul>
+				@endif
+
+				@if ( ! empty( $suggestion['quick_wins'] ) )
+					<h4 class="performance-ai-panel__heading">{{ __( 'Quick wins' ) }}</h4>
+					<ul class="performance-ai-panel__list">
+						@foreach ( $suggestion['quick_wins'] as $win )
+							<li>{{ $win }}</li>
+						@endforeach
+					</ul>
+				@endif
+
+				@if ( ! empty( $suggestion['caveats'] ) )
+					<h4 class="performance-ai-panel__heading">{{ __( 'Caveats' ) }}</h4>
+					<ul class="performance-ai-panel__list performance-ai-panel__list--muted">
+						@foreach ( $suggestion['caveats'] as $caveat )
+							<li>{{ $caveat }}</li>
+						@endforeach
+					</ul>
+				@endif
+			</div>
+		@endif
+	@endif
+</div>

--- a/resources/views/livewire/ai/query-insight-panel.blade.php
+++ b/resources/views/livewire/ai/query-insight-panel.blade.php
@@ -1,0 +1,152 @@
+<div class="performance-ai-panel" data-feature="performance.query_insight">
+	@if ( ! $this->isEnabled )
+		<p class="performance-ai-panel__disabled">
+			{{ __( 'AI query insight is currently disabled.' ) }}
+		</p>
+	@else
+		<div class="performance-ai-panel__fields">
+			<label class="performance-ai-panel__label" for="query-insight-query">
+				{{ __( 'Query' ) }}
+			</label>
+			<textarea
+				id="query-insight-query"
+				wire:model.live="query"
+				class="performance-ai-panel__textarea"
+				rows="5"
+				placeholder="SELECT * FROM …"
+			></textarea>
+
+			<label class="performance-ai-panel__label" for="query-insight-explain">
+				{{ __( 'EXPLAIN plan (optional)' ) }}
+			</label>
+			<textarea
+				id="query-insight-explain"
+				wire:model.live="explain"
+				class="performance-ai-panel__textarea"
+				rows="4"
+				placeholder="EXPLAIN output …"
+			></textarea>
+
+			<label class="performance-ai-panel__label" for="query-insight-schema">
+				{{ __( 'Relevant schema (optional, JSON or text)' ) }}
+			</label>
+			<textarea
+				id="query-insight-schema"
+				wire:model.live="schema"
+				class="performance-ai-panel__textarea"
+				rows="4"
+				placeholder='{ "articles": { "id": "bigint", "slug": "varchar(191)" } }'
+			></textarea>
+
+			<div class="performance-ai-panel__meta">
+				<label class="performance-ai-panel__label" for="query-insight-connection">
+					{{ __( 'Connection' ) }}
+				</label>
+				<input
+					id="query-insight-connection"
+					type="text"
+					wire:model.live="connection"
+					class="performance-ai-panel__input"
+					placeholder="mysql"
+				/>
+
+				<label class="performance-ai-panel__label" for="query-insight-time-ms">
+					{{ __( 'Observed duration (ms)' ) }}
+				</label>
+				<input
+					id="query-insight-time-ms"
+					type="number"
+					step="0.01"
+					wire:model.live="timeMs"
+					class="performance-ai-panel__input"
+					placeholder="120.5"
+				/>
+			</div>
+		</div>
+
+		<button
+			type="button"
+			wire:click="analyze"
+			wire:loading.attr="disabled"
+			wire:target="analyze"
+			@disabled( $isLoading || '' === trim( $query ) )
+			class="performance-ai-panel__button"
+		>
+			<span wire:loading.remove wire:target="analyze">
+				{{ __( 'Analyze query' ) }}
+			</span>
+			<span wire:loading wire:target="analyze">
+				{{ __( 'Analyzing…' ) }}
+			</span>
+		</button>
+
+		@if ( null !== $error )
+			<p class="performance-ai-panel__error" role="alert">
+				{{ $error }}
+			</p>
+		@endif
+
+		@if ( null !== $insight )
+			<div class="performance-ai-panel__result">
+				@if ( ! empty( $insight['summary'] ) )
+					<p class="performance-ai-panel__summary">{{ $insight['summary'] }}</p>
+				@endif
+
+				@if ( ! empty( $insight['bottlenecks'] ) )
+					<h4 class="performance-ai-panel__heading">{{ __( 'Bottlenecks' ) }}</h4>
+					<ol class="performance-ai-panel__list">
+						@foreach ( $insight['bottlenecks'] as $bottleneck )
+							<li>{{ $bottleneck }}</li>
+						@endforeach
+					</ol>
+				@endif
+
+				@if ( ! empty( $insight['suggested_indexes'] ) )
+					<h4 class="performance-ai-panel__heading">{{ __( 'Suggested indexes' ) }}</h4>
+					<ul class="performance-ai-panel__list">
+						@foreach ( $insight['suggested_indexes'] as $index )
+							<li>
+								<code>{{ $index['table'] }}({{ implode( ', ', $index['columns'] ) }})</code>
+								@if ( '' !== $index['rationale'] )
+									<span class="performance-ai-panel__rationale">{{ $index['rationale'] }}</span>
+								@endif
+							</li>
+						@endforeach
+					</ul>
+				@endif
+
+				@if ( ! empty( $insight['rewrites'] ) )
+					<h4 class="performance-ai-panel__heading">{{ __( 'Suggested rewrites' ) }}</h4>
+					<ul class="performance-ai-panel__list">
+						@foreach ( $insight['rewrites'] as $rewrite )
+							<li>
+								<div class="performance-ai-panel__rewrite">
+									<div class="performance-ai-panel__rewrite-before">
+										<span class="performance-ai-panel__rewrite-label">{{ __( 'Before' ) }}</span>
+										<code>{{ $rewrite['original'] }}</code>
+									</div>
+									<div class="performance-ai-panel__rewrite-after">
+										<span class="performance-ai-panel__rewrite-label">{{ __( 'After' ) }}</span>
+										<code>{{ $rewrite['suggested'] }}</code>
+									</div>
+								</div>
+								@if ( '' !== $rewrite['rationale'] )
+									<span class="performance-ai-panel__rationale">{{ $rewrite['rationale'] }}</span>
+								@endif
+							</li>
+						@endforeach
+					</ul>
+				@endif
+
+				@if ( ! empty( $insight['caveats'] ) )
+					<h4 class="performance-ai-panel__heading">{{ __( 'Caveats' ) }}</h4>
+					<ul class="performance-ai-panel__list performance-ai-panel__list--muted">
+						@foreach ( $insight['caveats'] as $caveat )
+							<li>{{ $caveat }}</li>
+						@endforeach
+					</ul>
+				@endif
+			</div>
+		@endif
+	@endif
+</div>

--- a/routes/api-ai.php
+++ b/routes/api-ai.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Performance package AI JSON API routes.
+ *
+ * Loaded from `PerformanceServiceProvider::registerRoutes()` under the
+ * dedicated `ai_middleware` stack (Sanctum + a `performance.ai.use`
+ * Gate by default) because these endpoints dispatch to paid LLM
+ * providers — sharing the stateless public middleware used by the
+ * metrics ingest would let anonymous callers drain the credit balance.
+ *
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare(strict_types=1);
+
+use ArtisanPackUI\Performance\Http\Controllers\Api\AiAgentApiController;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('ai')->group(function (): void {
+    Route::post('/query-insight', [AiAgentApiController::class, 'queryInsight'])
+        ->name('ai.query-insight');
+
+    Route::post('/optimization-suggestion', [AiAgentApiController::class, 'optimizationSuggestion'])
+        ->name('ai.optimization-suggestion');
+});

--- a/src/Ai/Agents/OptimizationSuggestionAgent.php
+++ b/src/Ai/Agents/OptimizationSuggestionAgent.php
@@ -1,0 +1,451 @@
+<?php
+
+/**
+ * Optimization suggestion agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use JsonException;
+
+/**
+ * Suggest where to focus optimization work given aggregate performance
+ * metrics over a date range.
+ *
+ * Distinct from {@see PerformanceInsightAgent}: that agent works on a single
+ * slow query. This one looks at the *portfolio* — Core Web Vitals, route
+ * timings, cache hit rates, slow-query counts — and decides which fires
+ * are worth putting out first.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'range' => [ 'from' => 'YYYY-MM-DD', 'to' => 'YYYY-MM-DD' ], // required
+ *   'metrics' => [                                                // required
+ *     [
+ *       'metric'    => string,   // e.g. 'lcp', 'inp', 'query_time_ms'
+ *       'route'     => string,   // e.g. 'GET /articles/{slug}'
+ *       'p50'       => float,
+ *       'p75'       => float,
+ *       'p90'       => float,
+ *       'p99'       => float,
+ *       'samples'   => int,
+ *     ],
+ *     …
+ *   ],
+ *   'context' => [                                                // optional
+ *     'traffic_mix'      => string,  // e.g. '65% mobile, 35% desktop'
+ *     'recent_changes'   => string,  // e.g. 'switched to Vite last week'
+ *     'business_priority'=> string,  // e.g. 'checkout > blog'
+ *   ],
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   summary:         string,                              // portfolio-level diagnosis
+ *   focus_areas: [
+ *     {
+ *       title:       string,
+ *       routes:      string[],
+ *       impact:      'high' | 'medium' | 'low',
+ *       effort:      'high' | 'medium' | 'low',
+ *       rationale:   string,
+ *       actions:     string[],                            // concrete follow-ups
+ *     }
+ *   ],
+ *   quick_wins:      string[],                            // low-effort/high-return items
+ *   caveats:         string[]                             // gaps in the data
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.1.0
+ */
+class OptimizationSuggestionAgent extends ArtisanPackAgent
+{
+
+    /**
+     * Impact and effort levels the model must choose from.
+     *
+     * @since 1.1.0
+     *
+     * @var array<int, string>
+     */
+    protected const LEVELS = [ 'high', 'medium', 'low' ];
+
+    /**
+     * {@inheritDoc}
+     *
+     * Portfolio-level suggestions are point-in-time snapshots of the
+     * current metrics window; once the operator ships one of the focus
+     * areas, the previous suggestion is stale.
+     */
+    public bool $cacheable = false;
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'performance.optimization_suggestion';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/performance';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-sonnet-4-6';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You review aggregate application performance metrics and recommend where the team should focus optimization work.
+
+Requirements:
+- Base every recommendation on the provided metrics and context. Do NOT invent routes, thresholds, or numbers.
+- `summary` is a portfolio-level diagnosis in 2-4 sentences — what stands out across the whole date range.
+- `focus_areas` groups related regressions into 1-5 focused work streams, most-impactful first. Each area MUST cite specific `routes` from the input metrics.
+- Set `impact` and `effort` to one of `high`, `medium`, or `low`. Impact is user-facing (SLO risk, revenue-adjacent). Effort is engineering cost.
+- `actions` lists 2-5 concrete follow-ups for that focus area — not vague advice. Prefer "add a covering index on articles(slug, published_at)" over "improve DB performance".
+- `quick_wins` surfaces low-effort/high-return items that stand alone from the focus areas (e.g. bump PHP OPcache, enable Brotli, deploy resource hints for a specific route).
+- Bias toward the `business_priority` when provided — if two focus areas would help equally, pick the one closer to the priority.
+- `caveats` captures what would sharpen the picture (missing device breakdown, no sample counts on some rows, single-day range, etc.). An empty array is fine when the input is clean.
+
+Return a JSON object with keys: summary (string), focus_areas (array of objects), quick_wins (array of strings), caveats (array of strings).
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'required'             => [ 'summary', 'focus_areas', 'quick_wins', 'caveats' ],
+            'properties'           => [
+                'summary'     => [ 'type' => 'string' ],
+                'focus_areas' => [
+                    'type'  => 'array',
+                    'items' => [
+                        'type'                 => 'object',
+                        'additionalProperties' => false,
+                        'required'             => [ 'title', 'routes', 'impact', 'effort', 'rationale', 'actions' ],
+                        'properties'           => [
+                            'title'     => [ 'type' => 'string' ],
+                            'routes'    => [
+                                'type'  => 'array',
+                                'items' => [ 'type' => 'string' ],
+                            ],
+                            'impact'    => [ 'type' => 'string', 'enum' => self::LEVELS ],
+                            'effort'    => [ 'type' => 'string', 'enum' => self::LEVELS ],
+                            'rationale' => [ 'type' => 'string' ],
+                            'actions'   => [
+                                'type'  => 'array',
+                                'items' => [ 'type' => 'string' ],
+                            ],
+                        ],
+                    ],
+                ],
+                'quick_wins'  => [
+                    'type'  => 'array',
+                    'items' => [ 'type' => 'string' ],
+                ],
+                'caveats'     => [
+                    'type'  => 'array',
+                    'items' => [ 'type' => 'string' ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute( Credentials $credentials, string $model, string $instructions ): array
+    {
+        $normalized = $this->normalizeInput( $this->input() );
+
+        // Empty metrics list => short-circuit. There is nothing for the
+        // model to reason about and we would only invite hallucinations.
+        if ( [] === $normalized['metrics'] ) {
+            return [
+                'output'        => [
+                    'summary'     => 'No metrics to analyze in the requested range.',
+                    'focus_areas' => [],
+                    'quick_wins'  => [],
+                    'caveats'     => [ 'metrics list was empty' ],
+                ],
+                'input_tokens'  => 0,
+                'output_tokens' => 0,
+            ];
+        }
+
+        $prompter = app( AgentPrompter::class );
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage( $normalized ),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output'        => $this->validateOutput( $result['output'] ?? [] ),
+            'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+            'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+        ];
+    }
+
+    /**
+     * Validate and shape-check the raw agent input.
+     *
+     * @since 1.1.0
+     *
+     * @param  mixed  $input  Raw agent input.
+     *
+     * @return array{ range: array{ from: string, to: string }, metrics: array<int, array<string, mixed>>, context: array<string, string> }
+     */
+    protected function normalizeInput( mixed $input ): array
+    {
+        if ( ! is_array( $input ) ) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                'input must be an array with `range` and `metrics` keys.',
+            );
+        }
+
+        if ( ! isset( $input['range'] ) || ! is_array( $input['range'] ) ) {
+            throw FeatureError::forFeature( $this->featureKey, '`range` must be an array with `from` and `to` keys.' );
+        }
+
+        $from = isset( $input['range']['from'] ) && is_string( $input['range']['from'] )
+            ? trim( $input['range']['from'] )
+            : '';
+        $to   = isset( $input['range']['to'] ) && is_string( $input['range']['to'] )
+            ? trim( $input['range']['to'] )
+            : '';
+
+        if ( '' === $from || '' === $to ) {
+            throw FeatureError::forFeature( $this->featureKey, '`range.from` and `range.to` must be non-empty strings.' );
+        }
+
+        if ( ! isset( $input['metrics'] ) || ! is_array( $input['metrics'] ) ) {
+            throw FeatureError::forFeature( $this->featureKey, '`metrics` must be an array.' );
+        }
+
+        $context = [];
+
+        if ( isset( $input['context'] ) && is_array( $input['context'] ) ) {
+            foreach ( $input['context'] as $key => $value ) {
+                if ( is_string( $key ) && is_string( $value ) && '' !== trim( $value ) ) {
+                    $context[ $key ] = trim( $value );
+                }
+            }
+        }
+
+        return [
+            'range'   => [
+                'from' => $from,
+                'to'   => $to,
+            ],
+            'metrics' => array_values( $input['metrics'] ),
+            'context' => $context,
+        ];
+    }
+
+    /**
+     * Assemble the structured message body for the prompter.
+     *
+     * @since 1.1.0
+     *
+     * @param  array{ range: array{ from: string, to: string }, metrics: array<int, array<string, mixed>>, context: array<string, string> }  $normalized  Normalized input.
+     *
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage( array $normalized ): array
+    {
+        $parts = [
+            [
+                'type' => 'text',
+                'text' => sprintf( 'Date range: %s to %s', $normalized['range']['from'], $normalized['range']['to'] ),
+            ],
+        ];
+
+        if ( [] !== $normalized['context'] ) {
+            $parts[] = [
+                'type' => 'text',
+                'text' => "Context:\n" . $this->encode( $normalized['context'] ),
+            ];
+        }
+
+        $parts[] = [
+            'type' => 'text',
+            'text' => "Metrics:\n" . $this->encode( $normalized['metrics'] ),
+        ];
+
+        return $parts;
+    }
+
+    /**
+     * Serialize a payload to a stable JSON string.
+     *
+     * @since 1.1.0
+     *
+     * @param  array<mixed>  $value  Payload to serialize.
+     *
+     * @return string
+     */
+    protected function encode( array $value ): string
+    {
+        try {
+            return json_encode(
+                $value,
+                JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+            );
+        } catch ( JsonException $exception ) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                sprintf( 'payload could not be serialized for the model: %s', $exception->getMessage() ),
+                $exception,
+            );
+        }
+    }
+
+    /**
+     * Enforce output invariants — coerce shapes, drop malformed rows.
+     *
+     * @since 1.1.0
+     *
+     * @param  array<string, mixed>  $output  Decoded model output.
+     *
+     * @return array{ summary: string, focus_areas: array<int, array{ title: string, routes: array<int, string>, impact: string, effort: string, rationale: string, actions: array<int, string> }>, quick_wins: array<int, string>, caveats: array<int, string> }
+     */
+    protected function validateOutput( array $output ): array
+    {
+        return [
+            'summary'     => isset( $output['summary'] ) ? trim( (string) $output['summary'] ) : '',
+            'focus_areas' => $this->focusAreaList( $output['focus_areas'] ?? [] ),
+            'quick_wins'  => $this->stringList( $output['quick_wins'] ?? [] ),
+            'caveats'     => $this->stringList( $output['caveats'] ?? [] ),
+        ];
+    }
+
+    /**
+     * Shape-check focus-area rows.
+     *
+     * @since 1.1.0
+     *
+     * @param  mixed  $raw  Raw focus-area list.
+     *
+     * @return array<int, array{ title: string, routes: array<int, string>, impact: string, effort: string, rationale: string, actions: array<int, string> }>
+     */
+    protected function focusAreaList( mixed $raw ): array
+    {
+        if ( ! is_array( $raw ) ) {
+            return [];
+        }
+
+        $out = [];
+
+        foreach ( $raw as $row ) {
+            if ( ! is_array( $row ) ) {
+                continue;
+            }
+
+            $title = isset( $row['title'] ) ? trim( (string) $row['title'] ) : '';
+
+            if ( '' === $title ) {
+                continue;
+            }
+
+            $out[] = [
+                'title'     => $title,
+                'routes'    => $this->stringList( $row['routes'] ?? [] ),
+                'impact'    => $this->clampLevel( $row['impact'] ?? '' ),
+                'effort'    => $this->clampLevel( $row['effort'] ?? '' ),
+                'rationale' => isset( $row['rationale'] ) ? trim( (string) $row['rationale'] ) : '',
+                'actions'   => $this->stringList( $row['actions'] ?? [] ),
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Coerce an impact/effort value into the allowed vocabulary.
+     *
+     * Falls back to `medium` when the model returns anything unexpected —
+     * safer than leaking the raw value into the UI, and matches how a
+     * human triager would treat "unknown severity".
+     *
+     * @since 1.1.0
+     *
+     * @param  mixed  $value  Raw level from the model.
+     *
+     * @return string
+     */
+    protected function clampLevel( mixed $value ): string
+    {
+        if ( is_string( $value ) ) {
+            $lower = strtolower( trim( $value ) );
+
+            if ( in_array( $lower, self::LEVELS, true ) ) {
+                return $lower;
+            }
+        }
+
+        return 'medium';
+    }
+
+    /**
+     * Filter a raw list into a clean array of non-empty strings.
+     *
+     * @since 1.1.0
+     *
+     * @param  mixed  $raw  Raw list from the model.
+     *
+     * @return array<int, string>
+     */
+    protected function stringList( mixed $raw ): array
+    {
+        if ( ! is_array( $raw ) ) {
+            return [];
+        }
+
+        $out = [];
+
+        foreach ( $raw as $value ) {
+            if ( is_string( $value ) && '' !== trim( $value ) ) {
+                $out[] = $value;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/src/Ai/Agents/PerformanceInsightAgent.php
+++ b/src/Ai/Agents/PerformanceInsightAgent.php
@@ -1,0 +1,435 @@
+<?php
+
+/**
+ * Performance insight agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use JsonException;
+
+/**
+ * Explain why a specific query is slow and suggest optimizations.
+ *
+ * The agent only *suggests* indexes and rewrites — it never issues DDL or
+ * mutates the database. Callers are expected to review the recommendations
+ * and generate migrations by hand.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'query'         => string,             // required, the SQL statement
+ *   'explain'       => array|string|null,  // optional, EXPLAIN plan (JSON array or raw text)
+ *   'schema'        => array|null,         // optional, list of relevant table schemas
+ *   'time_ms'       => float|int|null,     // optional, observed duration in milliseconds
+ *   'connection'    => string|null,        // optional, DB connection driver ('mysql', 'pgsql', …)
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   summary:         string,          // one-paragraph diagnosis
+ *   bottlenecks:     string[],        // ranked list of the biggest issues
+ *   suggested_indexes: [
+ *     { table: string, columns: string[], rationale: string }
+ *   ],
+ *   rewrites:        [
+ *     { original: string, suggested: string, rationale: string }
+ *   ],
+ *   caveats:         string[]         // uncertainties / missing context
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.1.0
+ */
+class PerformanceInsightAgent extends ArtisanPackAgent
+{
+    /**
+     * {@inheritDoc}
+     *
+     * Query-insight outputs are point-in-time diagnoses of a specific
+     * slow query. Once the operator adds the suggested index or rewrites
+     * the query, the previous diagnosis is stale — a cache hit would
+     * hand back suggestions naming bottlenecks that no longer exist.
+     */
+    public bool $cacheable = false;
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'performance.query_insight';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/performance';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-sonnet-4-6';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You analyze a single slow SQL query and explain why it is slow, then suggest optimizations.
+
+Requirements:
+- Base every claim on the provided query, EXPLAIN plan, and schema. Do NOT invent columns, indexes, tables, or row counts that are not present in the input.
+- `summary` is a single paragraph (2-4 sentences) diagnosing the primary bottleneck.
+- `bottlenecks` ranks issues by expected impact — biggest first (e.g. full table scan, filesort, index miss, N+1 pattern hint).
+- `suggested_indexes` lists composite/single-column indexes that would eliminate the ranked bottlenecks. Each entry MUST name a real table from the schema and columns that exist on it. Include a one-sentence `rationale`.
+- `rewrites` proposes query rewrites (JOIN order, subquery flattening, EXISTS-vs-IN, covering SELECT, etc.). Set `original` to the exact clause you replaced and `suggested` to the replacement. Include a one-sentence `rationale`.
+- You suggest, you do NOT execute: NEVER emit `CREATE INDEX`, `ALTER TABLE`, or any DDL/DML — the frontend renders your suggestions and a human decides whether to write a migration.
+- `caveats` captures anything a downstream reader should know — missing EXPLAIN plan, unknown row counts, ambiguous JOIN cardinality, etc. An empty array is fine when the input is complete.
+
+Return a JSON object with keys: summary (string), bottlenecks (array of strings), suggested_indexes (array of objects), rewrites (array of objects), caveats (array of strings).
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'required'             => [ 'summary', 'bottlenecks', 'suggested_indexes', 'rewrites', 'caveats' ],
+            'properties'           => [
+                'summary'           => [ 'type' => 'string' ],
+                'bottlenecks'       => [
+                    'type'  => 'array',
+                    'items' => [ 'type' => 'string' ],
+                ],
+                'suggested_indexes' => [
+                    'type'  => 'array',
+                    'items' => [
+                        'type'                 => 'object',
+                        'additionalProperties' => false,
+                        'required'             => [ 'table', 'columns', 'rationale' ],
+                        'properties'           => [
+                            'table'     => [ 'type' => 'string' ],
+                            'columns'   => [
+                                'type'  => 'array',
+                                'items' => [ 'type' => 'string' ],
+                            ],
+                            'rationale' => [ 'type' => 'string' ],
+                        ],
+                    ],
+                ],
+                'rewrites'          => [
+                    'type'  => 'array',
+                    'items' => [
+                        'type'                 => 'object',
+                        'additionalProperties' => false,
+                        'required'             => [ 'original', 'suggested', 'rationale' ],
+                        'properties'           => [
+                            'original'  => [ 'type' => 'string' ],
+                            'suggested' => [ 'type' => 'string' ],
+                            'rationale' => [ 'type' => 'string' ],
+                        ],
+                    ],
+                ],
+                'caveats'           => [
+                    'type'  => 'array',
+                    'items' => [ 'type' => 'string' ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute( Credentials $credentials, string $model, string $instructions ): array
+    {
+        $normalized = $this->normalizeInput( $this->input() );
+
+        $prompter = app( AgentPrompter::class );
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage( $normalized ),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output'        => $this->validateOutput( $result['output'] ?? [] ),
+            'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+            'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+        ];
+    }
+
+    /**
+     * Validate and shape-check the raw agent input.
+     *
+     * @since 1.1.0
+     *
+     * @param  mixed  $input  Raw agent input.
+     *
+     * @return array{ query: string, explain: array<mixed>|string|null, schema: array<mixed>|null, time_ms: float|null, connection: string|null }
+     */
+    protected function normalizeInput( mixed $input ): array
+    {
+        if ( ! is_array( $input ) ) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                'input must be an array with a `query` key.',
+            );
+        }
+
+        $query = isset( $input['query'] ) && is_string( $input['query'] ) ? trim( $input['query'] ) : '';
+
+        if ( '' === $query ) {
+            throw FeatureError::forFeature( $this->featureKey, '`query` must be a non-empty string.' );
+        }
+
+        $explain = $input['explain'] ?? null;
+
+        if ( null !== $explain && ! is_array( $explain ) && ! is_string( $explain ) ) {
+            throw FeatureError::forFeature( $this->featureKey, '`explain` must be an array, string, or null.' );
+        }
+
+        $schema = $input['schema'] ?? null;
+
+        if ( null !== $schema && ! is_array( $schema ) ) {
+            throw FeatureError::forFeature( $this->featureKey, '`schema` must be an array or null.' );
+        }
+
+        $timeMs = null;
+
+        if ( isset( $input['time_ms'] ) && ( is_int( $input['time_ms'] ) || is_float( $input['time_ms'] ) ) ) {
+            $timeMs = (float) $input['time_ms'];
+        }
+
+        $connection = isset( $input['connection'] ) && is_string( $input['connection'] )
+            ? trim( $input['connection'] )
+            : '';
+
+        return [
+            'query'      => $query,
+            'explain'    => $explain,
+            'schema'     => $schema,
+            'time_ms'    => $timeMs,
+            'connection' => '' === $connection ? null : $connection,
+        ];
+    }
+
+    /**
+     * Assemble the structured message body for the prompter.
+     *
+     * @since 1.1.0
+     *
+     * @param  array{ query: string, explain: array<mixed>|string|null, schema: array<mixed>|null, time_ms: float|null, connection: string|null }  $normalized  Normalized input.
+     *
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage( array $normalized ): array
+    {
+        $parts = [];
+
+        if ( null !== $normalized['connection'] ) {
+            $parts[] = [ 'type' => 'text', 'text' => sprintf( 'Connection: %s', $normalized['connection'] ) ];
+        }
+
+        if ( null !== $normalized['time_ms'] ) {
+            $parts[] = [ 'type' => 'text', 'text' => sprintf( 'Observed duration: %s ms', $normalized['time_ms'] ) ];
+        }
+
+        $parts[] = [ 'type' => 'text', 'text' => "Query:\n" . $normalized['query'] ];
+
+        if ( null !== $normalized['explain'] ) {
+            $parts[] = [
+                'type' => 'text',
+                'text' => "EXPLAIN plan:\n" . $this->encode( $normalized['explain'] ),
+            ];
+        }
+
+        if ( null !== $normalized['schema'] ) {
+            $parts[] = [
+                'type' => 'text',
+                'text' => "Schema:\n" . $this->encode( $normalized['schema'] ),
+            ];
+        }
+
+        return $parts;
+    }
+
+    /**
+     * Serialize a payload to a stable JSON string, or pass through a string.
+     *
+     * @since 1.1.0
+     *
+     * @param  array<mixed>|string  $value  Payload to serialize.
+     *
+     * @return string
+     */
+    protected function encode( array|string $value ): string
+    {
+        if ( is_string( $value ) ) {
+            return $value;
+        }
+
+        try {
+            return json_encode(
+                $value,
+                JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+            );
+        } catch ( JsonException $exception ) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                sprintf( 'payload could not be serialized for the model: %s', $exception->getMessage() ),
+                $exception,
+            );
+        }
+    }
+
+    /**
+     * Enforce output invariants — coerce shapes, drop malformed rows.
+     *
+     * @since 1.1.0
+     *
+     * @param  array<string, mixed>  $output  Decoded model output.
+     *
+     * @return array{ summary: string, bottlenecks: array<int, string>, suggested_indexes: array<int, array{ table: string, columns: array<int, string>, rationale: string }>, rewrites: array<int, array{ original: string, suggested: string, rationale: string }>, caveats: array<int, string> }
+     */
+    protected function validateOutput( array $output ): array
+    {
+        return [
+            'summary'           => isset( $output['summary'] ) ? trim( (string) $output['summary'] ) : '',
+            'bottlenecks'       => $this->stringList( $output['bottlenecks'] ?? [] ),
+            'suggested_indexes' => $this->indexList( $output['suggested_indexes'] ?? [] ),
+            'rewrites'          => $this->rewriteList( $output['rewrites'] ?? [] ),
+            'caveats'           => $this->stringList( $output['caveats'] ?? [] ),
+        ];
+    }
+
+    /**
+     * Filter a raw list into a clean array of non-empty strings.
+     *
+     * @since 1.1.0
+     *
+     * @param  mixed  $raw  Raw list from the model.
+     *
+     * @return array<int, string>
+     */
+    protected function stringList( mixed $raw ): array
+    {
+        if ( ! is_array( $raw ) ) {
+            return [];
+        }
+
+        $out = [];
+
+        foreach ( $raw as $value ) {
+            if ( is_string( $value ) && '' !== trim( $value ) ) {
+                $out[] = $value;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Shape-check suggested-index rows.
+     *
+     * @since 1.1.0
+     *
+     * @param  mixed  $raw  Raw index list.
+     *
+     * @return array<int, array{ table: string, columns: array<int, string>, rationale: string }>
+     */
+    protected function indexList( mixed $raw ): array
+    {
+        if ( ! is_array( $raw ) ) {
+            return [];
+        }
+
+        $out = [];
+
+        foreach ( $raw as $row ) {
+            if ( ! is_array( $row ) ) {
+                continue;
+            }
+
+            $table   = isset( $row['table'] ) ? trim( (string) $row['table'] ) : '';
+            $columns = $this->stringList( $row['columns'] ?? [] );
+
+            if ( '' === $table || [] === $columns ) {
+                continue;
+            }
+
+            $out[] = [
+                'table'     => $table,
+                'columns'   => $columns,
+                'rationale' => isset( $row['rationale'] ) ? trim( (string) $row['rationale'] ) : '',
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Shape-check rewrite rows.
+     *
+     * @since 1.1.0
+     *
+     * @param  mixed  $raw  Raw rewrite list.
+     *
+     * @return array<int, array{ original: string, suggested: string, rationale: string }>
+     */
+    protected function rewriteList( mixed $raw ): array
+    {
+        if ( ! is_array( $raw ) ) {
+            return [];
+        }
+
+        $out = [];
+
+        foreach ( $raw as $row ) {
+            if ( ! is_array( $row ) ) {
+                continue;
+            }
+
+            $original  = isset( $row['original'] ) ? trim( (string) $row['original'] ) : '';
+            $suggested = isset( $row['suggested'] ) ? trim( (string) $row['suggested'] ) : '';
+
+            if ( '' === $original || '' === $suggested ) {
+                continue;
+            }
+
+            $out[] = [
+                'original'  => $original,
+                'suggested' => $suggested,
+                'rationale' => isset( $row['rationale'] ) ? trim( (string) $row['rationale'] ) : '',
+            ];
+        }
+
+        return $out;
+    }
+}

--- a/src/Http/Controllers/Api/AiAgentApiController.php
+++ b/src/Http/Controllers/Api/AiAgentApiController.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * AiAgentApiController.
+ *
+ * Single dispatch endpoint pair for the performance package's AI agents.
+ * React and Vue frontends POST here with a validated payload; the controller
+ * resolves the registered agent, runs it, and returns the structured output.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Http\Controllers\Api;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\Performance\Ai\Agents\OptimizationSuggestionAgent;
+use ArtisanPackUI\Performance\Ai\Agents\PerformanceInsightAgent;
+use ArtisanPackUI\Performance\Http\Requests\Api\Ai\OptimizationSuggestionAiRequest;
+use ArtisanPackUI\Performance\Http\Requests\Api\Ai\QueryInsightAiRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Gate;
+use Throwable;
+
+/**
+ * Handles API requests for the performance package's AI agents.
+ *
+ * The controller holds a static feature → agent map instead of reflecting
+ * through the registry so a caller cannot execute an arbitrary agent class
+ * by naming it in a request body.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.1.0
+ */
+class AiAgentApiController extends Controller
+{
+    /**
+     * Feature-key → agent-class map for this package.
+     *
+     * @since 1.1.0
+     *
+     * @var array<string, class-string>
+     */
+    protected const AGENTS = [
+        'performance.query_insight'           => PerformanceInsightAgent::class,
+        'performance.optimization_suggestion' => OptimizationSuggestionAgent::class,
+    ];
+
+    /**
+     * Explain why a query is slow.
+     *
+     * @since 1.1.0
+     */
+    public function queryInsight( QueryInsightAiRequest $request ): JsonResponse
+    {
+        return $this->dispatchAgent( 'performance.query_insight', $request->validated() );
+    }
+
+    /**
+     * Suggest portfolio-level optimizations from a metrics batch.
+     *
+     * @since 1.1.0
+     */
+    public function optimizationSuggestion( OptimizationSuggestionAiRequest $request ): JsonResponse
+    {
+        return $this->dispatchAgent( 'performance.optimization_suggestion', $request->validated() );
+    }
+
+    /**
+     * Run the agent associated with `$featureKey` against `$input`.
+     *
+     * The registry-toggle short-circuit returns a 409 with the feature key so
+     * frontends can render a "This feature is disabled" state without needing
+     * to parse the exception message. Missing credentials return 412; validation
+     * failures inside the agent return 422; anything else is a 500.
+     *
+     * @since 1.1.0
+     *
+     * @param  string                $featureKey  Fully-qualified feature key.
+     * @param  array<string, mixed>  $input       Validated request payload.
+     *
+     * @return JsonResponse
+     */
+    protected function dispatchAgent( string $featureKey, array $input ): JsonResponse
+    {
+        if ( ! isset( self::AGENTS[ $featureKey ] ) ) {
+            return response()->json( [
+                'message' => __( 'Unknown AI feature.' ),
+            ], 404 );
+        }
+
+        // Belt-and-braces authorization: the route middleware already
+        // requires an authenticated caller, but the `performance.ai.use`
+        // Gate is what quota / role policies hook into. Runs on every
+        // dispatch even if a host removes auth middleware.
+        if ( ! Gate::allows( 'performance.ai.use' ) ) {
+            return response()->json( [
+                'message'     => __( 'You are not permitted to use this AI feature.' ),
+                'feature_key' => $featureKey,
+            ], 403 );
+        }
+
+        $registry = app( FeatureRegistry::class );
+
+        if ( null !== $registry->get( $featureKey ) && ! $registry->isToggleOn( $featureKey ) ) {
+            return response()->json( [
+                'message'     => __( 'This AI feature is disabled.' ),
+                'feature_key' => $featureKey,
+            ], 409 );
+        }
+
+        $agentClass = self::AGENTS[ $featureKey ];
+
+        try {
+            $output = $agentClass::for( $input )->run();
+        } catch ( FeatureDisabledException $exception ) {
+            return response()->json( [
+                'message'     => $exception->getMessage(),
+                'feature_key' => $featureKey,
+            ], 409 );
+        } catch ( MissingCredentialsException $exception ) {
+            return response()->json( [
+                'message'     => $exception->getMessage(),
+                'feature_key' => $featureKey,
+            ], 412 );
+        } catch ( FeatureError $exception ) {
+            return response()->json( [
+                'message'     => $exception->getMessage(),
+                'feature_key' => $featureKey,
+            ], 422 );
+        } catch ( Throwable $exception ) {
+            // The generic 500 hides provider errors, DB failures, and
+            // upstream laravel/ai bugs behind the same message, so ops
+            // needs the trace in the log to tell them apart.
+            report( $exception );
+
+            return response()->json( [
+                'message'     => __( 'AI agent failed to run.' ),
+                'feature_key' => $featureKey,
+            ], 500 );
+        }
+
+        return response()->json( [
+            'data'        => $output,
+            'feature_key' => $featureKey,
+        ] );
+    }
+}

--- a/src/Http/Requests/Api/Ai/OptimizationSuggestionAiRequest.php
+++ b/src/Http/Requests/Api/Ai/OptimizationSuggestionAiRequest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Form request for the optimization suggestion AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Http\Requests\Api\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates the JSON payload submitted to the optimization-suggestion endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.1.0
+ */
+class OptimizationSuggestionAiRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @since 1.1.0
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @since 1.1.0
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'range'                       => [ 'required', 'array' ],
+            'range.from'                  => [ 'required', 'string', 'date' ],
+            'range.to'                    => [ 'required', 'string', 'date', 'after_or_equal:range.from' ],
+            'metrics'                     => [ 'required', 'array', 'max:1000' ],
+            'metrics.*'                   => [ 'array' ],
+            'context'                     => [ 'nullable', 'array' ],
+            'context.traffic_mix'         => [ 'nullable', 'string', 'max:255' ],
+            'context.recent_changes'      => [ 'nullable', 'string', 'max:2000' ],
+            'context.business_priority'   => [ 'nullable', 'string', 'max:255' ],
+        ];
+    }
+}

--- a/src/Http/Requests/Api/Ai/QueryInsightAiRequest.php
+++ b/src/Http/Requests/Api/Ai/QueryInsightAiRequest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Form request for the query insight AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Http\Requests\Api\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates the JSON payload submitted to the query-insight endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.1.0
+ */
+class QueryInsightAiRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * The endpoint is already gated by the route middleware stack; this
+     * request-level check exists so overrides in host apps have a hook.
+     *
+     * @since 1.1.0
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @since 1.1.0
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'query'      => [ 'required', 'string', 'max:16000' ],
+            'explain'    => [ 'nullable' ],
+            'schema'     => [ 'nullable' ],
+            'time_ms'    => [ 'nullable', 'numeric', 'min:0' ],
+            'connection' => [ 'nullable', 'string', 'max:64' ],
+        ];
+    }
+}

--- a/src/Livewire/Ai/OptimizationSuggestionPanel.php
+++ b/src/Livewire/Ai/OptimizationSuggestionPanel.php
@@ -1,0 +1,266 @@
+<?php
+
+/**
+ * OptimizationSuggestionPanel Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\Performance\Ai\Agents\OptimizationSuggestionAgent;
+use ArtisanPackUI\Performance\Models\PerformanceMetric;
+use Illuminate\Support\Carbon;
+use Illuminate\View\View;
+use Livewire\Attributes\On;
+use Livewire\Attributes\Validate;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Trigger UI for the {@see OptimizationSuggestionAgent}.
+ *
+ * Pulls aggregate metrics for a rolling date window straight from the
+ * `performance_metrics` table so the panel works out of the box without
+ * a parent component threading the payload in. Emits
+ * `performance-ai-optimization-generated` (payload: the full agent
+ * output) so a containing dashboard can archive or forward it.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.1.0
+ */
+class OptimizationSuggestionPanel extends Component
+{
+    /**
+     * Maximum rolling-window length the panel accepts.
+     *
+     * Livewire public properties are client-mutable, so an unbounded
+     * `$windowDays` would let any authenticated caller ask for centuries
+     * of aggregate rows and OOM the worker. The cap has to be far enough
+     * out to be useful (quarter-over-quarter regression triage) but well
+     * short of the row counts a real install accumulates.
+     *
+     * @since 1.1.0
+     */
+    protected const MAX_WINDOW_DAYS = 90;
+
+    /**
+     * Hard cap on aggregate rows fed to the agent per run.
+     *
+     * Beyond a few thousand rows the JSON prompt is both slow to build
+     * and larger than most providers will accept — the cap keeps the
+     * request bounded even when the aggregates table has grown very
+     * large. Rows are ordered by `sample_count DESC` so the most
+     * representative rows survive the cut.
+     *
+     * @since 1.1.0
+     */
+    protected const MAX_METRICS_ROWS = 2000;
+
+    /**
+     * Rolling window in days.
+     *
+     * @since 1.1.0
+     *
+     * @var int
+     */
+    #[Validate( 'integer|min:1|max:90' )]
+    public int $windowDays = 7;
+
+    /**
+     * Optional business priority hint passed straight to the agent's
+     * `context.business_priority` field.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    public string $businessPriority = '';
+
+    /**
+     * Optional recent-changes hint passed straight to the agent's
+     * `context.recent_changes` field.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    public string $recentChanges = '';
+
+    public bool $isLoading = false;
+
+    public ?string $error = null;
+
+    /**
+     * Last successful agent output, or `null` before the first successful run.
+     *
+     * @since 1.1.0
+     *
+     * @var array<string, mixed>|null
+     */
+    public ?array $suggestion = null;
+
+    /**
+     * React to a parent dashboard nudging the panel with fresh context.
+     *
+     * @since 1.1.0
+     *
+     * @param  array{ window_days?: int, business_priority?: string, recent_changes?: string }  $payload  New context.
+     *
+     * @return void
+     */
+    #[On( 'performance-ai-context-updated' )]
+    public function contextUpdated( array $payload ): void
+    {
+        if ( isset( $payload['window_days'] ) && is_int( $payload['window_days'] ) && $payload['window_days'] > 0 ) {
+            $this->windowDays = min( $payload['window_days'], self::MAX_WINDOW_DAYS );
+        }
+
+        if ( isset( $payload['business_priority'] ) ) {
+            $this->businessPriority = (string) $payload['business_priority'];
+        }
+
+        if ( isset( $payload['recent_changes'] ) ) {
+            $this->recentChanges = (string) $payload['recent_changes'];
+        }
+    }
+
+    /**
+     * Run the agent against the last `$windowDays` days of metrics.
+     *
+     * @since 1.1.0
+     *
+     * @return void
+     */
+    public function suggest(): void
+    {
+        $this->error      = null;
+        $this->suggestion = null;
+        $this->isLoading  = true;
+
+        // Second line of defence after the `#[Validate]` attribute — the
+        // #[On] listener and any client-side mutation could still push a
+        // value outside the accepted range before suggest() fires.
+        $windowDays = max( 1, min( $this->windowDays, self::MAX_WINDOW_DAYS ) );
+
+        try {
+            $from = Carbon::now()->subDays( $windowDays - 1 )->startOfDay();
+            $to   = Carbon::now()->endOfDay();
+
+            $metrics = $this->collectMetrics( $from, $to );
+
+            $context = array_filter( [
+                'business_priority' => trim( $this->businessPriority ),
+                'recent_changes'    => trim( $this->recentChanges ),
+            ], static fn ( string $value ): bool => '' !== $value );
+
+            $this->suggestion = OptimizationSuggestionAgent::for( [
+                'range'   => [
+                    'from' => $from->toDateString(),
+                    'to'   => $to->toDateString(),
+                ],
+                'metrics' => $metrics,
+                'context' => $context,
+            ] )->run();
+
+            $this->dispatch( 'performance-ai-optimization-generated', suggestion: $this->suggestion );
+        } catch ( FeatureDisabledException $exception ) {
+            $this->error = __( 'This AI feature is disabled.' );
+        } catch ( MissingCredentialsException $exception ) {
+            $this->error = __( 'AI credentials are not configured.' );
+        } catch ( FeatureError $exception ) {
+            $this->error = $exception->getMessage();
+        } catch ( Throwable $exception ) {
+            $this->error = __( 'The AI agent could not complete this request.' );
+        } finally {
+            $this->isLoading = false;
+        }
+    }
+
+    /**
+     * Determine whether this feature is enabled in the registry.
+     *
+     * @since 1.1.0
+     *
+     * @return bool
+     */
+    public function getIsEnabledProperty(): bool
+    {
+        $registry = app( FeatureRegistry::class );
+        $key      = 'performance.optimization_suggestion';
+
+        if ( null === $registry->get( $key ) ) {
+            return false;
+        }
+
+        return $registry->isToggleOn( $key );
+    }
+
+    /**
+     * Render the component view.
+     *
+     * @since 1.1.0
+     *
+     * @return View
+     */
+    public function render(): View
+    {
+        return view( 'performance::livewire.ai.optimization-suggestion-panel' );
+    }
+
+    /**
+     * Collect aggregate metrics for the current window.
+     *
+     * Kept as a hook so a subclass or a host app that stores metrics
+     * elsewhere (Prometheus, Datadog, a data warehouse) can override
+     * without reimplementing the surrounding component.
+     *
+     * @since 1.1.0
+     *
+     * @param  Carbon  $from  Range start (inclusive).
+     * @param  Carbon  $to    Range end (inclusive).
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function collectMetrics( Carbon $from, Carbon $to ): array
+    {
+        // toBase() skips Eloquent model hydration + `retrieved` events on
+        // what can easily be tens of thousands of aggregate rows on a
+        // busy install. The limit is a load-safety cap, not a semantic
+        // one — hitting it means the prompt would have been too big for
+        // the model anyway.
+        return PerformanceMetric::query()
+            ->whereBetween( 'date', [ $from->toDateString(), $to->toDateString() ] )
+            ->orderByDesc( 'sample_count' )
+            ->orderBy( 'date' )
+            ->orderBy( 'route' )
+            ->limit( self::MAX_METRICS_ROWS )
+            ->toBase()
+            ->get( [ 'date', 'route', 'metric', 'p50', 'p75', 'p90', 'p99', 'sample_count', 'device_type' ] )
+            ->map( static fn ( object $row ): array => [
+                'date'    => (string) $row->date,
+                'route'   => $row->route,
+                'metric'  => $row->metric,
+                'p50'     => (float) $row->p50,
+                'p75'     => (float) $row->p75,
+                'p90'     => (float) $row->p90,
+                'p99'     => (float) $row->p99,
+                'samples' => (int) $row->sample_count,
+                'device'  => $row->device_type,
+            ] )
+            ->all();
+    }
+}

--- a/src/Livewire/Ai/QueryInsightPanel.php
+++ b/src/Livewire/Ai/QueryInsightPanel.php
@@ -1,0 +1,220 @@
+<?php
+
+/**
+ * QueryInsightPanel Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Performance\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\Performance\Ai\Agents\PerformanceInsightAgent;
+use Illuminate\View\View;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Trigger UI for the {@see PerformanceInsightAgent}.
+ *
+ * Renders a form for a query + optional EXPLAIN plan + schema hint, then
+ * displays the returned diagnosis. Emits `performance-ai-insight-generated`
+ * (payload: the full agent output) when a suggestion is produced so a
+ * containing dashboard can archive or forward it.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.1.0
+ */
+class QueryInsightPanel extends Component
+{
+    public string $query = '';
+
+    public string $explain = '';
+
+    public string $schema = '';
+
+    public string $connection = '';
+
+    public ?float $timeMs = null;
+
+    public bool $isLoading = false;
+
+    public ?string $error = null;
+
+    /**
+     * Last successful agent output, or `null` before the first successful run.
+     *
+     * @since 1.1.0
+     *
+     * @var array<string, mixed>|null
+     */
+    public ?array $insight = null;
+
+    /**
+     * Mount the component with an optional pre-selected slow query.
+     *
+     * @since 1.1.0
+     *
+     * @param  string      $query       SQL text.
+     * @param  string      $explain     Raw EXPLAIN plan text.
+     * @param  string      $schema      Relevant schema snippet.
+     * @param  string      $connection  DB connection driver.
+     * @param  float|null  $timeMs      Observed duration in milliseconds.
+     */
+    public function mount(
+        string $query = '',
+        string $explain = '',
+        string $schema = '',
+        string $connection = '',
+        ?float $timeMs = null,
+    ): void {
+        $this->query      = $query;
+        $this->explain    = $explain;
+        $this->schema     = $schema;
+        $this->connection = $connection;
+        $this->timeMs     = $timeMs;
+    }
+
+    /**
+     * Load a slow query into the panel from a sibling component (typically
+     * the {@see \ArtisanPackUI\Performance\Livewire\QueryAnalyzer}).
+     *
+     * @since 1.1.0
+     *
+     * @param  array{ query?: string, explain?: string, schema?: string, connection?: string, time_ms?: float|int }  $payload  New context.
+     *
+     * @return void
+     */
+    #[On( 'performance-ai-query-selected' )]
+    public function querySelected( array $payload ): void
+    {
+        if ( isset( $payload['query'] ) ) {
+            $this->query = (string) $payload['query'];
+        }
+
+        if ( isset( $payload['explain'] ) ) {
+            $this->explain = (string) $payload['explain'];
+        }
+
+        if ( isset( $payload['schema'] ) ) {
+            $this->schema = (string) $payload['schema'];
+        }
+
+        if ( isset( $payload['connection'] ) ) {
+            $this->connection = (string) $payload['connection'];
+        }
+
+        if ( isset( $payload['time_ms'] ) && ( is_int( $payload['time_ms'] ) || is_float( $payload['time_ms'] ) ) ) {
+            $this->timeMs = (float) $payload['time_ms'];
+        }
+    }
+
+    /**
+     * Run the agent and populate `$insight` or `$error`.
+     *
+     * @since 1.1.0
+     *
+     * @return void
+     */
+    public function analyze(): void
+    {
+        $this->error     = null;
+        $this->insight   = null;
+        $this->isLoading = true;
+
+        try {
+            $input = [
+                'query'      => $this->query,
+                'explain'    => '' === trim( $this->explain ) ? null : $this->explain,
+                'schema'     => $this->parseSchema( $this->schema ),
+                'time_ms'    => $this->timeMs,
+                'connection' => '' === trim( $this->connection ) ? null : $this->connection,
+            ];
+
+            $this->insight = PerformanceInsightAgent::for( $input )->run();
+
+            $this->dispatch( 'performance-ai-insight-generated', insight: $this->insight );
+        } catch ( FeatureDisabledException $exception ) {
+            $this->error = __( 'This AI feature is disabled.' );
+        } catch ( MissingCredentialsException $exception ) {
+            $this->error = __( 'AI credentials are not configured.' );
+        } catch ( FeatureError $exception ) {
+            $this->error = $exception->getMessage();
+        } catch ( Throwable $exception ) {
+            $this->error = __( 'The AI agent could not complete this request.' );
+        } finally {
+            $this->isLoading = false;
+        }
+    }
+
+    /**
+     * Determine whether this feature is enabled in the registry.
+     *
+     * @since 1.1.0
+     *
+     * @return bool
+     */
+    public function getIsEnabledProperty(): bool
+    {
+        $registry = app( FeatureRegistry::class );
+        $key      = 'performance.query_insight';
+
+        if ( null === $registry->get( $key ) ) {
+            return false;
+        }
+
+        return $registry->isToggleOn( $key );
+    }
+
+    /**
+     * Render the component view.
+     *
+     * @since 1.1.0
+     *
+     * @return View
+     */
+    public function render(): View
+    {
+        return view( 'performance::livewire.ai.query-insight-panel' );
+    }
+
+    /**
+     * Attempt to decode the raw schema textarea as JSON, falling back to
+     * passing the raw string through when it is not valid JSON.
+     *
+     * @since 1.1.0
+     *
+     * @param  string  $raw  Raw schema text.
+     *
+     * @return array<mixed>|string|null
+     */
+    protected function parseSchema( string $raw ): array|string|null
+    {
+        $trimmed = trim( $raw );
+
+        if ( '' === $trimmed ) {
+            return null;
+        }
+
+        $decoded = json_decode( $trimmed, true );
+
+        if ( is_array( $decoded ) ) {
+            return $decoded;
+        }
+
+        return $trimmed;
+    }
+}

--- a/src/PerformanceServiceProvider.php
+++ b/src/PerformanceServiceProvider.php
@@ -18,6 +18,8 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Performance;
 
+use ArtisanPackUI\Performance\Ai\Agents\OptimizationSuggestionAgent;
+use ArtisanPackUI\Performance\Ai\Agents\PerformanceInsightAgent;
 use ArtisanPackUI\Performance\Cache\CacheInvalidator;
 use ArtisanPackUI\Performance\Cache\CacheStatistics;
 use ArtisanPackUI\Performance\Cache\CacheStrategyManager;
@@ -41,6 +43,8 @@ use ArtisanPackUI\Performance\Images\DominantColorExtractor;
 use ArtisanPackUI\Performance\Images\ResponsiveImageGenerator;
 use ArtisanPackUI\Performance\JavaScript\ScriptManager;
 use ArtisanPackUI\Performance\Listeners\OptimizeUploadedMedia;
+use ArtisanPackUI\Performance\Livewire\Ai\OptimizationSuggestionPanel as OptimizationSuggestionPanelComponent;
+use ArtisanPackUI\Performance\Livewire\Ai\QueryInsightPanel as QueryInsightPanelComponent;
 use ArtisanPackUI\Performance\Livewire\CacheManager as CacheManagerComponent;
 use ArtisanPackUI\Performance\Livewire\MetricsChart as MetricsChartComponent;
 use ArtisanPackUI\Performance\Livewire\PerformanceDashboard as PerformanceDashboardComponent;
@@ -256,8 +260,39 @@ class PerformanceServiceProvider extends ServiceProvider
         $this->registerMediaLibraryIntegration();
         $this->registerOctaneResetHooks();
         $this->registerCommands();
+        $this->registerAiGate();
         $this->registerRoutes();
         $this->publishConfiguration();
+    }
+
+    /**
+     * Declare AI features owned by this package.
+     *
+     * Auto-discovered by artisanpack-ui/ai when the ai package is installed.
+     * Each entry maps a fully-qualified feature key to the agent class that
+     * fulfills it, along with a human-readable label and description for the
+     * admin UI.
+     *
+     * @since 1.1.0
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function aiFeatures(): array
+    {
+        return [
+            'performance.query_insight'          => [
+                'agent'       => PerformanceInsightAgent::class,
+                'package'     => 'artisanpack-ui/performance',
+                'label'       => __( 'Query insight' ),
+                'description' => __( 'Explain why a slow query is slow and suggest indexes or rewrites.' ),
+            ],
+            'performance.optimization_suggestion' => [
+                'agent'       => OptimizationSuggestionAgent::class,
+                'package'     => 'artisanpack-ui/performance',
+                'label'       => __( 'Optimization suggestions' ),
+                'description' => __( 'Look at aggregate performance metrics and recommend where to focus optimization work.' ),
+            ],
+        ];
     }
 
     /**
@@ -464,6 +499,8 @@ class PerformanceServiceProvider extends ServiceProvider
         \Livewire\Livewire::component( 'perf-cache-manager', CacheManagerComponent::class );
         \Livewire\Livewire::component( 'perf-query-analyzer', QueryAnalyzerComponent::class );
         \Livewire\Livewire::component( 'perf-recommendations-panel', RecommendationsPanelComponent::class );
+        \Livewire\Livewire::component( 'perf-ai-query-insight-panel', QueryInsightPanelComponent::class );
+        \Livewire\Livewire::component( 'perf-ai-optimization-suggestion-panel', OptimizationSuggestionPanelComponent::class );
     }
 
     /**
@@ -508,15 +545,65 @@ class PerformanceServiceProvider extends ServiceProvider
 
         $adminMiddleware[] = 'throttle:' . $throttle;
 
+        // AI route group rides a separate middleware stack. These
+        // endpoints dispatch to paid LLM providers so the shipped
+        // default gates them behind Sanctum plus a `performance.ai.use`
+        // Gate — sharing the stateless public middleware used by the
+        // metrics ingest would let anonymous callers drain provider
+        // credit. Hosts running a different guard can override the
+        // stack; the Gate check inside the controller still fires.
+        $aiMiddleware = (array) config(
+            'artisanpack.performance.routes.ai_middleware',
+            [ 'api', 'auth:sanctum' ],
+        );
+
+        $aiMiddleware[] = 'throttle:' . $throttle;
+
         Route::middleware( $adminMiddleware )
             ->prefix( $prefix )
             ->name( 'artisanpack.performance.api.admin.' )
             ->group( __DIR__ . '/../routes/api-admin.php' );
 
+        Route::middleware( $aiMiddleware )
+            ->prefix( $prefix )
+            ->name( 'artisanpack.performance.api.' )
+            ->group( __DIR__ . '/../routes/api-ai.php' );
+
         Route::middleware( $middleware )
             ->prefix( $prefix )
             ->name( 'artisanpack.performance.api.' )
             ->group( __DIR__ . '/../routes/api.php' );
+    }
+
+    /**
+     * Register the default `performance.ai.use` authorization gate.
+     *
+     * The AI API endpoints (`/api/performance/ai/*`) gate on this
+     * ability so that paid quota isn't spent by every authenticated
+     * user. Ships with a permissive default (any authenticated user can
+     * use AI features) so upgrades are non-breaking; installers should
+     * override this gate in their own `AuthServiceProvider` to enforce
+     * a stricter policy — limit to admins, apply per-tenant quotas, etc.
+     *
+     * @since 1.1.0
+     */
+    protected function registerAiGate(): void
+    {
+        $gate = \Illuminate\Support\Facades\Gate::getFacadeRoot();
+
+        // Guard so an installer who registered their own `performance.ai.use`
+        // before our boot() (via a plugin, package-first AuthServiceProvider,
+        // etc.) is not silently overwritten by the permissive default.
+        if ( method_exists( $gate, 'has' ) && $gate->has( 'performance.ai.use' ) ) {
+            return;
+        }
+
+        \Illuminate\Support\Facades\Gate::define(
+            'performance.ai.use',
+            static function ( $user = null ): bool {
+                return null !== $user;
+            },
+        );
     }
 
     /**

--- a/tests/Feature/Ai/AiAgentApiControllerTest.php
+++ b/tests/Feature/Ai/AiAgentApiControllerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Support\Facades\Gate;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns a shaped query insight response', function (): void {
+    $this->prompter->queue( [
+        'summary'           => 'Full scan.',
+        'bottlenecks'       => [ 'Missing index' ],
+        'suggested_indexes' => [
+            [ 'table' => 'articles', 'columns' => [ 'slug' ], 'rationale' => 'covers WHERE' ],
+        ],
+        'rewrites'          => [],
+        'caveats'           => [],
+    ] );
+
+    $response = $this->postJson( '/api/performance/ai/query-insight', [
+        'query'   => 'SELECT * FROM articles WHERE slug = ?',
+        'time_ms' => 210,
+    ] );
+
+    $response
+        ->assertOk()
+        ->assertJsonPath( 'feature_key', 'performance.query_insight' )
+        ->assertJsonPath( 'data.summary', 'Full scan.' )
+        ->assertJsonPath( 'data.suggested_indexes.0.table', 'articles' );
+} );
+
+it( 'validates the query field on query-insight', function (): void {
+    $response = $this->postJson( '/api/performance/ai/query-insight', [] );
+
+    $response->assertStatus( 422 );
+} );
+
+it( 'returns 403 when the performance.ai.use gate denies', function (): void {
+    Gate::define( 'performance.ai.use', static fn ( $user = null ): bool => false );
+
+    $response = $this->postJson( '/api/performance/ai/query-insight', [
+        'query' => 'SELECT 1',
+    ] );
+
+    $response
+        ->assertStatus( 403 )
+        ->assertJsonPath( 'feature_key', 'performance.query_insight' );
+} );
+
+it( 'returns 409 when the query insight feature is disabled', function (): void {
+    // The feature key literally contains a dot, so Config::set with dot-
+    // notation would write to the wrong path. Set the whole `features`
+    // array to keep the key intact.
+    $features                              = $this->app['config']->get( 'artisanpack.ai.features', [] );
+    $features['performance.query_insight'] = [ 'enabled' => false ];
+    $this->app['config']->set( 'artisanpack.ai.features', $features );
+
+    $response = $this->postJson( '/api/performance/ai/query-insight', [
+        'query' => 'SELECT 1',
+    ] );
+
+    $response
+        ->assertStatus( 409 )
+        ->assertJsonPath( 'feature_key', 'performance.query_insight' );
+} );
+
+it( 'returns a shaped optimization suggestion response', function (): void {
+    $this->prompter->queue( [
+        'summary'     => 'Focus on articles.',
+        'focus_areas' => [
+            [
+                'title'     => 'Article LCP',
+                'routes'    => [ 'GET /articles/{slug}' ],
+                'impact'    => 'high',
+                'effort'    => 'medium',
+                'rationale' => 'p75 regressed',
+                'actions'   => [ 'Preload hero image' ],
+            ],
+        ],
+        'quick_wins'  => [],
+        'caveats'     => [],
+    ] );
+
+    $response = $this->postJson( '/api/performance/ai/optimization-suggestion', [
+        'range'   => [ 'from' => '2026-07-01', 'to' => '2026-07-07' ],
+        'metrics' => [
+            [ 'metric' => 'lcp', 'route' => 'GET /articles/{slug}', 'p75' => 4600 ],
+        ],
+    ] );
+
+    $response
+        ->assertOk()
+        ->assertJsonPath( 'feature_key', 'performance.optimization_suggestion' )
+        ->assertJsonPath( 'data.focus_areas.0.impact', 'high' );
+} );
+
+it( 'validates optimization-suggestion payload', function (): void {
+    $response = $this->postJson( '/api/performance/ai/optimization-suggestion', [
+        'range' => [ 'from' => '2026-07-05', 'to' => '2026-07-01' ],
+    ] );
+
+    $response->assertStatus( 422 );
+} );

--- a/tests/Feature/Ai/AiAgentTestSetup.php
+++ b/tests/Feature/Ai/AiAgentTestSetup.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Shared setup helpers for performance AI agent tests.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Contracts\CredentialResolver;
+use ArtisanPackUI\Ai\Credentials\ChainedCredentialResolver;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use Illuminate\Support\Facades\Gate;
+use Tests\Support\FakeAgentPrompter;
+
+/**
+ * Registers a fake prompter and stub credentials for both performance features.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.1.0
+ */
+class AiAgentTestSetup
+{
+    /**
+     * Prepare the container so agents can run against a fake prompter.
+     *
+     * @since 1.1.0
+     *
+     * @param  \Illuminate\Foundation\Application  $app  Application instance.
+     *
+     * @return FakeAgentPrompter The bound fake prompter.
+     */
+    public static function bootstrap( $app ): FakeAgentPrompter
+    {
+        /** @var ChainedCredentialResolver $resolver */
+        $resolver = $app->make( CredentialResolver::class );
+        $resolver->setOverride(
+            new Credentials( provider: 'anthropic', apiKey: 'sk-test', defaultModel: 'claude-sonnet-4-6' ),
+        );
+        $resolver->useStore( fn () => null );
+
+        $prompter = new FakeAgentPrompter();
+        $app->instance( AgentPrompter::class, $prompter );
+
+        foreach (
+            [
+                'performance.query_insight',
+                'performance.optimization_suggestion',
+            ] as $key
+        ) {
+            $app['config']->set( "artisanpack.ai.features.{$key}.enabled", true );
+        }
+
+        // Allow the shipped `performance.ai.use` Gate by default so the
+        // happy-path controller tests don't need to construct an Eloquent
+        // User. Tests that want to exercise the 403 path override this
+        // Gate back to `false` before calling the endpoint.
+        Gate::define( 'performance.ai.use', static fn ( $user = null ): bool => true );
+
+        return $prompter;
+    }
+}

--- a/tests/Feature/Ai/OptimizationSuggestionAgentTest.php
+++ b/tests/Feature/Ai/OptimizationSuggestionAgentTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Performance\Ai\Agents\OptimizationSuggestionAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns the shaped suggestion when the prompter responds', function (): void {
+    $this->prompter->queue( [
+        'summary'     => 'Article routes regressed after Vite switch.',
+        'focus_areas' => [
+            [
+                'title'     => 'Article LCP',
+                'routes'    => [ 'GET /articles/{slug}' ],
+                'impact'    => 'high',
+                'effort'    => 'medium',
+                'rationale' => 'p75 LCP jumped from 2.1s to 4.6s',
+                'actions'   => [ 'Preload the hero image', 'Move the ad-slot script to defer' ],
+            ],
+        ],
+        'quick_wins'  => [ 'Enable Brotli on the CDN' ],
+        'caveats'     => [ 'no device breakdown in the metrics' ],
+    ] );
+
+    $result = OptimizationSuggestionAgent::for( [
+        'range'   => [ 'from' => '2026-07-01', 'to' => '2026-07-07' ],
+        'metrics' => [
+            [ 'metric' => 'lcp', 'route' => 'GET /articles/{slug}', 'p75' => 4600, 'samples' => 300 ],
+        ],
+    ] )->run();
+
+    expect( $result['summary'] )->toContain( 'Article' );
+    expect( $result['focus_areas'] )->toHaveCount( 1 );
+    expect( $result['focus_areas'][0]['impact'] )->toBe( 'high' );
+    expect( $result['focus_areas'][0]['effort'] )->toBe( 'medium' );
+    expect( $result['focus_areas'][0]['actions'] )->toHaveCount( 2 );
+    expect( $result['quick_wins'] )->toContain( 'Enable Brotli on the CDN' );
+} );
+
+it( 'short-circuits when metrics list is empty', function (): void {
+    $result = OptimizationSuggestionAgent::for( [
+        'range'   => [ 'from' => '2026-07-01', 'to' => '2026-07-07' ],
+        'metrics' => [],
+    ] )->run();
+
+    expect( $result['summary'] )->toContain( 'No metrics' );
+    expect( $result['focus_areas'] )->toBe( [] );
+    expect( $this->prompter->calls )->toBe( [] );
+} );
+
+it( 'clamps unknown impact/effort levels to medium', function (): void {
+    $this->prompter->queue( [
+        'summary'     => 'ok',
+        'focus_areas' => [
+            [
+                'title'     => 'DB pressure',
+                'routes'    => [ 'GET /home' ],
+                'impact'    => 'catastrophic',
+                'effort'    => 42,
+                'rationale' => 'r',
+                'actions'   => [],
+            ],
+        ],
+        'quick_wins'  => [],
+        'caveats'     => [],
+    ] );
+
+    $result = OptimizationSuggestionAgent::for( [
+        'range'   => [ 'from' => '2026-07-01', 'to' => '2026-07-07' ],
+        'metrics' => [ [ 'metric' => 'lcp', 'route' => 'GET /home', 'p75' => 3000 ] ],
+    ] )->run();
+
+    expect( $result['focus_areas'][0]['impact'] )->toBe( 'medium' );
+    expect( $result['focus_areas'][0]['effort'] )->toBe( 'medium' );
+} );
+
+it( 'drops focus areas without a title', function (): void {
+    $this->prompter->queue( [
+        'summary'     => 'ok',
+        'focus_areas' => [
+            [ 'title' => '', 'routes' => [], 'impact' => 'high', 'effort' => 'low', 'rationale' => '', 'actions' => [] ],
+            [ 'title' => 'Keep me', 'routes' => [], 'impact' => 'low', 'effort' => 'low', 'rationale' => '', 'actions' => [] ],
+        ],
+        'quick_wins'  => [],
+        'caveats'     => [],
+    ] );
+
+    $result = OptimizationSuggestionAgent::for( [
+        'range'   => [ 'from' => '2026-07-01', 'to' => '2026-07-07' ],
+        'metrics' => [ [ 'metric' => 'lcp', 'route' => 'GET /home', 'p75' => 3000 ] ],
+    ] )->run();
+
+    expect( $result['focus_areas'] )->toHaveCount( 1 );
+    expect( $result['focus_areas'][0]['title'] )->toBe( 'Keep me' );
+} );
+
+it( 'raises FeatureError when range is missing', function (): void {
+    expect( fn () => OptimizationSuggestionAgent::for( [
+        'metrics' => [ [ 'metric' => 'lcp' ] ],
+    ] )->run() )->toThrow( FeatureError::class );
+} );
+
+it( 'raises FeatureError when metrics is missing', function (): void {
+    expect( fn () => OptimizationSuggestionAgent::for( [
+        'range' => [ 'from' => '2026-07-01', 'to' => '2026-07-07' ],
+    ] )->run() )->toThrow( FeatureError::class );
+} );
+
+it( 'forwards context into the prompter message', function (): void {
+    $this->prompter->queue( [
+        'summary'     => 'x',
+        'focus_areas' => [],
+        'quick_wins'  => [],
+        'caveats'     => [],
+    ] );
+
+    OptimizationSuggestionAgent::for( [
+        'range'   => [ 'from' => '2026-07-01', 'to' => '2026-07-07' ],
+        'metrics' => [ [ 'metric' => 'lcp', 'route' => 'GET /home', 'p75' => 3000 ] ],
+        'context' => [ 'business_priority' => 'checkout > blog' ],
+    ] )->run();
+
+    $call = $this->prompter->calls[0];
+    $flat = collect( $call['message'] )->pluck( 'text' )->implode( "\n" );
+
+    expect( $flat )->toContain( 'checkout > blog' );
+    expect( $flat )->toContain( '2026-07-01' );
+} );

--- a/tests/Feature/Ai/PerformanceInsightAgentTest.php
+++ b/tests/Feature/Ai/PerformanceInsightAgentTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Performance\Ai\Agents\PerformanceInsightAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns the shaped insight when the prompter responds', function (): void {
+    $this->prompter->queue( [
+        'summary'           => 'Full scan on articles because slug is not indexed.',
+        'bottlenecks'       => [ 'No index on articles.slug', 'Filesort for ORDER BY published_at' ],
+        'suggested_indexes' => [
+            [
+                'table'     => 'articles',
+                'columns'   => [ 'slug', 'published_at' ],
+                'rationale' => 'covers the WHERE and ORDER BY',
+            ],
+        ],
+        'rewrites'          => [
+            [
+                'original'  => 'SELECT *',
+                'suggested' => 'SELECT id, slug, published_at',
+                'rationale' => 'avoid dragging BLOBs into the sort',
+            ],
+        ],
+        'caveats'           => [ 'row counts unknown' ],
+    ] );
+
+    $result = PerformanceInsightAgent::for( [
+        'query'      => 'SELECT * FROM articles WHERE slug = ? ORDER BY published_at DESC',
+        'time_ms'    => 850.4,
+        'connection' => 'mysql',
+    ] )->run();
+
+    expect( $result['summary'] )->toContain( 'Full scan' );
+    expect( $result['bottlenecks'] )->toHaveCount( 2 );
+    expect( $result['suggested_indexes'][0]['table'] )->toBe( 'articles' );
+    expect( $result['suggested_indexes'][0]['columns'] )->toBe( [ 'slug', 'published_at' ] );
+    expect( $result['rewrites'][0]['original'] )->toBe( 'SELECT *' );
+    expect( $result['caveats'] )->toContain( 'row counts unknown' );
+} );
+
+it( 'drops malformed suggested_indexes rows', function (): void {
+    $this->prompter->queue( [
+        'summary'           => 'ok',
+        'bottlenecks'       => [],
+        'suggested_indexes' => [
+            [ 'table' => '', 'columns' => [ 'x' ], 'rationale' => 'skipped: empty table' ],
+            [ 'table' => 'foo', 'columns' => [], 'rationale' => 'skipped: empty columns' ],
+            [ 'table' => 'orders', 'columns' => [ 'user_id' ], 'rationale' => 'kept' ],
+            'not-an-array',
+        ],
+        'rewrites'          => [],
+        'caveats'           => [],
+    ] );
+
+    $result = PerformanceInsightAgent::for( [ 'query' => 'SELECT 1' ] )->run();
+
+    expect( $result['suggested_indexes'] )->toHaveCount( 1 );
+    expect( $result['suggested_indexes'][0]['table'] )->toBe( 'orders' );
+} );
+
+it( 'drops rewrites missing original or suggested', function (): void {
+    $this->prompter->queue( [
+        'summary'           => 'ok',
+        'bottlenecks'       => [],
+        'suggested_indexes' => [],
+        'rewrites'          => [
+            [ 'original' => '', 'suggested' => 'x', 'rationale' => 'skipped' ],
+            [ 'original' => 'x', 'suggested' => '', 'rationale' => 'skipped' ],
+            [ 'original' => 'a', 'suggested' => 'b', 'rationale' => 'kept' ],
+        ],
+        'caveats'           => [],
+    ] );
+
+    $result = PerformanceInsightAgent::for( [ 'query' => 'SELECT 1' ] )->run();
+
+    expect( $result['rewrites'] )->toHaveCount( 1 );
+    expect( $result['rewrites'][0]['original'] )->toBe( 'a' );
+} );
+
+it( 'raises FeatureError when query is missing', function (): void {
+    expect( fn () => PerformanceInsightAgent::for( [] )->run() )
+        ->toThrow( FeatureError::class );
+} );
+
+it( 'raises FeatureError when query is empty', function (): void {
+    expect( fn () => PerformanceInsightAgent::for( [ 'query' => '   ' ] )->run() )
+        ->toThrow( FeatureError::class );
+} );
+
+it( 'forwards explain and schema into the prompter message', function (): void {
+    $this->prompter->queue( [
+        'summary'           => 'x',
+        'bottlenecks'       => [],
+        'suggested_indexes' => [],
+        'rewrites'          => [],
+        'caveats'           => [],
+    ] );
+
+    PerformanceInsightAgent::for( [
+        'query'   => 'SELECT 1',
+        'explain' => [ [ 'type' => 'ALL', 'rows' => 10000 ] ],
+        'schema'  => [ 'users' => [ 'id' => 'bigint' ] ],
+    ] )->run();
+
+    $call    = $this->prompter->calls[0];
+    $flat    = collect( $call['message'] )->pluck( 'text' )->implode( "\n" );
+
+    expect( $flat )->toContain( 'EXPLAIN plan' );
+    expect( $flat )->toContain( 'Schema' );
+    expect( $flat )->toContain( 'SELECT 1' );
+} );

--- a/tests/Support/FakeAgentPrompter.php
+++ b/tests/Support/FakeAgentPrompter.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Test fake for the AgentPrompter contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace Tests\Support;
+
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+
+/**
+ * Records every prompter call and returns queued responses in order.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Performance
+ *
+ * @since      1.1.0
+ */
+final class FakeAgentPrompter implements AgentPrompter
+{
+    /**
+     * Recorded calls, in invocation order.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    public array $calls = [];
+
+    /**
+     * Queued responses (FIFO).
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    private array $queue = [];
+
+    /**
+     * Push a canned response onto the queue.
+     *
+     * @since 1.1.0
+     *
+     * @param  array<string, mixed>  $output        Structured output body.
+     * @param  int                   $inputTokens   Reported input tokens.
+     * @param  int                   $outputTokens  Reported output tokens.
+     *
+     * @return void
+     */
+    public function queue( array $output, int $inputTokens = 100, int $outputTokens = 50 ): void
+    {
+        $this->queue[] = [
+            'output'        => $output,
+            'input_tokens'  => $inputTokens,
+            'output_tokens' => $outputTokens,
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function prompt(
+        Credentials $credentials,
+        string $model,
+        string $instructions,
+        string|array $message,
+        array $outputSchema,
+    ): array {
+        $this->calls[] = [
+            'credentials'   => $credentials,
+            'model'         => $model,
+            'instructions'  => $instructions,
+            'message'       => $message,
+            'output_schema' => $outputSchema,
+        ];
+
+        if ( [] === $this->queue ) {
+            return [
+                'output'        => [],
+                'input_tokens'  => 0,
+                'output_tokens' => 0,
+            ];
+        }
+
+        return array_shift( $this->queue );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace Tests;
 
+use ArtisanPackUI\Ai\AiServiceProvider;
 use ArtisanPackUI\Performance\PerformanceServiceProvider;
 use Illuminate\Foundation\Application;
 use Livewire\LivewireServiceProvider;
@@ -39,6 +40,7 @@ abstract class TestCase extends BaseTestCase
     {
         return [
             LivewireServiceProvider::class,
+            AiServiceProvider::class,
             PerformanceServiceProvider::class,
         ];
     }
@@ -63,5 +65,13 @@ abstract class TestCase extends BaseTestCase
             'prefix'                  => '',
             'foreign_key_constraints' => true,
         ] );
+
+        // Testbench has no sanctum guard configured, so the shipped
+        // `['api', 'auth:sanctum']` default on the AI route group would
+        // blow up before any test could exercise the controller. Route
+        // middleware is bound at service-provider boot, so this has to
+        // land before boot — hence defineEnvironment rather than the
+        // per-test AiAgentTestSetup::bootstrap().
+        $app['config']->set( 'artisanpack.performance.routes.ai_middleware', [ 'api' ] );
     }
 }


### PR DESCRIPTION
## Description

Adds the two AI features owned by the performance package: a per-query insight agent (issue #95) that explains why a slow query is slow and suggests indexes/rewrites, and a portfolio-level optimization agent (issue #96) that reads aggregate metrics over a date range and recommends where to focus. Bundled together so React and Vue support ships in the package without touching `@artisanpack-ui/react` / `@artisanpack-ui/vue`.

**Closes:** #95, #96

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #95, #96

## Motivation and Context

Milestone 1.1 requires both agents to ship with Livewire, React, and Vue trigger UIs. Building all three frontends inside the performance package (rather than adding coupling to the shared UI packages) keeps the pivot to multi-framework support isolated to each domain package.

## Changes Made

**Agents (`src/Ai/Agents/`):**
- `PerformanceInsightAgent` — feature key `performance.query_insight`, `defaultModel` claude-sonnet-4-6, output includes `summary`, `bottlenecks`, `suggested_indexes`, `rewrites`, `caveats`. Suggests only — never emits DDL.
- `OptimizationSuggestionAgent` — feature key `performance.optimization_suggestion`, output includes `summary`, `focus_areas` (with impact/effort levels), `quick_wins`, `caveats`. Short-circuits when metrics list is empty.
- Both agents override `$cacheable = false` — outputs are point-in-time diagnostic snapshots.

**Livewire (`src/Livewire/Ai/` + `resources/views/livewire/ai/`):**
- `QueryInsightPanel` (`perf-ai-query-insight-panel`) with a `#[On('performance-ai-query-selected')]` listener for load-from-QueryAnalyzer flow.
- `OptimizationSuggestionPanel` (`perf-ai-optimization-suggestion-panel`) with `windowDays` capped at 90 via `#[Validate]` + `MAX_WINDOW_DAYS`, and `collectMetrics()` using `toBase()` with a `MAX_METRICS_ROWS = 2000` cap ordered by `sample_count DESC`.

**React + Vue (in-package, not exported through the shared UI packages):**
- `QueryInsightPanel` + `OptimizationSuggestionPanel` in both `resources/js/react/` and `resources/js/vue/`.
- New `PerformanceClient` methods `suggestQueryInsight` and `suggestOptimization`; a `PerformanceAiError` class; `postAi` guards against null/malformed 2xx bodies so callers' catch branches fire cleanly.

**HTTP API:**
- Dedicated `routes/api-ai.php` under a new `ai_middleware` config (default `['api', 'auth:sanctum']`) so anonymous callers can't drain provider tokens.
- `performance.ai.use` Gate registered in the service provider (permissive default: any authenticated user); `AiAgentApiController::dispatchAgent` checks it belt-and-braces.
- Two form requests; the controller `report()`s Throwable before returning 500 so ops gets the trace.

**Service provider:**
- `aiFeatures()` method registers both agents with `artisanpack-ui/ai`.
- Livewire component registration for the two panels.
- `registerAiGate()` called from `boot()`.

**Composer:**
- Adds `artisanpack-ui/ai: ^1.0` to `require`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 25.5
- PHP Version: 8.4.3 (Herd)

**Automated:**
- Full package suite: 767 passed, 6 skipped, 1601 assertions.
- New AI tests (`tests/Feature/Ai/`): 19 tests across `PerformanceInsightAgentTest`, `OptimizationSuggestionAgentTest`, and `AiAgentApiControllerTest`. Coverage includes happy path, malformed-row drop, empty-metrics short-circuit, impact/effort clamp, feature-toggle 409, and the new `performance.ai.use` Gate 403.
- Lint: `./vendor/bin/php-cs-fixer fix` (0 changed) + `./vendor/bin/phpcs` clean.

**Manual (against the dev app):**
- `/ai-issues-test/issue-95` — exercises happy + malformed modes with a real EXPLAIN plan input; verified suggested_indexes and rewrites render, `Full table scan` visible in happy path.
- `/ai-issues-test/issue-96` — exercises happy, empty (short-circuit), and clamped-levels modes; verified focus_areas render with impact/effort badges, empty mode reports `metrics list was empty`, clamped mode coerces to `medium`.

## Review Fixes Applied

Applied 7 findings from the internal code review before merging:

1. AI endpoints separated from the public metrics-ingest middleware onto `ai_middleware` (Sanctum + Gate).
2. `windowDays` capped at 90 with `#[Validate]` and defence-in-depth clamps.
3. Both agents opt out of caching (point-in-time diagnostics).
4. `postAi` throws `PerformanceAiError` on null/malformed 2xx bodies.
5. `parseSchema` in React/Vue widened to pass raw text through, matching the "JSON or text" placeholder and Livewire behavior.
6. `collectMetrics` switched to `toBase()` with a 2000-row cap.
7. Controller `report()`s exceptions before returning 500.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-powered query insights and optimization suggestions across the API, web UI, and Livewire/Vue/React components.
  * Introduced new AI panels for submitting query details or performance metrics and viewing structured recommendations.
* **Documentation**
  * Expanded the README with an AI features section, usage examples, and API response/error details.
* **Bug Fixes**
  * Added clearer handling for disabled features, missing credentials, and validation errors in AI requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->